### PR TITLE
RDKB-56356: wifiWebConfig.txt file size is increasing drastically

### DIFF
--- a/source/apps/analytics/wifi_analytics.c
+++ b/source/apps/analytics/wifi_analytics.c
@@ -35,7 +35,9 @@
 
 const char *subdoc_type_to_string(webconfig_subdoc_type_t type)
 {
-#define	DOC2S(x) case x: return #x;
+#define DOC2S(x) \
+    case x:      \
+        return #x;
     switch (type) {
         DOC2S(webconfig_subdoc_type_private)
         DOC2S(webconfig_subdoc_type_null)
@@ -45,7 +47,6 @@ const char *subdoc_type_to_string(webconfig_subdoc_type_t type)
         DOC2S(webconfig_subdoc_type_mesh)
         DOC2S(webconfig_subdoc_type_mesh_backhaul)
         DOC2S(webconfig_subdoc_type_mesh_sta)
-        DOC2S(webconfig_subdoc_type_mesh_backhaul_sta)
         DOC2S(webconfig_subdoc_type_lnf)
         DOC2S(webconfig_subdoc_type_dml)
         DOC2S(webconfig_subdoc_type_associated_clients)
@@ -56,11 +57,22 @@ const char *subdoc_type_to_string(webconfig_subdoc_type_t type)
         DOC2S(webconfig_subdoc_type_harvester)
         DOC2S(webconfig_subdoc_type_wifi_config)
         DOC2S(webconfig_subdoc_type_csi)
+        DOC2S(webconfig_subdoc_type_stats_config)
+        DOC2S(webconfig_subdoc_type_steering_config)
+        DOC2S(webconfig_subdoc_type_steering_clients)
+        DOC2S(webconfig_subdoc_type_vif_neighbors)
+        DOC2S(webconfig_subdoc_type_mesh_backhaul_sta)
         DOC2S(webconfig_subdoc_type_levl)
         DOC2S(webconfig_subdoc_type_cac)
-        default:
-            wifi_util_error_print(WIFI_APPS,"%s:%d: event not handle[%d]\r\n",__func__, __LINE__, type);
-            break;
+        DOC2S(webconfig_subdoc_type_radio_stats)
+        DOC2S(webconfig_subdoc_type_neighbor_stats)
+        DOC2S(webconfig_subdoc_type_assocdev_stats)
+        DOC2S(webconfig_subdoc_type_radiodiag_stats)
+        DOC2S(webconfig_subdoc_type_radio_temperature)
+    default:
+        wifi_util_error_print(WIFI_APPS, "%s:%d: event not handle[%d]\r\n", __func__, __LINE__,
+            type);
+        break;
     }
 
     return "unknown subdoc";

--- a/source/apps/blaster/wifi_blaster.c
+++ b/source/apps/blaster/wifi_blaster.c
@@ -1625,10 +1625,9 @@ static void process_request(active_msmt_t *cfg)
 
         if (ctrl->network_mode == rdk_dev_mode_type_ext) {
             active_msmt_report_all_steps(cfg, msg, status);
+            mgr->ctrl.webconfig_state |= ctrl_webconfig_state_blaster_cfg_complete_rsp_pending;
         }
-
         active_msmt_log_message(BLASTER_DEBUG_LOG, "%s:%d %s\n" ,__FUNCTION__, __LINE__, msg);
-        mgr->ctrl.webconfig_state |= ctrl_webconfig_state_blaster_cfg_complete_rsp_pending;
 
         pthread_mutex_unlock(&g_active_msmt->lock);
         return;

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -456,10 +456,12 @@ int webconfig_analyze_pending_states(wifi_ctrl_t *ctrl)
 
         case ctrl_webconfig_state_blaster_cfg_complete_rsp_pending:
                 /* Once the blaster triggered successfully, update the status as completed and pass it to OVSM */
+                type = webconfig_subdoc_type_blaster;
                 mgr->blaster_config_global.Status = blaster_state_completed;
                 webconfig_send_blaster_status(ctrl);
             break;
         case ctrl_webconfig_state_steering_clients_rsp_pending:
+            type = webconfig_subdoc_type_steering_clients;
             webconfig_send_steering_clients_status(ctrl);
             break;
         case ctrl_webconfig_state_trigger_dml_thread_data_update_pending:
@@ -1696,7 +1698,6 @@ int webconfig_hal_radio_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t
                 ctrl->webconfig_state |= ctrl_webconfig_state_radio_cfg_rsp_pending;
                 return RETURN_ERR;
             }
-            wifi_util_dbg_print(WIFI_MGR, "%s:%d: config applied.\n", __func__, __LINE__);
 
             start_wifi_sched_timer(mgr_radio_data->vaps.radio_index, ctrl, wifi_radio_sched);
 
@@ -2012,6 +2013,7 @@ webconfig_error_t webconfig_ctrl_apply(webconfig_subdoc_t *doc, webconfig_subdoc
 
                     }
                 } else if (ctrl->network_mode == rdk_dev_mode_type_gw) {
+                    ctrl->webconfig_state &= ~(ctrl_webconfig_state_blaster_cfg_init_rsp_pending | ctrl_webconfig_state_blaster_cfg_complete_rsp_pending);
                     wifi_util_error_print(WIFI_CTRL, "%s:%d: Device is in GW Mode. No need to send blaster status\n", __func__, __LINE__);
                 }
             } else {


### PR DESCRIPTION
 after multiple blast triggers

Reason for change: blaster webconfig state flag was not clear for device in gw mode.
Test Procedure: trigger blaster and check for overflow in the logs Risks: Low

Change-Id: Ibde1adcda7743a71f335256f241be7ff08597c66