### PR TITLE
Check for CCE IEs in Probe Response Mgmt Frames

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -56,6 +56,7 @@ extern "C" {
 #define WIFI_ACCESSPOINT_DEV_DEAUTH         "Device.WiFi.AccessPoint.{i}.X_RDK_deviceDeauthenticated"
 #define WIFI_ACCESSPOINT_DIAGDATA           "Device.WiFi.AccessPoint.{i}.X_RDK_DiagData"
 #define WIFI_ACCESSPOINT_FORCE_APPLY        "Device.WiFi.AccessPoint.{i}.ForceApply"
+#define WIFI_ACCESSPOINT_CCE_IND_PROBE      "Device.WiFi.AccessPoint.{i}.Mgmt.Probe.CCEInd"
 #define WIFI_ACCESSPOINT_RADIUS_CONNECTED_ENDPOINT   "Device.WiFi.AccessPoint.{i}.Security.ConnectedRadiusEndpoint"
 #define WIFI_ACCESSPOINT_RAWFRAME_MGMT_ACTION_TX     "Device.WiFi.AccessPoint.{i}.RawFrame.Mgmt.Action.Tx"
 #define WIFI_ACCESSPOINT_RAWFRAME_MGMT_ACTION_RX     "Device.WiFi.AccessPoint.{i}.RawFrame.Mgmt.Action.Rx"

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1088,6 +1088,10 @@ int mgmt_wifi_frame_recv(int ap_index, mac_address_t sta_mac, uint8_t *frame, ui
         memcpy(mgmt_frame.data, frame, len);
         mgmt_frame.frame.len = len;
         evt_subtype = wifi_event_hal_probe_req_frame;
+    } else if (type == WIFI_MGMT_FRAME_TYPE_PROBE_RSP) {
+        memcpy(mgmt_frame.data, frame, len);
+        mgmt_frame.frame.len = len;
+        evt_subtype = wifi_event_hal_probe_rsp_frame;
     } else if (type == WIFI_MGMT_FRAME_TYPE_AUTH) {
         memcpy(mgmt_frame.data, frame, len);
         mgmt_frame.frame.len = len;

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -139,6 +139,11 @@ void process_probe_req_frame_event(frame_data_t *msg, uint32_t msg_length)
     wifi_util_dbg_print(WIFI_CTRL,"%s:%d wifi mgmt frame message: ap_index:%d length:%d type:%d dir:%d rssi:%d phy_rate:%d\r\n", __FUNCTION__, __LINE__, msg->frame.ap_index, msg->frame.len, msg->frame.type, msg->frame.dir, msg->frame.sig_dbm, msg->frame.phy_rate);
 }
 
+void process_probe_rsp_frame_event(frame_data_t* msg, uint32_t msg_length)
+{
+    wifi_util_dbg_print(WIFI_CTRL,  "%s:%d Wi-Fi mgmt frame message: ap_index:%d length:%d type:%d dir:%d\r\n", __func__, __LINE__, msg->frame.ap_index, msg->frame.len, msg->frame.type, msg->frame.dir);
+}
+
 void process_auth_frame_event(frame_data_t *msg, uint32_t msg_length)
 {
     wifi_util_dbg_print(WIFI_CTRL,"%s:%d wifi mgmt frame message: ap_index:%d length:%d type:%d dir:%d\r\n", __FUNCTION__, __LINE__, msg->frame.ap_index, msg->frame.len, msg->frame.type, msg->frame.dir);
@@ -3197,6 +3202,10 @@ void handle_hal_indication(wifi_ctrl_t *ctrl, void *data, unsigned int len,
 
     case wifi_event_hal_auth_frame:
         process_auth_frame_event(data, len);
+        break;
+
+    case wifi_event_hal_probe_rsp_frame:
+        process_probe_rsp_frame_event(data, len);
         break;
 
     case wifi_event_hal_assoc_req_frame:

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2945,7 +2945,10 @@ void bus_register_handlers(wifi_ctrl_t *ctrl)
                                     { bus_data_type_object, false, 0, 0, 0, NULL } },
                                 { WIFI_COLLECT_STATS_ASSOC_DEVICE_STATS, bus_element_type_event,
                                     { NULL, NULL, NULL, NULL, eventSubHandler, NULL}, slow_speed, ZERO_TABLE,
-                                    { bus_data_type_bytes, false, 0, 0, 0, NULL } }
+                                    { bus_data_type_bytes, false, 0, 0, 0, NULL } },
+                                { WIFI_ACCESSPOINT_CCE_IND_PROBE, bus_element_type_event,
+                                    { NULL, NULL, NULL, NULL, eventSubHandler, NULL}, slow_speed, ZERO_TABLE,
+                                    { bus_data_type_bytes, false, 0, 0, 0, NULL} }
     };
 
     rc = get_bus_descriptor()->bus_open_fn(&ctrl->handle, component_name);


### PR DESCRIPTION
Necessary for DPP in the context of EasyMesh so that Enrollee APs can know which channel(s) to send a DPP Presence Announcement Frame on such that the Proxy Agent will hear it.

Note: may also need to do something equivalent for Beacon frames containing CCE IEs, but we've heard that there would be bus limitations if consuming and processing too many management frames, especially something as frequent as beacons. Could anyone elaborate on this potential restriction? Canonically the EasyMesh spec claims that CCE IEs should be embedded into both probes and beacons but this PR only addresses probe responses due to the aforementioned "bus restrictions"

Thanks :^)