### PR TITLE
RDKB-57697: WIFI_BANDUTILIZATION & CHUTIL markers are not coming.

### DIFF
--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -2024,6 +2024,7 @@ static void config_radio_channel_util(wifi_monitor_data_t *data)
 
     data->u.mon_stats_config.data_type = mon_stats_type_radio_channel_stats;
     data->u.mon_stats_config.args.scan_mode = WIFI_RADIO_SCAN_MODE_ONCHAN;
+    data->u.mon_stats_config.delay_provider_sec = WIFI_CHANUTIL_PROVIDER_DELAY_SEC;
     /* Request to get channel utilization */
     data->u.mon_stats_config.args.app_info = whix_app_event_type_chan_util;
     for (radioIndex = 0; radioIndex < getNumberRadios(); radioIndex++) {
@@ -2045,6 +2046,7 @@ static void config_radio_channel_stats(wifi_monitor_data_t *data)
     /* Request to collect other channel stats */
     data->u.mon_stats_config.data_type = mon_stats_type_radio_channel_stats;
     data->u.mon_stats_config.args.scan_mode = WIFI_RADIO_SCAN_MODE_ONCHAN;
+    data->u.mon_stats_config.delay_provider_sec = WIFI_CHANUTIL_PROVIDER_DELAY_SEC;
     data->u.mon_stats_config.args.app_info = whix_app_event_type_chan_stats;
 
     //for each vap push the event to monitor queue

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -1998,13 +1998,14 @@ static void whix_common_config_to_monitor_queue(wifi_monitor_data_t *data, bool 
     if ((global_param != NULL) && (global_param->whix_chutility_loginterval != 0) && (global_param->whix_log_interval != 0)) {
         if (is_channel_util) {
             data->u.mon_stats_config.interval_ms = (global_param->whix_chutility_loginterval) * 1000;
+            data->u.mon_stats_config.delay_provider_sec = WIFI_CHANUTIL_PROVIDER_DELAY_SEC;
         } else {
             data->u.mon_stats_config.interval_ms = (global_param->whix_log_interval) * 1000;
         }
     } else {
-        data->u.mon_stats_config.delay_provider_sec = WIFI_CHANUTIL_PROVIDER_DELAY_SEC;
         if (is_channel_util) {
             data->u.mon_stats_config.interval_ms = CHAN_UTIL_INTERVAL_MS;
+            data->u.mon_stats_config.delay_provider_sec = WIFI_CHANUTIL_PROVIDER_DELAY_SEC;
         } else {
             data->u.mon_stats_config.interval_ms = TELEMETRY_UPDATE_INTERVAL_MS;
         }

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -1998,14 +1998,12 @@ static void whix_common_config_to_monitor_queue(wifi_monitor_data_t *data, bool 
     if ((global_param != NULL) && (global_param->whix_chutility_loginterval != 0) && (global_param->whix_log_interval != 0)) {
         if (is_channel_util) {
             data->u.mon_stats_config.interval_ms = (global_param->whix_chutility_loginterval) * 1000;
-            data->u.mon_stats_config.delay_provider_sec = WIFI_CHANUTIL_PROVIDER_DELAY_SEC;
         } else {
             data->u.mon_stats_config.interval_ms = (global_param->whix_log_interval) * 1000;
         }
     } else {
         if (is_channel_util) {
             data->u.mon_stats_config.interval_ms = CHAN_UTIL_INTERVAL_MS;
-            data->u.mon_stats_config.delay_provider_sec = WIFI_CHANUTIL_PROVIDER_DELAY_SEC;
         } else {
             data->u.mon_stats_config.interval_ms = TELEMETRY_UPDATE_INTERVAL_MS;
         }


### PR DESCRIPTION
Reason for change: Provider is executing before initial scan is complete
                   so adding a delay of 5sec to the provider function.

Test Procedure: 
 1. Load the device with the above mentioned build.
 2. Verify for the ChUtilityLogInterval to be 15mins with the below command  dmcli eRT getv Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.ChUtilityLogInterval
 3. Check for the WIFI_BANDUTILIZATION and CHUTIL markers in /rdklogs/logs/wifihealth.txt

Priority: P1

Risks: Low 

Signed-off-by: Samyuktha Karthikeyan <samyuktha_karthikeyan@comcast.com>

Change-Id: Ie15157b3fd275bef06014c2e1962704a4bd5d57c