### PR TITLE
Fixed "Add SendActionFrame function and mgmtFrameRecieved event"

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1135,14 +1135,17 @@ int mgmt_wifi_frame_recv(int ap_index, mac_address_t sta_mac, uint8_t *frame, ui
     rdata.raw_data_len = sizeof(wifi_frame_t)+mgmt_frame.frame.len;
 
     // Publish the management frame to the X_RDK_mgmtFrameRecieved 
-    bus_handle_t m_bus_hdl;
-    bus_init(&m_bus_hdl);
+    wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
+    if (ctrl != NULL){
 
-    char event_name[200] = {0};
-    sprintf(event_name, "Device.WiFi.AccessPoint.%d.X_RDK_mgmtFrameRecieved", ap_index);
+    	char event_name[200] = {0};
+    	sprintf(event_name, "Device.WiFi.AccessPoint.%d.X_RDK_mgmtFrameRecieved", ap_index);
 
-    get_bus_descriptor()->bus_event_publish_fn(&m_bus_hdl, event_name, &rdata);
-
+    	get_bus_descriptor()->bus_event_publish_fn(&ctrl->handle, event_name, &rdata);
+    } else {
+	wifi_util_dbg_print(WIFI_CTRL,"%s:%d NULL ctrl object. Not publishing managment frame...\n", __func__,__LINE__);
+    }
+    
     push_event_to_ctrl_queue((frame_data_t *)&mgmt_frame, sizeof(mgmt_frame), wifi_event_type_hal_ind, evt_subtype, NULL);
     return RETURN_OK;
 }

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -4769,16 +4769,16 @@ webconfig_error_t decode_assocdev_stats_object(wifi_provider_response_t **assoc_
         decode_param_bool(assoc_data, "cli_Active", param);
         client_stats_data[count].cli_Active = (param->type & cJSON_True) ? true:false;
 
-        decode_param_string(assoc_data, "cli_OperatingStandard", param);
+        decode_param_allow_empty_string(assoc_data, "cli_OperatingStandard", param);
         strncpy(client_stats_data[count].cli_OperatingStandard, param->valuestring, sizeof(client_stats_data[count].cli_OperatingStandard) - 1);
 
-        decode_param_string(assoc_data, "cli_OperatingChannelBandwidth", param);
+        decode_param_allow_empty_string(assoc_data, "cli_OperatingChannelBandwidth", param);
         strncpy(client_stats_data[count].cli_OperatingChannelBandwidth, param->valuestring, sizeof(client_stats_data[count].cli_OperatingChannelBandwidth) - 1);
 
         decode_param_integer(assoc_data, "cli_SNR", param);
         client_stats_data[count].cli_SNR = param->valuedouble;
 
-        decode_param_string(assoc_data, "cli_InterferenceSources", param);
+        decode_param_allow_empty_string(assoc_data, "cli_InterferenceSources", param);
         strncpy(client_stats_data[count].cli_InterferenceSources, param->valuestring, sizeof(client_stats_data[count].cli_InterferenceSources) - 1);
 
         decode_param_integer(assoc_data, "cli_DataFramesSentAck", param);

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -466,6 +466,7 @@ webconfig_error_t translate_radio_object_to_easymesh_for_dml(webconfig_subdoc_da
         oper_param = &decoded_params->radios[index].oper;
         radio_index = convert_radio_name_to_radio_index(decoded_params->radios[index].name);
         em_radio_info->enabled = oper_param->enable;
+        em_radio_info->band = oper_param->band;
         radio_iface_map = NULL;
         for (unsigned int k = 0; k < (sizeof(wifi_prop->radio_interface_map)/sizeof(radio_interface_mapping_t)); k++) {
             if (wifi_prop->radio_interface_map[k].radio_index == radio_index) {


### PR DESCRIPTION

This fixes the crash previously noticed in the PR below. @rakhilpe, I have not seen any difference in logging. Can you comment if this code changes the logging frequency for you? If that continues to be an issue, can you provide some additional information to help guide the debugging, given that it's a relatively simple PR?

> Adds a OneWiFi SendActionFrame method that sends an action frame via the HAL and a new X_RDK_mgmtFrameRecieved event, which publishes data each time the HAL receives a management frame.
> 
> The event allows applications to subscribe to X_RDK_mgmtFrameRecieved to process incoming management frames.
