### PR TITLE
RDKBWIFI-24: Added ExtraVendorIEs item to Subdoc for adding additional vendor IEs + VAP refresh

### DIFF
--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -3727,7 +3727,12 @@ bool is_vap_param_config_changed(wifi_vap_info_t *vap_info_old, wifi_vap_info_t 
                 vap_info_new->u.bss_info.preassoc.sixGOpInfoMinRate,
                 sizeof(vap_info_old->u.bss_info.preassoc.sixGOpInfoMinRate)) ||
             IS_CHANGED(vap_info_old->u.bss_info.hostap_mgt_frame_ctrl,
-                vap_info_new->u.bss_info.hostap_mgt_frame_ctrl)) {
+                vap_info_new->u.bss_info.hostap_mgt_frame_ctrl) ||
+            IS_CHANGED(vap_info_old->u.bss_info.vendor_elements_len,
+                vap_info_new->u.bss_info.vendor_elements_len) ||
+            IS_BIN_CHANGED(vap_info_old->u.bss_info.vendor_elements,
+                vap_info_new->u.bss_info.vendor_elements,
+                sizeof(vap_info_old->u.bss_info.vendor_elements))) {
             return true;
         }
     }

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -343,6 +343,7 @@ webconfig_error_t encode_vap_common_object(const wifi_vap_info_t *vap_info,
     const rdk_wifi_vap_info_t *rdk_vap_info, cJSON *vap_object)
 {
     char mac_str[32];
+    char extra_vendor_ies_hex_str[(vap_info->u.bss_info.vendor_elements_len * 2) + 1];
 
     //VAP Name
     cJSON_AddStringToObject(vap_object, "VapName", vap_info->vap_name);
@@ -454,6 +455,13 @@ webconfig_error_t encode_vap_common_object(const wifi_vap_info_t *vap_info,
         vap_info->u.bss_info.hostap_mgt_frame_ctrl);
 
     cJSON_AddBoolToObject(vap_object, "MboEnabled", vap_info->u.bss_info.mbo_enabled);
+
+    memset(extra_vendor_ies_hex_str, 0, sizeof(extra_vendor_ies_hex_str));
+    for (int i = 0; i < vap_info->u.bss_info.vendor_elements_len; i++) {
+        sprintf(extra_vendor_ies_hex_str + (i * 2), "%02x",
+            vap_info->u.bss_info.vendor_elements[i]);
+    }
+    cJSON_AddStringToObject(vap_object, "ExtraVendorIEs", extra_vendor_ies_hex_str);
 
     return webconfig_error_none;
 }


### PR DESCRIPTION
Reason for the change: Allows new vendor elements to be synced with other apps
Risks: Low
Priority: P0

Added ExtraVendorIEs item to Subdoc for adding additional vendor IEs + VAP refresh

**Depends on HAL PR [#21](https://github.com/rdkcentral/rdk-wifi-hal/pull/21) being merged/checked out!**

## Testing Information

1. Apply the [webconfig_test_cce.patch](https://github.com/user-attachments/files/18697327/webconfig_test_cce.patch) patch from within the `OneWifi` directory.
2. Run `make -f build/linux/cce_makefile all` to build the testing application
3. Start OneWifi (`cd install/bin && sudo ./OneWifi -c`)
4. Start `cce` vendor IE adder: `sudo ./install/bin/cce --add`
5. Run the `unified-wifi-mesh` stack (controller + agent). 
6. Once they recognize each other the agent will begin sending subdocs which will trigger the `cce` program to add a vendor_ie and send it's own subdoc, updating the broadcasting AP.
7. `cce` will exit successfully.

After `cce` has exited, the beacons and probe responses will be updated to include a CCE IE and can be observed in a wireshark monitor mode capture.




## Examples

Here are some screenshots of a pcap (along with a pcap) in chronological order demonstrating the addition of the WFA CCE IE using the program described here. 

### Arrival Time: 13:04:21     -     No custom vendor information elements added
![No IEs](https://github.com/user-attachments/assets/0c5e308e-aef0-4a50-8882-594c0c42487d)

### Arrival Time: 13:04:30     -     Single CCE vendor IE added 
![One CCE](https://github.com/user-attachments/assets/1647204e-25ca-4ec2-8903-2681ae0c5f75)

### Arrival Time: 13:04:50     -     All custom vendor IEs removed
![Remove CCE](https://github.com/user-attachments/assets/deec4085-97a5-49ae-ad3a-8811383799cf)
