### PR TITLE
RDKB-58072:Xfinity subdoc schema for Preassoc TCM

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -2871,13 +2871,13 @@ INSTMSMT_PH2 -->
                                             <writable>true</writable>
                                         </parameter>
                                         <parameter>
-                                            <name>TimeInMs</name>
+                                            <name>TcmWaitTime</name>
                                             <type>int</type>
                                             <syntax>int</syntax>
                                             <writable>true</writable>
                                         </parameter>
                                         <parameter>
-                                            <name>MinMgmtFrames</name>
+                                            <name>TcmMinMgmtFrames</name>
                                             <type>int</type>
                                             <syntax>int</syntax>
                                             <writable>true</writable>

--- a/config/subdoc_schemas_1_4/xfinity_subdoc_schema
+++ b/config/subdoc_schemas_1_4/xfinity_subdoc_schema
@@ -47,9 +47,11 @@
                     "BasicDataTransmitRates": "12",
                     "OperationalDataTransmitRates": "12,24,36,48,54",
                     "SupportedDataTransmitRates": "12,24,36,48,54",
-                    "MinimumAdvertisedMCS": "3",
-                    "TimeInMs": 150,
-                    "MinMgmtFrames": 3,
+                    "MinimumAdvertisedMCS": "3"
+                },
+                "TcmPreAssociationDeny": {
+                    "TcmWaitTime": 150,
+                    "TcmMinMgmtFrames": 3,
                     "TcmExpWeightage": "0.6",
                     "TcmGradientThreshold": "0.18"
                 },
@@ -148,9 +150,11 @@
                 "BasicDataTransmitRates": "12",
                 "OperationalDataTransmitRates": "12,24,36,48,54",
                 "SupportedDataTransmitRates": "12,24,36,48,54",
-                "MinimumAdvertisedMCS": "3",
-                "TimeInMs": 150,
-                "MinMgmtFrames": 3,
+                "MinimumAdvertisedMCS": "3"
+            },
+            "TcmPreAssociationDeny": {
+                "TcmWaitTime": 150,
+                "TcmMinMgmtFrames": 3,
                 "TcmExpWeightage": "0.6",
                 "TcmGradientThreshold": "0.18"
             },
@@ -247,9 +251,11 @@
                     "BasicDataTransmitRates": "12",
                     "OperationalDataTransmitRates": "12,24,36,48,54",
                     "SupportedDataTransmitRates": "12,24,36,48,54",
-                    "MinimumAdvertisedMCS": "3",
-                    "TimeInMs": 150,
-                    "MinMgmtFrames": 3,
+                    "MinimumAdvertisedMCS": "3"
+                },
+                "TcmPreAssociationDeny": {
+                    "TcmWaitTime": 150,
+                    "TcmMinMgmtFrames": 3,
                     "TcmExpWeightage": "0.6",
                     "TcmGradientThreshold": "0.18"
                 },
@@ -348,9 +354,11 @@
                 "BasicDataTransmitRates": "12",
                 "OperationalDataTransmitRates": "12,24,36,48,54",
                 "SupportedDataTransmitRates": "12,24,36,48,54",
-                "MinimumAdvertisedMCS": "3",
-                "TimeInMs": 150,
-                "MinMgmtFrames": 3,
+                "MinimumAdvertisedMCS": "3"
+            },
+            "TcmPreAssociationDeny": {
+                "TcmWaitTime": 150,
+                "TcmMinMgmtFrames": 3,
                 "TcmExpWeightage": "0.6",
                 "TcmGradientThreshold": "0.18"
             },
@@ -450,9 +458,11 @@
                 "OperationalDataTransmitRates": "12,24,36,48,54",
                 "SupportedDataTransmitRates": "12,24,36,48,54",
                 "MinimumAdvertisedMCS": "3",
-                "6GOpInfoMinRate": "",
-                "TimeInMs": 150,
-                "MinMgmtFrames": 3,
+                "6GOpInfoMinRate": ""
+            },
+            "TcmPreAssociationDeny": {
+                "TcmWaitTime": 150,
+                "TcmMinMgmtFrames": 3,
                 "TcmExpWeightage": "0.6",
                 "TcmGradientThreshold": "0.18"
             },
