### PR TITLE
RDKB-56120 Incorrect 6G radio blaster metrics sent to cloud

### DIFF
--- a/config/WifiSingleClientActiveMeasurement.avsc
+++ b/config/WifiSingleClientActiveMeasurement.avsc
@@ -23,6 +23,20 @@
             "default": null
           },
           {
+            "name": "schema_version",
+            "type": [
+              "null",
+              {
+                "name": "Schema_Version",
+                "namespace": "com.comcast.kestrel.datatype",
+                "size": 16,
+                "type": "fixed"
+              }
+            ],
+            "doc": "The current version of the schema",
+            "default": null
+          },
+          {
             "name": "plan_id",
             "type": [
               "null",
@@ -122,7 +136,7 @@
                               "null",
                               {
                                 "type": "enum",
-                                "symbols": ["radio_2_4G", "radio_5G"],
+                                "symbols": ["radio_2_4G", "radio_5G", "radio_6G"],
                                 "name": "radio_type",
                                 "doc": "Band of the Radio"
                               }
@@ -170,7 +184,7 @@
                       "null",
                       {
                         "type": "enum",
-                        "symbols": ["a", "b", "g", "n", "ac", "ax"],
+                        "symbols": ["a", "b", "g", "n", "ac", "ax", "be"],
                         "name": "OperatingStandard",
                         "doc": "802.11 operating standard"
                       }
@@ -184,7 +198,7 @@
                       "null",
                       {
                         "type": "enum",
-                        "symbols": ["_20MHz", "_40MHz", "_80MHz", "_80_80MHz", "_160MHz"],
+                        "symbols": ["_20MHz", "_40MHz", "_80MHz", "_80_80MHz", "_160MHz", "_320MHz"],
                         "name": "OperatingChannelBandwidth",
                         "doc": "802.11 operating channel bandwidth"
                       }
@@ -206,7 +220,7 @@
                         "doc": "802.11 operating channel bandwidth",
                         "name": "WifiRadioFrequencyBand",
                         "namespace": "com.comcast.kestrel.odp.datatype",
-                        "symbols": ["_2_4GHz", "_5GHz"],
+                        "symbols": ["_2_4GHz", "_5GHz", "_6GHz"],
                         "type": "enum"
                       }
                     ],
@@ -273,6 +287,37 @@
                         ]
                       }
                     }
+                  },
+                  {
+                    "name": "WiFiBlasterCPUMetrics",
+                    "default": null,
+                    "type": ["null",
+                     {
+                      "namespace": "com.comcast.kestrel.odp",
+                      "name": "WiFiBlasterCPUMetricsData",
+                      "type": "record",
+                      "doc": "Common information related to the CPU metrics while blasting is in progress",
+                      "fields": [{
+                          "name": "CPU_Usage",
+                          "type": ["null", "int"],
+                          "doc": "The percentage of CPU used while blaster is in progress",
+                          "default": null
+                        },
+                        {
+                          "name": "Memory_Usage",
+                          "type": ["null", "long"],
+                          "doc": "The amount of memory in KB used while blaster is in progress",
+                          "default": null
+                        },
+                        {
+                          "name": "Load_Average",
+                          "type": ["null", "float"],
+                          "doc": "The load average while blaster is in progress",
+                          "default": null
+                        }
+                      ]
+                    }
+                   ]
                   }
                 ]
               }

--- a/source/apps/blaster/wifi_single_client_msmt.c
+++ b/source/apps/blaster/wifi_single_client_msmt.c
@@ -87,10 +87,11 @@ static void to_plan_char(unsigned char *plan, unsigned char *key)
 
 // UUID - 96673104-5a8b-4976-82dd-b204f13dfeee
 
-// HASH - 43a46540f87428b5ca3a090dcd00f68b
+// HASH - 3b9ae70c21cf6410cf29e5c65427fe40
 
