### PR TITLE
RDKB-58137: can errors console spam

### DIFF
--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -878,7 +878,7 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
     } else {
         dwell_time = args->dwell_time;
         if (dwell_time == 0) {
-            dwell_time = 10;
+            dwell_time = 20;
         }
         if (args->scan_mode == WIFI_RADIO_SCAN_MODE_ONCHAN) {
             // make sure dwell time is less than 20ms if DFS channel
@@ -887,9 +887,7 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
                 radioOperation->band == WIFI_FREQUENCY_5_BAND) {
                 if (is_5g_20M_channel_in_dfs(radioOperation->channel) ||
                     radioOperation->channelWidth == WIFI_CHANNELBANDWIDTH_160MHZ) {
-                    if (dwell_time > 20) {
-                        dwell_time = 20;
-                    }
+                    dwell_time = 20;
                 }
             }
         }


### PR DESCRIPTION
Reason for change: SM sends dwell time zero for onchannel survey. Change dwell time to 20ms if requested dwell time is zero.
Test Procedure: Enable Onewifi SM and check for error message is not present.
 "wlc_scan_on_dfs_chan: WLC_SCAN ignored due to less dwell time 10sec"
Risks: Low
Priority: P2

Change-Id: I6ac17ce4ca9b12b620b5dafb8cb8734caf500cbc