### PR TITLE
RDKB-58139: LEVL fingerprints are not reflected on CUJO portal

### DIFF
--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2554,8 +2554,8 @@ int events_bus_publish(wifi_event_t *evt)
         if (events_getSubscribed(eventName) == TRUE) {
             pthread_mutex_lock(&ctrl->events_bus_data.events_bus_lock);
             memset(&data, 0, sizeof(raw_data_t));
-            data.data_type = bus_data_type_uint8;
-            data.raw_data.u8 = evt->u.mon_data->u.dev.sta_mac[0];
+            data.data_type = bus_data_type_bytes;
+            data.raw_data.bytes = evt->u.mon_data->u.dev.sta_mac;
             data.raw_data_len = sizeof(evt->u.mon_data->u.dev.sta_mac);
 
             rc = get_bus_descriptor()->bus_event_publish_fn(&ctrl->handle, eventName, &data);


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: Invalid data type is being passed to rbus publish function.

Test Procedure:
1. Load the above mentioned build.
2. Subscribe to this event like below, rbuscli -i
rbuscli> sub Device.WiFi.AccessPoint.2.X_RDK_deviceConnected
3. Connect a client to any of the private vap.
4. And check for the received event data is not null and contains mac address of the connected client.
5. If the data is null, then issue is reproduced.

Risks: Medium

Priority: P1

Change-Id: Id4de9aade2044cd02ae8ded8e95c836293fd6d8f Signed-off-by:Sanjay_Venkatesan@comcast.com