-uint8_t ACTHASHVAL[16] = {0x43, 0xa4, 0x65, 0x40, 0xf8, 0x74, 0x28, 0xb5,
-                          0xca, 0x3a, 0x09, 0x0d, 0xcd, 0x00, 0xf6, 0x8b
+
+uint8_t ACTHASHVAL[16] = {0x3b, 0x9a, 0xe7, 0x0c, 0x21, 0xcf, 0x64, 0x10,
+                          0xcf, 0x29, 0xe5, 0xc6, 0x54, 0x27, 0xfe, 0x40
                          };
 
 uint8_t ACTUUIDVAL[16] = {0x96, 0x67, 0x31, 0x04, 0x5a, 0x8b, 0x49, 0x76,
@@ -254,6 +255,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
     const char * dest = "event:raw.kestrel.reports.WifiSingleClientActiveMeasurement";
     const char * contentType = "avro/binary"; // contentType "application/json", "avro/binary"
     unsigned char PlanId[PLAN_ID_LENGTH];
+    char *schema_version = "1.1";
     uuid_t transaction_id;
     char trans_id[37];
     FILE *fp;
@@ -479,6 +481,37 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
     // uuid - fixed 16 bytes
     uuid_generate_random(transaction_id);
     uuid_unparse(transaction_id, trans_id);
+
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: schema version is %s\n", __func__, __LINE__,
+        schema_version);
+    avro_value_get_by_name(&adr, "header", &adrField, NULL);
+
+    if (CHK_AVRO_ERR) {
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
+            avro_strerror());
+    }
+
+    avro_value_get_by_name(&adrField, "schema_version", &adrField, NULL);
+
+    if (CHK_AVRO_ERR) {
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
+            avro_strerror());
+    }
+
+    avro_value_set_branch(&adrField, 1, &optional);
+
+    if (CHK_AVRO_ERR) {
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
+            avro_strerror());
+    }
+
+    avro_value_set_fixed(&optional, schema_version, 16);
+
+    if (CHK_AVRO_ERR) {
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
+            avro_strerror());
+    }
+
     unsigned char PlanId_hex[16];
     int loop = 0;
     memset(PlanId_hex, '\0', 16);
@@ -697,6 +730,11 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
         {
             wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, radio number set to : \"%s\"\n", "radio_5G");
             avro_value_set_enum(&optional, avro_schema_enum_get_by_name(avro_value_get_schema(&optional), "radio_5G"));
+        } else if (RadioCount == 2) {
+            wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, radio number set to : \"%s\"\n",
+                "radio_6G");
+            avro_value_set_enum(&optional,
+                avro_schema_enum_get_by_name(avro_value_get_schema(&optional), "radio_6G"));
         }
 
         //noise_floor
@@ -902,6 +940,11 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
         {
             wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, frequency_band = \"%s\"\n", "5GHz, set to _5GHz" );
             avro_value_set_enum(&optional, avro_schema_enum_get_by_name(avro_value_get_schema(&optional), "_5GHz" ));
+        } else if (strstr("6GHz", radio_stats[radio_idx]->frequency_band)) {
+            wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, frequency_band = \"%s\"\n",
+                "6GHz, set to _6GHz");
+            avro_value_set_enum(&optional,
+                avro_schema_enum_get_by_name(avro_value_get_schema(&optional), "_6GHz"));
         }
     }
     if ( CHK_AVRO_ERR ) {
@@ -1044,6 +1087,50 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
             wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__, avro_strerror());
         }
     }
