### PR TITLE
RDKB-58055: wifiSM log improvement

### DIFF
--- a/source/apps/sm/sm_neighbor_cache.c
+++ b/source/apps/sm/sm_neighbor_cache.c
@@ -121,8 +121,8 @@ static sm_neighbor_t* neighbor_get_or_alloc(sm_neighbor_cache_t *cache, sm_neigh
     return neighbor;
 }
 
-
-static int neighbor_convert_hal_to_sample(unsigned int radio_index, wifi_neighbor_ap2_t *hal, dpp_neighbor_record_list_t *result)
+static int neighbor_convert_hal_to_sample(unsigned int radio_index, wifi_neighbor_ap2_t *hal,
+    dpp_neighbor_record_list_t *result, survey_type_t survey_type)
 {
     CHECK_NULL(hal);
     CHECK_NULL(result);
@@ -137,11 +137,12 @@ static int neighbor_convert_hal_to_sample(unsigned int radio_index, wifi_neighbo
     entry->lastseen = time(NULL); /* TODO: get the time of the scan ? */
     entry->chanwidth = str_to_dpp_chan_width(hal->ap_OperatingChannelBandwidth);
 
-    wifi_util_dbg_print(WIFI_SM, "%s:%d: Fetched neighbor sample on %s channel %u SSID %s\n", __func__, __LINE__, radio_index_to_radio_type_str(radio_index), hal->ap_Channel, hal->ap_SSID);
+    wifi_util_dbg_print(WIFI_SM, "%s:%d: Fetched neighbor %s sample on %s channel %u SSID %s\n",
+        __func__, __LINE__, survey_type_to_str(survey_type),
+        radio_index_to_radio_type_str(radio_index), hal->ap_Channel, hal->ap_SSID);
 
     return RETURN_OK;
 }
-
 
 static int neighbor_sample_add(sm_neighbor_cache_t *cache, survey_type_t survey_type,
                              unsigned int radio_index, wifi_neighbor_ap2_t *stats)
@@ -178,7 +179,7 @@ static int neighbor_sample_add(sm_neighbor_cache_t *cache, survey_type_t survey_
         goto exit_err;
     }
 
-    rc = neighbor_convert_hal_to_sample(radio_index, stats, sample);
+    rc = neighbor_convert_hal_to_sample(radio_index, stats, sample, survey_type);
     if (rc != RETURN_OK) {
         wifi_util_error_print(WIFI_SM, "%s:%d: failed to convert hal to sample\n", __func__, __LINE__);
         goto exit_err;

--- a/source/apps/sm/wifi_sm.c
+++ b/source/apps/sm/wifi_sm.c
@@ -99,11 +99,17 @@ int neighbor_response(wifi_provider_response_t *provider_response)
 
     neighbor_ap =  (wifi_neighbor_ap2_t *)provider_response->stat_pointer;
 
-    wifi_util_dbg_print(WIFI_SM,"%s:%d: radio_index : %d stats_array_size : %d\r\n",__func__, __LINE__, radio_index, provider_response->stat_array_size);
-
-    for (count = 0; count < provider_response->stat_array_size; count++) {
-        wifi_util_dbg_print(WIFI_SM,"%s:%d: count : %d ap_SSID : %s\r\n",__func__, __LINE__, count, neighbor_ap[count].ap_SSID);
-        sm_neighbor_sample_store(radio_index, survey_type, &neighbor_ap[count]);
+    wifi_util_dbg_print(WIFI_SM, "%s:%d: radio_index : %d stats_array_size : %d\r\n", __func__,
+        __LINE__, radio_index, provider_response->stat_array_size);
+    if (provider_response->stat_array_size == 0) {
+        wifi_util_dbg_print(WIFI_SM, "%s:%d: No neighbor APs found in %s on %s\r\n", __func__,
+            __LINE__, survey_type_to_str(survey_type), radio_index_to_radio_type_str(radio_index));
+    } else {
+        for (count = 0; count < provider_response->stat_array_size; count++) {
+            wifi_util_dbg_print(WIFI_SM, "%s:%d: count : %d ap_SSID : %s\r\n", __func__, __LINE__,
+                count, neighbor_ap[count].ap_SSID);
+            sm_neighbor_sample_store(radio_index, survey_type, &neighbor_ap[count]);
+        }
     }
     return RETURN_OK;
 }


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: SM App Neighbor logs enhancement.

Test Procedure:
1. Boot up the TCH XB8 with above mentioned build
2. Enable the Onewifi SM feature & also enable the SM debug using the following command • dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.SM_APP.Disable bool false • Touch /nvram/wifiSM
3. Check for the Neighbor logs in /tmp/wifiSM.

Risks: Low

Priority: P2

Change-Id: I7e40af6cf054ecb359e92167b9b7e2717bf25229 Signed-off-by:Sanjay_Venkatesan@comcast.com