### PR TITLE
Fixed "Add SendActionFrame function and mgmtFrameRecieved event"

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -55,6 +55,8 @@ extern "C" {
 #define WIFI_ACCESSPOINT_DEV_DISCONNECTED   "Device.WiFi.AccessPoint.{i}.X_RDK_deviceDisconnected"
 #define WIFI_ACCESSPOINT_DEV_DEAUTH         "Device.WiFi.AccessPoint.{i}.X_RDK_deviceDeauthenticated"
 #define WIFI_ACCESSPOINT_DIAGDATA           "Device.WiFi.AccessPoint.{i}.X_RDK_DiagData"
+#define WIFI_ACCESSPOINT_MGMT_FRAME_RECV    "Device.WiFi.AccessPoint.{i}.X_RDK_mgmtFrameRecieved"
+#define WIFI_ACCESSPOINT_ACT_FRAME_SEND     "Device.WiFi.AccessPoint.{i}.SendActionFrame"
 #define WIFI_ACCESSPOINT_FORCE_APPLY        "Device.WiFi.AccessPoint.{i}.ForceApply"
 #define WIFI_ACCESSPOINT_RADIUS_CONNECTED_ENDPOINT   "Device.WiFi.AccessPoint.{i}.Security.ConnectedRadiusEndpoint"
 #define WIFI_CSI_TABLE                      "Device.WiFi.X_RDK_CSI.{i}."
@@ -262,6 +264,13 @@ typedef enum {
     whix_app_event_type_radio_diag_stats,
     whix_app_event_type_max
 } whix_app_event_type_t;
+
+typedef struct {
+    mac_addr_t dest_addr;
+    unsigned int frequency;
+    unsigned int frame_len;
+    uint8_t frame_data[0];
+} __attribute__((packed)) action_frame_params_t;
 
 typedef struct {
     unsigned int            radio_index;

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2646,6 +2646,52 @@ bus_error_t get_client_assoc_request_multi(char const* methodName, raw_data_t *i
     return bus_error_success;
 }
 
+bus_error_t bus_send_action_frame(char *name, raw_data_t *p_data)
+{
+    unsigned int idx = 0;
+    int ret;
+    bool force_apply = false;
+    webconfig_subdoc_data_t *data;
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+    unsigned int num_of_radios = getNumberRadios();
+    unsigned int vap_array_index;
+    unsigned int radio_index;
+    int subdoc_type;
+    wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
+
+    if (!name) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d property name is not found\r\n", __FUNCTION__,
+            __LINE__);
+        return bus_error_invalid_input;
+    }
+
+    if (p_data->data_type != bus_data_type_bytes) {
+        wifi_util_error_print(WIFI_CTRL,"%s:%d-%s wrong bus data_type:%x\n", __func__,
+            __LINE__, name, p_data->data_type);
+        return bus_error_invalid_input;
+    }
+
+    ret = sscanf(name, "Device.WiFi.AccessPoint.%d.SendActionFrame", &idx);
+    if (ret == 1 || idx < 0 || idx > num_of_radios * MAX_NUM_VAP_PER_RADIO) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid name : %s\r\n", __func__, __LINE__, name);
+        return bus_error_invalid_input;
+    }
+
+    if (p_data->raw_data_len < sizeof(action_frame_params_t) + 1){
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid parameter size : %s\r\n", __func__, __LINE__, name);
+        return bus_error_invalid_input;
+    }
+
+    action_frame_params_t* params = (action_frame_params_t*)(p_data->raw_data.bytes);
+
+    if (wifi_sendActionFrame(idx, params->dest_addr, params->frequency, params->frame_data, params->frame_len)){
+        wifi_util_error_print(WIFI_CTRL, "%s:%d HAL sendActionFrame method failed : %s\r\n", __func__, __LINE__, name);
+        return bus_error_general;
+    }
+
+    return bus_error_success;
+}
+
 bus_error_t set_force_vap_apply(char *name, raw_data_t *p_data)
 {
     unsigned int idx = 0;
@@ -2812,6 +2858,12 @@ void bus_register_handlers(wifi_ctrl_t *ctrl)
                                 { WIFI_ACCESSPOINT_DIAGDATA, bus_element_type_event,
                                     { ap_get_handler, NULL, NULL, NULL, eventSubHandler, NULL}, slow_speed, ZERO_TABLE,
                                     { bus_data_type_string, false, 0, 0, 0, NULL } },
+                                { WIFI_ACCESSPOINT_MGMT_FRAME_RECV, bus_element_type_event,
+                                    { NULL, NULL, NULL, NULL, eventSubHandler, NULL}, high_speed, ZERO_TABLE,
+                                    { bus_data_type_bytes, false, 0, 0, 0, NULL } },
+                                { WIFI_ACCESSPOINT_ACT_FRAME_SEND, bus_element_type_method,
+                                    { NULL, bus_send_action_frame, NULL, NULL, NULL, NULL}, high_speed, ZERO_TABLE,
+                                    { bus_data_type_bytes, true, 0, 0, 0, NULL } },
                                 { WIFI_ACCESSPOINT_FORCE_APPLY, bus_element_type_method,
                                     { NULL, set_force_vap_apply, NULL, NULL, NULL, NULL}, slow_speed, ZERO_TABLE,
                                     { bus_data_type_boolean, true, 0, 0, 0, NULL } },


### PR DESCRIPTION

This fixes the crash previously noticed in the PR #28. @rakhilpe, I have not seen any difference in logging. Can you comment if this code changes the logging frequency for you? If that continues to be an issue, can you provide some additional information to help guide the debugging, given that it's a relatively simple PR?

> Adds a OneWiFi SendActionFrame method that sends an action frame via the HAL and a new X_RDK_mgmtFrameRecieved event, which publishes data each time the HAL receives a management frame.
>
> The event allows applications to subscribe to X_RDK_mgmtFrameRecieved to process incoming management frames.