+
+    avro_value_t cpu_dr = { 0 };
+    avro_value_get_by_name(&adrField, "blast_metrics", &drField, NULL);
+    avro_value_set_branch(&drField, 1, &optional);
+
+    // CPU health metrics
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: WiFiBlasterCPUMetrics\n", __func__, __LINE__,
+        avro_strerror());
+    avro_value_get_by_name(&optional, "WiFiBlasterCPUMetrics", &drField, NULL);
+    avro_value_set_branch(&drField, 1, &cpu_dr);
+    if (CHK_AVRO_ERR) {
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
+            avro_strerror());
+    }
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: CPU Usage : 0\n", __func__, __LINE__,
+        avro_strerror());
+    avro_value_get_by_name(&cpu_dr, "CPU_Usage", &drField, NULL);
+    avro_value_set_branch(&drField, 1, &optional);
+    avro_value_set_int(&optional, 0);
+    if (CHK_AVRO_ERR) {
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
+            avro_strerror());
+    }
+
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Memory Usage : 0\n", __func__, __LINE__,
+        avro_strerror());
+    avro_value_get_by_name(&cpu_dr, "Memory_Usage", &drField, NULL);
+    avro_value_set_branch(&drField, 1, &optional);
+    avro_value_set_long(&optional, 0);
+    if (CHK_AVRO_ERR) {
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
+            avro_strerror());
+    }
+
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Load Average : 0.0\n", __func__, __LINE__,
+        avro_strerror());
+    avro_value_get_by_name(&cpu_dr, "Load_Average", &drField, NULL);
+    avro_value_set_branch(&drField, 1, &optional);
+    avro_value_set_long(&optional, 0);
+    if (CHK_AVRO_ERR) {
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
+            avro_strerror());
+    }
+
     /* free the sta_data->sta_active_msmt_data allocated memory */
     if (sta_data->sta_active_msmt_data != NULL)
     {

--- a/source/apps/blaster/wifi_single_client_msmt.c
+++ b/source/apps/blaster/wifi_single_client_msmt.c
@@ -1098,7 +1098,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
     avro_value_set_branch(&drField, 1, &optional);
 
     // CPU health metrics
-    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: WiFiBlasterCPUMetrics\n", __func__, __LINE__,
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: WiFiBlasterCPUMetrics %s\n", __func__, __LINE__,
         avro_strerror());
     avro_value_get_by_name(&optional, "WiFiBlasterCPUMetrics", &drField, NULL);
     avro_value_set_branch(&drField, 1, &cpu_dr);
@@ -1106,7 +1106,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
         wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__,
             avro_strerror());
     }
-    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: CPU Usage : 0\n", __func__, __LINE__,
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: CPU Usage : 0 %s\n", __func__, __LINE__,
         avro_strerror());
     avro_value_get_by_name(&cpu_dr, "CPU_Usage", &drField, NULL);
     avro_value_set_branch(&drField, 1, &optional);
@@ -1116,7 +1116,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
             avro_strerror());
     }
 
-    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Memory Usage : 0\n", __func__, __LINE__,
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Memory Usage : 0 %s\n", __func__, __LINE__,
         avro_strerror());
     avro_value_get_by_name(&cpu_dr, "Memory_Usage", &drField, NULL);
     avro_value_set_branch(&drField, 1, &optional);
@@ -1126,7 +1126,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
             avro_strerror());
     }
 
-    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Load Average : 0.0\n", __func__, __LINE__,
+    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Load Average : 0.0 %s\n", __func__, __LINE__,
         avro_strerror());
     avro_value_get_by_name(&cpu_dr, "Load_Average", &drField, NULL);
     avro_value_set_branch(&drField, 1, &optional);

--- a/source/apps/blaster/wifi_single_client_msmt.c
+++ b/source/apps/blaster/wifi_single_client_msmt.c
@@ -248,6 +248,20 @@ static void printBlastMetricData(single_client_msmt_type_t msmtType, wifi_actvie
     }
 }
 
