### PR TITLE
Fixes possible SEGFAULT caused by uninitialized `external_protos`

### DIFF
--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -238,6 +238,13 @@ webconfig_error_t   translate_device_object_to_easymesh_for_dml(webconfig_subdoc
         return webconfig_error_translate_to_easymesh;
     }
 
+    // Check if proto is is uninitialized (all internal values and pointers are 0)
+    uint8_t empty_proto[sizeof(webconfig_external_easymesh_t)] = {0}; 
+    if (memcmp(proto, empty_proto, sizeof(webconfig_external_easymesh_t)) == 0) {
+        wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: external_protos is uninitialized or invalid\n", __func__, __LINE__);
+        return webconfig_error_translate_to_easymesh;
+    }
+
     if (proto->get_device_info(proto->data_model) == NULL) {
         wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: get_device_info is NULL\n",__func__, __LINE__);
     } else {


### PR DESCRIPTION
Added additional check in `translate_device_object_to_easymesh_for_dml` to verify that `external_protos` is initialized. 

In some scenarios, the pointer to `external_protos` could be valid (not `NULL`), avoiding the first check, but the data inside the struct (including function pointers) could be `0`/`NULL`.

If uninitialized, all pointers (including pointer functions) are NULL, causing a SEGFAULT when the following `proto->get_device_info` function pointer is attempted to be called and the `proto->data_model` is attempted to be fetched.