### PR TITLE
RDKBACCL-403,RDKBDEV-2853 : Bringup onewifi in BPI Reference platform 

### DIFF
--- a/source/core/wifi_easy_connect.c
+++ b/source/core/wifi_easy_connect.c
@@ -46,7 +46,7 @@
 #include "wifi_util.h"
 
 #if !defined(_BWG_PRODUCT_REQ_)
-#if !defined(_XF3_PRODUCT_REQ_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_) && !defined(_XB7_PRODUCT_REQ_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_XER5_PRODUCT_REQ_) && !defined(_SCER11BEL_PRODUCT_REQ_)
+#if !defined(_XF3_PRODUCT_REQ_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_) && !defined(_XB7_PRODUCT_REQ_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_XER5_PRODUCT_REQ_) && !defined(_SCER11BEL_PRODUCT_REQ_) && !defined(_PLATFORM_BANANAPI_R4_)
 static const char *wifi_health_log = "/rdklogs/logs/wifihealth.txt";
 
 extern bool is_device_associated(int ap_index, char *mac);
@@ -848,5 +848,5 @@ get_easy_connect_best_enrollee_channels	(unsigned int ap_index)
     return &g_easy_connect.channels_on_ap[ap_index];
 }
 
-#endif //#if !defined(_XF3_PRODUCT_REQ_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_) && !defined(_XB7_PRODUCT_REQ_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_XER5_PRODUCT_REQ_)  && !defined(_SCER11BEL_PRODUCT_REQ_)
+#endif //#if !defined(_XF3_PRODUCT_REQ_) && !defined(_CBR_PRODUCT_REQ_) && !defined(_HUB4_PRODUCT_REQ_) && !defined(_XB7_PRODUCT_REQ_) && !defined(_PLATFORM_TURRIS_) && !defined(_PLATFORM_RASPBERRYPI_) && !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_XER5_PRODUCT_REQ_)  && !defined(_SCER11BEL_PRODUCT_REQ_) && !defined(_PLATFORM_BANANAPI_R4_)
 #endif //#if !defined(_BWG_PRODUCT_REQ_)


### PR DESCRIPTION
Reason for change:  Added Onewifi integration with BPI flags to resolve issues for BPI platforms.
Test Procedure: wifi sanity test cases(2G) are passed.
 Risks: Low