+static char *get_frequency_band_from_radio_index(int radioIndex,
+    radio_data_t *radio_stats[])
+{
+    if (strstr("2.4GHz", radio_stats[radioIndex]->frequency_band)) {
+        return "radio_2_4G";
+    } else if (strstr("5GHz", radio_stats[radioIndex]->frequency_band)) {
+        return "radio_5G";
+    } else if (strstr("6GHz", radio_stats[radioIndex]->frequency_band)) {
+        return "radio_6G";
+    }
+
+    return "Not_found";
+}
+
 void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
 {
     char *telemetry_buf = NULL;
@@ -721,21 +735,12 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
         if ( CHK_AVRO_ERR ) {
              wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Avro error: %s\n", __func__, __LINE__, avro_strerror());
         }
-        if (RadioCount == 0)
-        {
-            wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, radio number set to : \"%s\"\n", "radio_2_4G");
-            avro_value_set_enum(&optional, avro_schema_enum_get_by_name(avro_value_get_schema(&optional), "radio_2_4G"));
-        }
-        else if (RadioCount == 1)
-        {
-            wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, radio number set to : \"%s\"\n", "radio_5G");
-            avro_value_set_enum(&optional, avro_schema_enum_get_by_name(avro_value_get_schema(&optional), "radio_5G"));
-        } else if (RadioCount == 2) {
-            wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, radio number set to : \"%s\"\n",
-                "radio_6G");
-            avro_value_set_enum(&optional,
-                avro_schema_enum_get_by_name(avro_value_get_schema(&optional), "radio_6G"));
-        }
+
+        char *radio_name = get_frequency_band_from_radio_index(RadioCount, radio_stats);
+        wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, radio number set to : \"%s\"\n",
+            radio_name);
+        avro_value_set_enum(&optional,
+            avro_schema_enum_get_by_name(avro_value_get_schema(&optional), radio_name));
 
         //noise_floor
         avro_value_get_by_name(&rdr, "noise_floor", &brdrField, NULL);

--- a/source/dml/tr_181/sbapi/webpa_interface.c
+++ b/source/dml/tr_181/sbapi/webpa_interface.c
@@ -421,6 +421,7 @@ char *getDeviceMac()
                 get_bus_descriptor()->bus_data_free_fn(&data);
                 return NULL;
             }
+            str = (char *)data.raw_data.bytes;
             if (str == NULL) {
                 wifi_util_dbg_print(WIFI_MON, "%s Null pointer, bus get string len=%d for : %s\n",
                     __FUNCTION__, len, CPE_MAC_NAMESPACE);
@@ -430,7 +431,6 @@ char *getDeviceMac()
                 return NULL;
             }
             pthread_mutex_unlock(&ctrl->lock);
-            str = (char *)data.raw_data.bytes;
             AnscMacToLower(webpa_interface.deviceMAC, str, sizeof(webpa_interface.deviceMAC));
         }
 

--- a/source/dml/tr_181/sbapi/webpa_interface.c
+++ b/source/dml/tr_181/sbapi/webpa_interface.c
@@ -90,64 +90,66 @@ static void *handle_parodus(void *arg)
     struct timespec time_to_wait;
     struct timespec tv_now;
     int rc = -1, ret = 0;
-    wrp_msg_t *wrp_msg ;
+    wrp_msg_t *wrp_msg;
     webpa_interface_t *interface = (webpa_interface_t *)arg;
     int count = 0;
 
