### PR TITLE
RDKB-58038: Give precedence to channel in RadioConfig.

### DIFF
--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -2509,7 +2509,16 @@ webconfig_error_t decode_radio_curr_operating_classes(const cJSON *obj_radio_set
     oper->operatingClass = param->valuedouble;
     oper->op_class = param->valuedouble;
     decode_param_integer(obj, "Channel", param);
-    oper->channel = param->valuedouble;
+    // update the channel only if oper->channel is not configured
+    // if oper->channel is already populated then don't overwrite.
+    if (oper->channel == 0) {
+        oper->channel = param->valuedouble;
+    } else {
+        wifi_util_info_print(WIFI_WEBCONFIG,
+            "%s:%d Not updating channel:%u from CurrentOperatingClasses as oper->channel:%u is "
+            "already populated.\n",
+            __FUNCTION__, __LINE__, param->valuedouble, oper->channel);
+    }
     return webconfig_error_none;
 }
 


### PR DESCRIPTION
Reason for change: When there is a mismatch in the channel value of subdoc in Radioconfig and currentoperatingclass, give precedence to channel in Radioconfig to ensure backward compatibility.

Test Procedure: Verified the fix working with channel change only in Radioconfig and ensured passing of the earlier failing testcase.

Risks: Low
Priority: P1

Change-Id: I5e5f8fe671a3e6c67c7da827d1b1eb0e60ca70b0