@@ -552,9 +562,11 @@
                 "OperationalDataTransmitRates": "12,24,36,48,54",
                 "SupportedDataTransmitRates": "12,24,36,48,54",
                 "MinimumAdvertisedMCS": "3",
-                "6GOpInfoMinRate": "",
-                "TimeInMs": 150,
-                "MinMgmtFrames": 3,
+                "6GOpInfoMinRate": ""
+            },
+            "TcmPreAssociationDeny": {
+                "TcmWaitTime": 150,
+                "TcmMinMgmtFrames": 3,
                 "TcmExpWeightage": "0.6",
                 "TcmGradientThreshold": "0.18"
             },

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -494,6 +494,18 @@ static bool is_preassoc_cac_config_changed(wifi_vap_info_t *old, wifi_vap_info_t
     }
 }
 
+static bool is_preassoc_tcm_config_changed(wifi_vap_info_t *old, wifi_vap_info_t *new)
+{
+    if ((IS_CHANGED(old->u.bss_info.preassoc.time_ms, new->u.bss_info.preassoc.time_ms))
+        || (IS_CHANGED(old->u.bss_info.preassoc.min_num_mgmt_frames, new->u.bss_info.preassoc.min_num_mgmt_frames))
+        || (IS_STR_CHANGED(old->u.bss_info.preassoc.tcm_exp_weightage, new->u.bss_info.preassoc.tcm_exp_weightage, sizeof(old->u.bss_info.preassoc.tcm_exp_weightage)))
+        || (IS_STR_CHANGED(old->u.bss_info.preassoc.tcm_gradient_threshold, new->u.bss_info.preassoc.tcm_gradient_threshold, sizeof(old->u.bss_info.preassoc.tcm_gradient_threshold)))) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 static bool is_postassoc_cac_config_changed(wifi_vap_info_t *old, wifi_vap_info_t *new)
 {
     if ((IS_STR_CHANGED(old->u.bss_info.postassoc.rssi_up_threshold, new->u.bss_info.postassoc.rssi_up_threshold, sizeof(old->u.bss_info.postassoc.rssi_up_threshold)))
@@ -1234,9 +1246,10 @@ int webconfig_cac_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data
         for (vap_index = 0; vap_index < getNumberVAPsPerRadio(radio_index); vap_index++) {
             wifi_util_dbg_print(WIFI_CTRL,"Comparing cac config\n");
 
-            if (is_preassoc_cac_config_changed(&l_vap_maps->vap_array[vap_index], &data->radios[radio_index].vaps.vap_map.vap_array[vap_index]) 
+            if (is_preassoc_tcm_config_changed(&l_vap_maps->vap_array[vap_index], &data->radios[radio_index].vaps.vap_map.vap_array[vap_index])
+                || is_preassoc_cac_config_changed(&l_vap_maps->vap_array[vap_index], &data->radios[radio_index].vaps.vap_map.vap_array[vap_index])
                 || is_postassoc_cac_config_changed(&l_vap_maps->vap_array[vap_index], &data->radios[radio_index].vaps.vap_map.vap_array[vap_index])) {
-                // cac data changed apply
+                // cac or tcm data changed apply
                 wifi_util_info_print(WIFI_CTRL, "%s:%d: Change detected in received cac config, applying new configuration for vap: %d\n",
                                     __func__, __LINE__, vap_index);
                 wifidb_update_wifi_cac_config(&data->radios[radio_index].vaps.vap_map);

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -1085,10 +1085,12 @@ pErr wifi_vap_cfg_subdoc_handler(void *data)
             cJSON_AddStringToObject(PreAssocDeny, "SupportedDataTransmitRates", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.supported_data_transmit_rates);
             cJSON_AddStringToObject(PreAssocDeny, "MinimumAdvertisedMCS", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.minimum_advertised_mcs);
             cJSON_AddStringToObject(PreAssocDeny, "6GOpInfoMinRate", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.sixGOpInfoMinRate);
-            cJSON_AddNumberToObject(PreAssocDeny, "TimeInMs", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.time_ms);
-            cJSON_AddNumberToObject(PreAssocDeny, "MinMgmtFrames", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.min_num_mgmt_frames);
-            cJSON_AddStringToObject(PreAssocDeny, "TcmExpWeightage", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.tcm_exp_weightage);
-            cJSON_AddStringToObject(PreAssocDeny, "TcmGradientThreshold", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.tcm_gradient_threshold);
+
+            cJSON *TcmPreAssocDeny =  cJSON_AddObjectToObject(vapConnectionControl_o,"TcmPreAssociationDeny");
+            cJSON_AddNumberToObject(TcmPreAssocDeny, "TcmWaitTime", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.time_ms);
+            cJSON_AddNumberToObject(TcmPreAssocDeny, "TcmMinMgmtFrames", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.min_num_mgmt_frames);
+            cJSON_AddStringToObject(TcmPreAssocDeny, "TcmExpWeightage", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.tcm_exp_weightage);
+            cJSON_AddStringToObject(TcmPreAssocDeny, "TcmGradientThreshold", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.preassoc.tcm_gradient_threshold);
 
             cJSON *PostAssocDeny =  cJSON_AddObjectToObject(vapConnectionControl_o,"PostAssociationDeny");
             cJSON_AddStringToObject(PostAssocDeny, "RssiUpThreshold", wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.postassoc.rssi_up_threshold);

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -9670,13 +9670,13 @@ PreAssocDeny_GetParamIntValue
     }
 
     /* check the parameter name and return the corresponding value */
-    if( AnscEqualString(ParamName, "TimeInMs", TRUE))
+    if( AnscEqualString(ParamName, "TcmWaitTime", TRUE))
     {
         *pInt = pcfg->u.bss_info.preassoc.time_ms;
         return TRUE;
     }
 
-    if( AnscEqualString(ParamName, "MinMgmtFrames", TRUE))
+    if( AnscEqualString(ParamName, "TcmMinMgmtFrames", TRUE))
     {
         *pInt = pcfg->u.bss_info.preassoc.min_num_mgmt_frames;
         return TRUE;
@@ -9961,7 +9961,7 @@ PreAssocDeny_SetParamIntValue
         return TRUE;
     }
     /* check the parameter name and return the corresponding value */
-    if( AnscEqualString(ParamName, "TimeInMs", TRUE))
+    if( AnscEqualString(ParamName, "TcmWaitTime", TRUE))
     {
         if (vapInfo->u.bss_info.preassoc.time_ms == iValue) {
             return TRUE;
@@ -9973,7 +9973,7 @@ PreAssocDeny_SetParamIntValue
         return TRUE;
     }
 
-    if( AnscEqualString(ParamName, "MinMgmtFrames", TRUE))
+    if( AnscEqualString(ParamName, "TcmMinMgmtFrames", TRUE))
     {
         if (vapInfo->u.bss_info.preassoc.min_num_mgmt_frames == iValue) {
             return TRUE;

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -3410,7 +3410,6 @@ webconfig_error_t decode_preassoc_cac_object(const cJSON *preassoc, wifi_preasso
 {
     const cJSON *param;
     int val, ret;
-    float fval;
     // RssiUpThreshold
     decode_param_allow_empty_string(preassoc, "RssiUpThreshold", param);
 
@@ -3545,11 +3544,22 @@ webconfig_error_t decode_preassoc_cac_object(const cJSON *preassoc, wifi_preasso
    else {
             strcpy((char *)preassoc_info->sixGOpInfoMinRate, "disabled");
    }
-  
-    decode_param_integer(preassoc, "TimeInMs", param);
+
+    wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: decoding preassoc settings passed\n", __func__, __LINE__);
+
+    return webconfig_error_none;
+}
+
+webconfig_error_t decode_tcm_preassoc_object(const cJSON *preassoc, wifi_preassoc_control_t *preassoc_info)
+{
+    const cJSON *param;
+    int ret;
+    float fval;
+
+    decode_param_integer(preassoc, "TcmWaitTime", param);
     preassoc_info->time_ms = param->valuedouble;
 
-    decode_param_integer(preassoc, "MinMgmtFrames", param);
+    decode_param_integer(preassoc, "TcmMinMgmtFrames", param);
     preassoc_info->min_num_mgmt_frames = param->valuedouble;
 
     decode_param_allow_empty_string(preassoc, "TcmExpWeightage", param);
@@ -3579,10 +3589,11 @@ webconfig_error_t decode_preassoc_cac_object(const cJSON *preassoc, wifi_preasso
 
         strcpy((char *)preassoc_info->tcm_gradient_threshold, param->valuestring);
     }
-    wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: decoding preassoc settings passed\n", __func__, __LINE__);
-  
+    wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: decoding tcm preassoc settings passed\n", __func__, __LINE__);
+
     return webconfig_error_none;
 }
+
 
 webconfig_error_t decode_postassoc_cac_object(const cJSON *postassoc, wifi_postassoc_control_t *postassoc_info)
 {
@@ -3709,6 +3720,12 @@ webconfig_error_t decode_cac_object(wifi_vap_info_t *vap_info, cJSON *obj_array 
     decode_param_object(obj_array, "PreAssociationDeny", preassoc);
     if (decode_preassoc_cac_object(preassoc, &vap_info->u.bss_info.preassoc) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: preassoc cac objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
+        return webconfig_error_decode;
+    }
+
+    decode_param_object(obj_array, "TcmPreAssociationDeny", preassoc);
+    if (decode_tcm_preassoc_object(preassoc, &vap_info->u.bss_info.preassoc) != webconfig_error_none) {
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: tcm preassoc  objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
 

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -546,9 +546,16 @@ webconfig_error_t encode_preassoc_object(const wifi_preassoc_control_t *preassoc
     } else {
         cJSON_AddStringToObject(preassoc, "6GOpInfoMinRate", preassoc_info->sixGOpInfoMinRate);
     }
-  
-    cJSON_AddNumberToObject(preassoc, "TimeInMs", preassoc_info->time_ms);
-    cJSON_AddNumberToObject(preassoc, "MinMgmtFrames", preassoc_info->min_num_mgmt_frames);
+    wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Encoding preassoc settings passed\n", __func__, __LINE__);
+
+    return webconfig_error_none;
+}
+
+
+webconfig_error_t encode_tcm_preassoc_object(const wifi_preassoc_control_t *preassoc_info, cJSON *preassoc)
+{
+    cJSON_AddNumberToObject(preassoc, "TcmWaitTime", preassoc_info->time_ms);
+    cJSON_AddNumberToObject(preassoc, "TcmMinMgmtFrames", preassoc_info->min_num_mgmt_frames);
     if(strlen((char *)preassoc_info->tcm_exp_weightage) == 0) {
         cJSON_AddStringToObject(preassoc, "TcmExpWeightage", TCM_WEIGH);
     } else {
@@ -559,10 +566,11 @@ webconfig_error_t encode_preassoc_object(const wifi_preassoc_control_t *preassoc
     } else {
         cJSON_AddStringToObject(preassoc, "TcmGradientThreshold", preassoc_info->tcm_gradient_threshold);
     }
-    wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Encoding preassoc settings passed\n", __func__, __LINE__);
+    wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Encoding tcm preassoc settings passed\n", __func__, __LINE__);
 
     return webconfig_error_none;
 }
+
 
 webconfig_error_t encode_connection_ctrl_object(const wifi_vap_info_t *vap_info, cJSON *vap_obj)
 {
@@ -575,6 +583,13 @@ webconfig_error_t encode_connection_ctrl_object(const wifi_vap_info_t *vap_info,
     cJSON_AddItemToObject(vap_obj, "PreAssociationDeny", obj);
     if (encode_preassoc_object(&vap_info->u.bss_info.preassoc, obj) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Preassoc object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
+        return webconfig_error_encode;
+    }
+
+    obj = cJSON_CreateObject();
+    cJSON_AddItemToObject(vap_obj, "TcmPreAssociationDeny", obj);
+    if (encode_tcm_preassoc_object(&vap_info->u.bss_info.preassoc, obj) != webconfig_error_none) {
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d TcmPreassoc object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }
 


### PR DESCRIPTION
Impacted Platforms:
OneWifi platforms

Reason for change: Implement Xfinity subdoc schema for Preassoc Tcm as  part of Epic

Test Procedure: Load the build and test the changes as per ACs

Risks: Low

Change-Id: Ic5eec8d8c28c87ada0a3e4702671343d1f427694 
Signed-off-by:Harshavardhan_Pulluru@comcast.com