### PR TITLE
REFPLTB-3230 REFPLTB-3233 REFPLTB-3234: Potential memory leak at PSM_Get_Record_Value2 call

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -7247,11 +7247,14 @@ char* Get_PSM_Record_Status(char *recName, char *strValue)
 {
     int retry = 0;
     int retPsmGet = RETURN_ERR;
+    char strVal[256] = {0};
     while(retry++ < 2) {
         retPsmGet = PSM_Get_Record_Value2(bus_handle, g_Subsystem, recName, NULL, &strValue);
         if (retPsmGet == RDKB_CCSP_SUCCESS) {
             wifi_util_dbg_print(WIFI_MGR,"%s:%d retPsmGet success for %s and strValue is %s\n", __FUNCTION__,__LINE__, recName, strValue);
-            return strValue;
+            strncpy(strVal, strValue, (strlen(strValue) + 1));
+            ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(strValue);
+            return strVal;
         } else if (retPsmGet == CCSP_CR_ERR_INVALID_PARAM) {
             wifi_util_dbg_print(WIFI_MGR,"%s:%d PSM_Get_Record_Value2 (%s) returned error %d \n",__FUNCTION__,__LINE__,recName,retPsmGet);
             return NULL;
@@ -7583,6 +7586,7 @@ int get_total_mac_list_from_psm(int instance_number, unsigned int *total_entries
     {
         wifi_util_dbg_print(WIFI_MGR, "%s:%d  mac list data:%s\n",__func__, __LINE__, l_strValue);
         strncpy(strValue, l_strValue, (strlen(l_strValue) + 1));
+        ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(l_strValue);
         sscanf(strValue, "%d:", &l_total_entries);
         wifi_util_dbg_print(WIFI_MGR, "%s:%d  recName: %s total entry:%d\n",__func__, __LINE__, recName, l_total_entries);
         if (l_total_entries != 0) {
@@ -7593,6 +7597,10 @@ int get_total_mac_list_from_psm(int instance_number, unsigned int *total_entries
         }
     } else {
         wifi_util_dbg_print(WIFI_MGR, "%s:%d PSM maclist get failure:%d mac list data:%s\n",__func__, __LINE__, retPsmGet, l_strValue);
+        if(retPsmGet == CCSP_SUCCESS)
+        {
+            ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(l_strValue);
+        }
     }
 
     return RETURN_ERR;

--- a/source/dml/tr_181/ml/cosa_wifi_internal.c
+++ b/source/dml/tr_181/ml/cosa_wifi_internal.c
@@ -206,11 +206,14 @@ char* PSM_Get_Record_Status(char *recName, char *strValue)
 {
     int retry = 0;
     int retPsmGet = CCSP_SUCCESS;
+    char strVal[256] = {0};
     while(retry++ < 2) {
         retPsmGet = PSM_Get_Record_Value2(bus_handle, g_Subsystem, recName, NULL, &strValue);
         if (retPsmGet == CCSP_SUCCESS) {
             wifi_util_dbg_print(WIFI_PSM,"%s:%d retPsmGet success for %s and strValue is %s\n", __FUNCTION__,__LINE__, recName, strValue);
-            return strValue;
+            strncpy(strVal, strValue, (strlen(strValue) + 1));
+            ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(strValue);
+            return strVal;
         } else if (retPsmGet == CCSP_CR_ERR_INVALID_PARAM) {
             wifi_util_dbg_print(WIFI_PSM,"%s:%d PSM_Get_Record_Value2 (%s) returned error %d \n",__FUNCTION__,__LINE__,recName,retPsmGet);
             return NULL;

--- a/source/dml/wifi_ssp/ssp_loop.c
+++ b/source/dml/wifi_ssp/ssp_loop.c
@@ -1051,6 +1051,7 @@ int get_psm_total_mac_list(int instance_number, unsigned int *total_entries, cha
     {
         wifi_util_dbg_print(WIFI_PSM, "%s:%d  mac list data:%s\n",__func__, __LINE__, l_strValue);
         strncpy(strValue, l_strValue, (strlen(l_strValue) + 1));
+        ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(l_strValue);
         sscanf(strValue, "%d:", &l_total_entries);
         wifi_util_dbg_print(WIFI_PSM, "%s:%d  recName: %s total entry:%d\n",__func__, __LINE__, recName, l_total_entries);
         if (l_total_entries != 0) {
@@ -1061,6 +1062,10 @@ int get_psm_total_mac_list(int instance_number, unsigned int *total_entries, cha
         }
     } else {
         wifi_util_dbg_print(WIFI_PSM, "%s:%d PSM maclist get failure:%d mac list data:%s\n",__func__, __LINE__, retPsmGet, l_strValue);
+        if(retPsmGet == CCSP_SUCCESS)
+        {
+            ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(l_strValue);
+        }
     }
 
     return RETURN_ERR;


### PR DESCRIPTION
Reason for change: Added code to release the memory. Test Procedure: 1) Added the change suggested in the ticket to generate the leak in the api which is calling during the service start. 2) Valgrind command is added in service file as given below,
    ExecStart=/bin/sh -c 'valgrind --tool=memcheck --leak-check=yes --show-reachable=yes --num-callers=20 --track-fds=yes /usr/bin/OneWifi -subsys eRT.'
3) Increased the file size in journald.conf file
4) Stopped the service using systemctl command, it will be automatically try to restart using rpiwifiinitialized.path 5) Executed "journalctl -u onewifi" immediately with the stop command, redirected to some text file in the /tmp folder
   Console command: "systemctl stop onewifi.service;journalctl -u onewifi > /tmp/leak_report.txt"
Risks: None