### PR TITLE
RDKB-57850: Unable to enable LEVL after FR

### DIFF
--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -180,12 +180,14 @@ typedef struct {
     int  wifi_csa_sched_handler_id[MAX_NUM_RADIOS];
     int  wifi_radio_sched_handler_id[MAX_NUM_RADIOS];
     int  wifi_vap_sched_handler_id[MAX_NUM_RADIOS * MAX_NUM_VAP_PER_RADIO];
+    int  wifi_acs_sched_handler_id[MAX_NUM_RADIOS];
 } wifi_scheduler_id_t;
 
 typedef enum {
     wifi_csa_sched,
     wifi_radio_sched,
     wifi_vap_sched,
+    wifi_acs_sched
 } wifi_scheduler_type_t;
 
 typedef struct {

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -2606,6 +2606,7 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
                             ch_chg->channel, ch_chg->event, ch_chg->sub_event, ch_chg->op_class);
 
     stop_wifi_sched_timer(ch_chg->radioIndex, ctrl, wifi_csa_sched);
+    stop_wifi_sched_timer(ch_chg->radioIndex, ctrl, wifi_acs_sched);
 
     if ((ch_chg->event == WIFI_EVENT_CHANNELS_CHANGED) && ((radio_params->channel == ch_chg->channel)
                 && (radio_params->channelWidth == ch_chg->channelWidth))) {
@@ -2793,7 +2794,6 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
     g_wifidb->ctrl.webconfig_state |= ctrl_webconfig_state_radio_cfg_rsp_pending;
     start_wifi_sched_timer(ch_chg->radioIndex, ctrl, wifi_radio_sched);
     update_wifi_radio_config(ch_chg->radioIndex, radio_params, radio_feat);
-    ctrl->acs_pending[ch_chg->radioIndex] = false;
 }
 
 #define MAX_NEIGHBOURS 250


### PR DESCRIPTION
Reason for change: The acs_pending flag is not being cleared. Whenever the onewifi is restarted, it remains fixed on the previous channel.
Test Procedure: Checking the execution of Device.WiFi.WebConfig.Data.Init once the onewifi is restarted.
Priority: P1
Risks: Low
Signed-off-by: mothishree_mallaiyanjothimani@comcast.com

Change-Id: I6607a50ef42aa686bd8026e8d076690d2f342dbc