-    prctl(PR_SET_NAME,  __func__, 0, 0, 0);
+    prctl(PR_SET_NAME, __func__, 0, 0, 0);
 
     pthread_detach(pthread_self());
 
     while (interface->thread_exit == false) {
-	clock_gettime(CLOCK_MONOTONIC, &tv_now);
-			
-	time_to_wait.tv_nsec = 0;
-	time_to_wait.tv_sec = tv_now.tv_sec + 120;
+        clock_gettime(CLOCK_MONOTONIC, &tv_now);
 
-	pthread_mutex_lock(&interface->lock);
+        time_to_wait.tv_nsec = 0;
+        time_to_wait.tv_sec = tv_now.tv_sec + 120;
+
+        pthread_mutex_lock(&interface->lock);
         rc = pthread_cond_timedwait(&interface->cond, &interface->lock, &time_to_wait);
-		
-	if ((rc == ETIMEDOUT) || (rc == 0)) {
 
-		// get the data from the queue and try to send all the messages
-		while ((count = queue_count(interface->queue)) >= 0) {
+        if ((rc == ETIMEDOUT) || (rc == 0)) {
 
-			wifi_util_dbg_print(WIFI_MON, "%s:%d: Queue count:%d\n", __func__, __LINE__, count);
-			if (count == 0) {
-				break;	
-			}
+            // get the data from the queue and try to send all the messages
+            while ((count = queue_count(interface->queue)) >= 0) {
 
-			wrp_msg = queue_peek(interface->queue, (uint32_t)(count - 1));
-			if (wrp_msg == NULL) {
-				assert(0);
-			}
+                wifi_util_dbg_print(WIFI_MON, "%s:%d: Queue count:%d\n", __func__, __LINE__, count);
+                if (count == 0) {
+                    break;
+                }
 
-			wifi_util_dbg_print(WIFI_MON, "Source:%s Destination:%s Content Type:%s\n", wrp_msg->u.event.source, wrp_msg->u.event.dest, wrp_msg->u.event.content_type);
-			//print_b64_endcoded_buffer(wrp_msg->u.event.payload, wrp_msg->u.event.payload_size);
+                wrp_msg = queue_peek(interface->queue, (uint32_t)(count - 1));
+                if (wrp_msg == NULL) {
+                    assert(0);
+                }
 
-			ret = libparodus_send(interface->client_instance, wrp_msg);
-			if (ret != 0) {
-				CcspTraceError(("Parodus send failed: '%s'\n",libparodus_strerror(ret)));
-			}
-                        wifi_util_dbg_print(WIFI_MON, "%s:%d Parodus sent successfully \n",__func__, __LINE__);
-			queue_remove(interface->queue, (uint32_t)count - 1);
-			free(wrp_msg->u.event.source);
-			free(wrp_msg->u.event.dest);
-			free(wrp_msg->u.event.content_type);
-			free(wrp_msg->u.event.payload);
-                        free(wrp_msg->u.event.headers->headers[0]);
-                        free(wrp_msg->u.event.headers->headers[1]);
-                        free(wrp_msg->u.event.headers);
-	       		free(wrp_msg);
-		}
-		pthread_mutex_unlock(&interface->lock);
+                wifi_util_info_print(WIFI_MON, "Source:%s Destination:%s Content Type:%s\n",
+                    wrp_msg->u.event.source, wrp_msg->u.event.dest, wrp_msg->u.event.content_type);
+                // print_b64_endcoded_buffer(wrp_msg->u.event.payload,
+                // wrp_msg->u.event.payload_size);
 
-	}
+                ret = libparodus_send(interface->client_instance, wrp_msg);
+                if (ret != 0) {
+                    CcspTraceError(("Parodus send failed: '%s'\n", libparodus_strerror(ret)));
+                }
+                wifi_util_info_print(WIFI_MON, "%s:%d Parodus sent successfully \n", __func__,
+                    __LINE__);
+                queue_remove(interface->queue, (uint32_t)count - 1);
+                free(wrp_msg->u.event.source);
+                free(wrp_msg->u.event.dest);
+                free(wrp_msg->u.event.content_type);
+                free(wrp_msg->u.event.payload);
+                free(wrp_msg->u.event.headers->headers[0]);
+                free(wrp_msg->u.event.headers->headers[1]);
+                free(wrp_msg->u.event.headers);
+                free(wrp_msg);
+            }
+            pthread_mutex_unlock(&interface->lock);
+        }
     }
 
-	rc = libparodus_shutdown(interface->client_instance);
+    rc = libparodus_shutdown(interface->client_instance);
 
-	return 0;
+    return 0;
 }
 void sendWebpaMsg(char *serviceName, char *dest, char *trans_id, char *traceParent, char *traceState, char *contentType, char *payload, unsigned int payload_len)
 {


### PR DESCRIPTION
Impacted Platforms:
All RDKB Platforms

Reason for change: Adding support for 6G

Test Procedure: Trigger the blaster and check the metrics

Risks: None

Priority: P1

Change-Id: I3c725f6571d259a55151827a94c54b80002cdeb0 Signed-off-by:Pavithra_Sundaravadivel@comcast.com