### PR TITLE
Additional changes for OneWifi compilation

### DIFF
--- a/build/linux/makefile
+++ b/build/linux/makefile
@@ -27,7 +27,7 @@
 # executable must be linked against.
 #
 
-include makefile.inc
+include build/linux/makefile.inc
 
 
 EASY_MESH_NODE = 1
@@ -397,8 +397,8 @@ endif
 LDFLAGS = $(LIBDIRS) $(LIBS)
 
 $(BUILD_DIR):
-	@mkdir -p ../install/lib
-	@mkdir -p ../install/bin
+	@mkdir -p $(INSTALLDIR)/lib
+	@mkdir -p $(INSTALLDIR)/bin
 #
 # Default target: the first target is the default target.
 # Just type "make -f Makefile.Linux" to build it.
@@ -452,4 +452,7 @@ clean:
 
 run:
 	./$(PROGRAM)
+
+setup:
+	./build/linux/setup.sh
 

--- a/build/linux/makefile.inc
+++ b/build/linux/makefile.inc
@@ -27,15 +27,15 @@ PLATFORM = $(shell uname -a)
 
 BASE_DIR := $(shell pwd)
 
-ONE_WIFI_HOME = $(BASE_DIR)/../generic
-WIFI_HAL_INTERFACE = $(BASE_DIR)/../halinterface
+ONE_WIFI_HOME = $(BASE_DIR)/
+WIFI_HAL_INTERFACE = $(BASE_DIR)/../halinterface/include
 WIFI_RDK_HAL = $(BASE_DIR)/../rdk-wifi-hal
 WIFI_HOSTAP_BASE = $(BASE_DIR)/../rdk-wifi-libhostap/source/hostap-2.10
 WIFI_HOSTAP_SRC = $(WIFI_HOSTAP_BASE)/src
 WIFI_HOSTAP_SUPPLICANT = $(WIFI_HOSTAP_BASE)/wpa_supplicant
 ONE_WIFI_EM_HOME = $(BASE_DIR)/../easy_mesh_onewifi
 
-INSTALLDIR = $(BASE_DIR)/../install
+INSTALLDIR = $(BASE_DIR)/install
 OBJDIR = obj
 CXX = g++
 CC = gcc

--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+ONEWIFI_DIR=$(pwd)
+HOSTAP_DIR="$(pwd)/../rdk-wifi-libhostap/source"
+UPSTREAM_HOSTAP_URL="git://w1.fi/hostap.git"
+SRCREV_2_10="9d07b9447e76059a2ddef2a879c57d0934634188"
+
+#git clone other wifi related components
+cd ..
+git clone https://github.com/rdkcentral/rdk-wifi-hal.git rdk-wifi-hal
+git clone https://github.com/Aniket0606/rdkb-halif-wifi.git halinterface
+
+
+
+#Check if the HOSTAP_DIR already present before creating
+if [ -d "$HOSTAP_DIR" ]; then
+        echo "Hostap directory $HOSTAP_DIR  already exists."
+else
+        mkdir -p $HOSTAP_DIR
+fi
+
+#clone the upstream hostap in HOSTAP_DIR as hostap-x.xx
+#and move to the relevant commit
+cd $HOSTAP_DIR
+echo "Cloning hostap in $HOSTAP_DIR"
+git clone $UPSTREAM_HOSTAP_URL hostap-2.10
+cd hostap-2.10
+git reset --hard $SRCREV_2_10
+
+#clone the hostap-patches and apply
+git clone https://github.com/rdkcentral/hostap-patches.git hostap-patches
+
+#Apply the patch
+patch_filename="0001-OneWifi-related-hostap-patch-for-2.10-based-hostap.patch"
+echo "Applying patch $patch_filename"
+git am hostap-patches/$patch_filename
+
+#Delete the hostap-patches directory after applying
+rm -rf hostap-patches
+
+#return back to initial directory
+cd $ONEWIFI_DIR


### PR DESCRIPTION
This change includes path changes in makefile to be compatible with github repositories. Also change to have the necessary repos required for compilation to be pulled as part of makefile setup command.