### PR TITLE
Send Assoc frame data only when client associates

### DIFF
--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -1577,7 +1577,7 @@ webconfig_error_t encode_frame_data(cJSON *obj_assoc_client, frame_data_t *frame
 
 webconfig_error_t encode_associated_client_object(rdk_wifi_vap_info_t *rdk_vap_info, cJSON *assoc_array, assoclist_type_t assoclist_type)
 {
-    bool print_assoc_client = false;
+    bool print_assoc_client = false, include_frame_data = false;
     if ((rdk_vap_info == NULL) || (assoc_array == NULL)) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Associated Client encode failed\n",__FUNCTION__, __LINE__);
         return webconfig_error_encode;
@@ -1611,10 +1611,12 @@ webconfig_error_t encode_associated_client_object(rdk_wifi_vap_info_t *rdk_vap_i
         assoc_dev_data = hash_map_get_first(devices_map);
         while (assoc_dev_data != NULL) {
             print_assoc_client = false;
+            include_frame_data = false;
             if (assoclist_type == assoclist_type_full) {
                 print_assoc_client = true;
             } else if ((assoclist_type == assoclist_type_add) && (assoc_dev_data->client_state == client_state_connected)) {
                 print_assoc_client = true;
+                include_frame_data = true;
             } else if ((assoclist_type == assoclist_type_remove) && (assoc_dev_data->client_state == client_state_disconnected)) {
                 print_assoc_client = true;
             }
@@ -1657,10 +1659,12 @@ webconfig_error_t encode_associated_client_object(rdk_wifi_vap_info_t *rdk_vap_i
                 cJSON_AddNumberToObject(obj_assoc_client, "FailedRetransCount", assoc_dev_data->dev_stats.cli_FailedRetransCount);
                 cJSON_AddNumberToObject(obj_assoc_client, "RetryCount", assoc_dev_data->dev_stats.cli_RetryCount);
                 cJSON_AddNumberToObject(obj_assoc_client, "MultipleRetryCount", assoc_dev_data->dev_stats.cli_MultipleRetryCount);
-                if (encode_frame_data(obj_assoc_client, &assoc_dev_data->sta_data.msg_data) !=
-                    webconfig_error_none) {
-                    wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Encode frame data failed for client %s\n",
-                        __func__, __LINE__, mac_string);
+                if (include_frame_data == true &&
+                    encode_frame_data(obj_assoc_client, &assoc_dev_data->sta_data.msg_data) !=
+                        webconfig_error_none) {
+                    wifi_util_error_print(WIFI_WEBCONFIG,
+                        "%s:%d Encode frame data failed for client %s\n", __func__, __LINE__,
+                        mac_string);
                 }
             }
             assoc_dev_data = hash_map_get_next(devices_map, assoc_dev_data);


### PR DESCRIPTION
Association frame data is needed only when the client associates, so add that in the subdoc only during that time.

Change-Id: Ibe3ee428649efa6d925b9349e98052e28afd5577