### PR TITLE
RDKB-58058: Telemetry and Rbus for Transient Client Management

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -2785,6 +2785,12 @@ INSTMSMT_PH2 -->
                                     <syntax>string</syntax>
                                     <writable>true</writable>
                                 </parameter>
+                                <parameter>
+                                    <name>TcmClientDenyAssociation</name>
+                                    <type>string</type>
+                                    <syntax>string</syntax>
+                                    <writable>true</writable>
+                                </parameter>
                             </parameters>
                             <objects>
                                 <object>

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -73,6 +73,7 @@ extern "C" {
 #define WIFI_COLLECT_STATS_RADIO_TEMPERATURE           "Device.WiFi.CollectStats.Radio.{i}.RadioTemperatureStats"
 #define WIFI_COLLECT_STATS_VAP_TABLE                   "Device.WiFi.CollectStats.AccessPoint.{i}."
 #define WIFI_COLLECT_STATS_ASSOC_DEVICE_STATS          "Device.WiFi.CollectStats.AccessPoint.{i}.AssociatedDeviceStats"
+#define WIFI_NOTIFY_DENY_TCM_ASSOCIATION               "Device.WiFi.ConnectionControl.TcmClientDenyAssociation"
 #define WIFI_STUCK_DETECT_FILE_NAME         "/nvram/wifi_stuck_detect"
 
 #define PLAN_ID_LENGTH     38

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -392,6 +392,39 @@ int notify_LM_Lite(wifi_ctrl_t *ctrl, LM_wifi_hosts_t *phosts, bool sync)
     return RETURN_OK;
 }
 
+int tcm_notify_deny_association(wifi_ctrl_t *ctrl, int ap_index, mac_addr_str_t mac,
+    double threshold_val, double snr_gradient)
+{
+    bus_error_t rc;
+    char str[2048];
+    wifi_vap_info_t *vap_info = NULL;
+
+    memset(str, 0, 2048);
+
+    if (ctrl == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: NULL Pointer \n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+
+    vap_info = getVapInfo(ap_index);
+
+    snprintf(str, sizeof(str), "%d,%s,%lf,%lf", (ap_index + 1), mac, threshold_val,
+        snr_gradient);
+
+    if (vap_info != NULL) {
+        strncpy(vap_info->u.bss_info.preassoc.tcm_client_deny_assoc_info, str,
+            sizeof(vap_info->u.bss_info.preassoc.tcm_client_deny_assoc_info));
+    }
+
+    rc = get_bus_descriptor()->bus_set_string_fn(&ctrl->handle, WIFI_NOTIFY_DENY_TCM_ASSOCIATION, str);
+    if (rc != bus_error_success) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: bus: bus_set_string_fn Failed %d\n", __func__,
+            __LINE__, rc);
+        return RETURN_ERR;
+    }
+    return RETURN_OK;
+}
+
 int webconfig_bus_apply_for_dml_thread_update(wifi_ctrl_t *ctrl,
     webconfig_subdoc_encoded_data_t *data)
 {

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -9287,6 +9287,12 @@ ConnectionControl_GetParamStringValue
         return 0;
     }
 
+    if( AnscEqualString(ParamName, "TcmClientDenyAssociation", TRUE))
+    {
+        snprintf(pValue,*pUlSize,pcfg->u.bss_info.preassoc.tcm_client_deny_assoc_info);
+        return 0;
+    }
+
     return -1;
 }
 


### PR DESCRIPTION
Impacted Platforms:
OneWifi platforms

Reason for change: Implement Rbus functions for TCM as part of Epic

Test Procedure: Load the build and test the changes as per ACs

Risks: Low

Change-Id: Id3b414554b23acfb3f685e7714270bcbb67adaa2 Signed-off-by:Harshavardhan_Pulluru@comcast.com