### PR TITLE
Add EasyConnect app

### DIFF
--- a/build/linux/makefile
+++ b/build/linux/makefile
@@ -226,6 +226,7 @@ INCLUDEDIRS = \
     -I$(ONE_WIFI_HOME)/source/apps/ocs \
     -I$(ONE_WIFI_HOME)/source/apps/sm \
     -I$(ONE_WIFI_HOME)/source/apps/whix \
+    -I$(ONE_WIFI_HOME)/source/apps/easyconnect \
     -I$(ONE_WIFI_HOME)/source/core/services \
     -I$(ONE_WIFI_HOME)/include/tr_181/ml \
     -I$(ONE_WIFI_HOME)/include \
@@ -376,6 +377,9 @@ ifdef ONEWIFI_BLASTER_APP_SUPPORT
 	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_blaster.c
 endif
 
+ifdef ONEWIFI_EASYCONNECT_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/easyconnect/*.c)
+endif
 
 COBJECTS = $(CSOURCES:.c=.o)  # expands to list of object files
 

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -124,7 +124,8 @@ typedef enum {
     wifi_app_inst_whix = wifi_app_inst_base << 13,
     wifi_app_inst_core = wifi_app_inst_base << 14,
     wifi_app_inst_ocs = wifi_app_inst_base << 15,
-    wifi_app_inst_max = wifi_app_inst_base << 16
+    wifi_app_inst_easyconnect = wifi_app_inst_base << 16,
+    wifi_app_inst_max = wifi_app_inst_base << 17
 } wifi_app_inst_t;
 
 typedef struct {

--- a/source/apps/easyconnect/wifi_easyconnect.c
+++ b/source/apps/easyconnect/wifi_easyconnect.c
@@ -1,0 +1,251 @@
+#include "wifi_base.h"
+#include "wifi_events.h"
+#include "wifi_hal.h"
+
+#include "wifi_analytics.h"
+#include "wifi_apps_mgr.h"
+#include "wifi_ctrl.h"
+#include "wifi_easyconnect.h"
+#include "wifi_mgr.h"
+#include "wifi_util.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef MAC2STR
+#define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
+#endif // MAC2STR
+
+#ifndef MACSTRFMT
+#define MACSTRFMT "%02x:%02x:%02x:%02x:%02x:%02x"
+#endif // MACSTRFMT
+
+#ifndef ARRAYSIZE
+#define ARRAYSIZE(a) (sizeof(a) / sizeof(*(a)))
+#endif // ARRAYSIZE
+
+/**
+ * @brief Is this IE a Wi-Fi Alliance CCE IE?
+ *
+ * @param ie The information element in question
+ * @param ie_len Length of the information element in bytes.
+ * @return true if this IE is a WFA CCE IE, otherwise false
+ */
+static bool is_cce_ie(const uint8_t *const ie, size_t ie_len)
+{
+    static const uint8_t OUI_WFA[3] = { 0x50, 0x6F, 0x9A };
+    static const uint8_t CCE_CONSTANT = 0x1E;
+    if (ie_len < 4)
+        return false;
+    return memcmp(ie, OUI_WFA, sizeof(OUI_WFA)) == 0 && *(ie + 3) == CCE_CONSTANT;
+}
+
+static void publish_cce_ie_info(const wifi_bss_info_t *bss_info, unsigned radio_idx)
+{
+    if (bss_info == NULL) {
+        wifi_util_error_print(WIFI_EC, "%s:%d: NULL BSS info!\n", __func__, __LINE__);
+        return;
+    }
+    wifi_ctrl_t *ctrl = get_wifictrl_obj();
+    raw_data_t rdata = { 0 };
+    rdata.raw_data.bytes = malloc(sizeof(wifi_bss_info_t));
+    if (rdata.raw_data.bytes == NULL) {
+        wifi_util_error_print(WIFI_EC, "%s:%d: Failed to malloc for wifi_bss_info_t!\n", __func__,
+            __LINE__);
+        return;
+    }
+    rdata.data_type = bus_data_type_bytes;
+    memcpy(rdata.raw_data.bytes, bss_info, sizeof(*bss_info));
+    rdata.raw_data_len = sizeof(*bss_info);
+    char path[256] = { 0 };
+    snprintf(path, sizeof(path), "Device.WiFi.Radio.%d.CCEInd", radio_idx + 1);
+    get_bus_descriptor()->bus_event_publish_fn(&ctrl->handle, path, &rdata);
+    free(rdata.raw_data.bytes);
+}
+
+static void handle_wifi_event_scan_results(wifi_app_t *app, void *data)
+{
+    int i;
+    int n = 0;
+    scan_results_t *scan_results = (scan_results_t *)data;
+    if (!scan_results) {
+        wifi_util_error_print(WIFI_EC, "%s:%d: NULL scan data!\n", __func__, __LINE__);
+        return;
+    }
+    wifi_util_dbg_print(WIFI_EC, "%s:%d: Got scan results on radio %d\n", __func__, __LINE__,
+        scan_results->radio_index);
+    if (app->data.u.ec.subscriptions[scan_results->radio_index] == false) {
+        wifi_util_dbg_print(WIFI_EC,
+            "%s:%d: Got a scan result on radio %d but there are no subscribers, skipping...\n",
+            __func__, __LINE__, scan_results->radio_index);
+        return;
+    }
+    for (i = 0; i < scan_results->num; i++) {
+        wifi_bss_info_t *bss_info = &scan_results->bss[i];
+        if (!bss_info || !bss_info->ie || bss_info->ie_len == 0) {
+            wifi_util_dbg_print(WIFI_EC, "%s:%d: Invalid BSS info! #%d\n", __func__, __LINE__, i);
+            continue;
+        }
+        uint8_t *ie_pos = bss_info->ie;
+        size_t ie_len_remaining = bss_info->ie_len;
+        while (ie_len_remaining > 2) {
+            uint8_t id = ie_pos[0];
+            uint8_t ie_len = ie_pos[1];
+            if (ie_len + 2 > ie_len_remaining)
+                break;
+            // 0xdd == Vendor IE
+            if (id == 0xdd && is_cce_ie(ie_pos + 2, ie_len)) {
+                wifi_util_dbg_print(WIFI_EC,
+                    "%s:%d: BSS %s Beacon and/or Probe Response from BSSID " MACSTRFMT
+                    " contains WFA CCE IE!\n",
+                    __func__, __LINE__, bss_info->ssid, MAC2STR(bss_info->bssid));
+                publish_cce_ie_info(bss_info, scan_results->radio_index);
+                n++;
+            }
+            // next IE
+            ie_len_remaining -= (ie_len + 2);
+            ie_pos += (ie_len + 2);
+        }
+    }
+    wifi_util_dbg_print(WIFI_EC, "%s:%d parsed and published %d frames containing CCE IE\n",
+        __func__, __LINE__, n);
+}
+
+static void handle_hal_event(wifi_app_t *app, wifi_event_subtype_t event_subtype, void *data)
+{
+    switch (event_subtype) {
+    case wifi_event_scan_results:
+        handle_wifi_event_scan_results(app, data);
+        break;
+    default:
+        wifi_util_dbg_print(WIFI_EC, "%s:%d: unhandled event sub_type=%d\n", __func__, __LINE__,
+            event_subtype);
+        break;
+    }
+}
+
+static bus_error_t event_sub_handler(char *eventName, bus_event_sub_action_t action,
+    int32_t interval, bool *autoPublish)
+{
+    uint32_t radio_idx = 0;
+    wifi_app_t *wifi_app = NULL;
+    wifi_ctrl_t *wifi_ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
+    if (!wifi_ctrl) {
+        wifi_util_error_print(WIFI_EC, "%s:%d: Wi-Fi control is NULL!\n", __func__, __LINE__);
+        return bus_error_general;
+    }
+
+    wifi_apps_mgr_t *apps_mgr = &wifi_ctrl->apps_mgr;
+    if (apps_mgr == NULL) {
+        wifi_util_error_print(WIFI_EC, "%s:%d NULL Pointer \n", __func__, __LINE__);
+        return bus_error_general;
+    }
+
+    wifi_app = get_app_by_inst(apps_mgr, wifi_app_inst_easyconnect);
+    if (wifi_app == NULL) {
+        wifi_util_error_print(WIFI_EC, "%s:%d NULL Pointer \n", __func__, __LINE__);
+        return bus_error_general;
+    }
+
+    *autoPublish = false;
+    if (sscanf(eventName, "Device.WiFi.Radio.%d.CCEInd", &radio_idx) != 1) {
+        wifi_util_error_print(WIFI_EC,
+            "%s:%d: sscanf failed for event %s, searching on bus path %s\n", __func__, __LINE__,
+            eventName, WIFI_EASYCONNECT_RADIO_CCE_IND);
+        return bus_error_general;
+    }
+    // ensure radio index is valid
+    if (radio_idx < 0 || radio_idx > MAX_NUM_RADIOS) {
+        wifi_util_error_print(WIFI_EC, "%s:%d: invalid radio index: %d\n", __func__, __LINE__,
+            radio_idx);
+        return bus_error_general;
+    }
+    if (action == bus_event_action_subscribe) {
+        wifi_util_info_print(WIFI_EC, "%s:%d: Adding subscrption for radio %d\n", __func__,
+            __LINE__, radio_idx);
+        wifi_app->data.u.ec.subscriptions[radio_idx - 1] = true;
+    } else if (action == bus_event_action_unsubscribe) {
+        wifi_app->data.u.ec.subscriptions[radio_idx - 1] = false;
+        wifi_util_info_print(WIFI_EC, "%s:%d: Removing subscription for radio %d\n", __func__,
+            __LINE__, radio_idx);
+    } else {
+        wifi_util_dbg_print(WIFI_EC, "%s:%d: unhandled action %d for radio %d\n", __func__,
+            __LINE__, action, radio_idx);
+        return bus_error_invalid_event;
+    }
+    return bus_error_success;
+}
+
+bus_error_t easyconnect_radio_addrowhandler(const char *tableName, const char *aliasName,
+    uint32_t *instNum)
+{
+    static unsigned int instanceCounter = 1;
+    *instNum = instanceCounter;
+    wifi_util_dbg_print(WIFI_EC, "%s:%d: tableName=%s aliasName=%s instNum=%d\n", __func__,
+        __LINE__, tableName, aliasName, *instNum);
+    instanceCounter = (instanceCounter % MAX_NUM_RADIOS) + 1;
+    return bus_error_success;
+}
+
+bus_error_t easyconnect_radio_removerowhandler(const char *rowName)
+{
+    wifi_util_dbg_print(WIFI_EC, "%s(): %s\n", __func__, rowName);
+    return bus_error_success;
+}
+
+int easyconnect_event(wifi_app_t *app, wifi_event_t *event)
+{
+    switch (event->event_type) {
+    case wifi_event_type_hal_ind:
+        handle_hal_event(app, event->sub_type, event->u.core_data.msg);
+        break;
+    default:
+        wifi_util_dbg_print(WIFI_EC, "%s:%d: unhandled event_type=%d\n", __func__, __LINE__,
+            event->event_type);
+        break;
+    }
+}
+
+int easyconnect_init(wifi_app_t *app, unsigned int create_flags)
+{
+    wifi_util_dbg_print(WIFI_EC, "%s called.", __func__);
+    char *app_name = "WifiAppsEasyConnect";
+    for (int i = 0; i < ARRAYSIZE(app->data.u.ec.subscriptions); i++) {
+        app->data.u.ec.subscriptions[i] = false;
+    }
+    // clang-format off
+    bus_data_element_t data_elements[] = {
+        { WIFI_EASYCONNECT_RADIO_TABLE,   bus_element_type_table,
+         { NULL, NULL, easyconnect_radio_addrowhandler, easyconnect_radio_removerowhandler, NULL,
+          NULL }, slow_speed, MAX_NUM_RADIOS, { bus_data_type_object, false, 0, 0, 0, NULL } },
+        { WIFI_EASYCONNECT_RADIO_CCE_IND, bus_element_type_event,
+         { NULL, NULL, NULL, NULL, event_sub_handler, NULL }, slow_speed, ZERO_TABLE,
+         { bus_data_type_bytes, false, 0, 0, 0, NULL } },
+    };
+    // clang-format on
+
+    if (app_init(app, create_flags) != 0) {
+        wifi_util_error_print(WIFI_EC, "%s:%d: Failed to register app!\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+    wifi_util_info_print(WIFI_EC, "%s:%d: EasyConnect app init'd\n", __func__, __LINE__);
+    if (get_bus_descriptor()->bus_reg_data_element_fn(&app->ctrl->handle, data_elements,
+            ARRAYSIZE(data_elements)) != bus_error_success) {
+        wifi_util_error_print(WIFI_EC, "%s:%d: failed to register data elements\n", __func__,
+            __LINE__);
+        return RETURN_ERR;
+    }
+    wifi_util_info_print(WIFI_EC, "%s:%d: EasyConnect app data elems registered\n", __func__,
+        __LINE__);
+    return RETURN_OK;
+}
+
+int easyconnect_deinit(wifi_app_t *app)
+{
+    wifi_util_info_print(WIFI_EC, "%s:%d: %s called.", __func__, __LINE__, __func__);
+    for (int i = 0; i < ARRAYSIZE(app->data.u.ec.subscriptions); i++) {
+        app->data.u.ec.subscriptions[i] = false;
+    }
+    app_deinit(app, app->desc.create_flag);
+    return 0;
+}

--- a/source/apps/easyconnect/wifi_easyconnect.h
+++ b/source/apps/easyconnect/wifi_easyconnect.h
@@ -1,0 +1,40 @@
+/************************************************************************************
+  If not stated otherwise in this file or this component's LICENSE file the
+  following copyright and licenses apply:
+
+  Copyright 2024 RDK Management
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ **************************************************************************/
+
+#ifndef _WIFI_EASYCONNECT_H
+#define _WIFI_EASYCONNECT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#define WIFI_EASYCONNECT_RADIO_TABLE        "Device.WiFi.Radio.{i}"
+#define WIFI_EASYCONNECT_RADIO_CCE_IND      "Device.WiFi.Radio.{i}.CCEInd"
+
+typedef struct _easyconnect_data {
+    bool subscriptions[MAX_NUM_RADIOS];
+} easyconnect_data_t;
+
+// EasyConnect relevant constructs
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // _WIFI_EASYCONNECT_H

--- a/source/apps/wifi_apps.c
+++ b/source/apps/wifi_apps.c
@@ -190,7 +190,28 @@ int blaster_event(wifi_app_t *app, wifi_event_t *event)
     return 0;
 }
 
-#endif
+#endif // ONEWIFI_BLASTER_APP_SUPPORT
+
+#ifdef ONEWIFI_EASYCONNECT_APP_SUPPORT
+extern int easyconnect_init(wifi_app_t *app, unsigned int create_flag);
+extern int easyconnect_deinit(wifi_app_t *app);
+extern int easyconnect_event(wifi_app_t *app, wifi_event_t *event);
+#else
+int easyconnect_init(wifi_app_t *app, unsigned int create_flag)
+{
+    return 0;
+}
+
+int easyconnect_deinit(wifi_app_t *app)
+{
+    return 0;
+}
+
+int easyconnect_event(wifi_app_t *app, wifi_event_t *event)
+{
+    return 0;
+}
+#endif // ONEWIFI_EASYCONNECT_APP_SUPPORT
 
 
 wifi_app_descriptor_t app_desc[] = {
@@ -280,7 +301,17 @@ wifi_app_descriptor_t app_desc[] = {
         "Blaster",
         blaster_init, blaster_event, blaster_deinit,
         NULL, NULL
-    }
+    },
+#ifdef ONEWIFI_EASYCONNECT_APP_SUPPORT
+    {
+        wifi_app_inst_easyconnect, 0,
+        wifi_event_type_hal_ind,
+        true, true,
+        "EasyConnect",
+        easyconnect_init, easyconnect_event, easyconnect_deinit,
+        NULL, NULL
+    },
+#endif // ONEWIFI_EASYCONNECT_APP_SUPPORT
 
 };
 

--- a/source/apps/wifi_apps_mgr.h
+++ b/source/apps/wifi_apps_mgr.h
@@ -43,6 +43,10 @@ extern "C" {
 #include "wifi_blaster.h"
 #endif
 
+#ifdef ONEWIFI_EASYCONNECT_APP_SUPPORT
+#include "wifi_easyconnect.h"
+#endif // ONEWIFI_EASYCONNECT_APP_SUPPORT
+
 #define MAX_APP_INIT_DATA 1024
 #define APP_DETACHED 0x01
 
@@ -80,6 +84,9 @@ typedef struct {
 #if defined (FEATURE_OFF_CHANNEL_SCAN_5G)
         off_channel_param_t  ocs[MAX_NUM_RADIOS];
 #endif //FEATURE_OFF_CHANNEL_SCAN_5G
+#ifdef ONEWIFI_EASYCONNECT_APP_SUPPORT
+        easyconnect_data_t ec;
+#endif // ONEWIFI_EASYCONNECT_APP_SUPPORT
     } u;
 } wifi_app_data_t;
 

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -814,6 +814,11 @@ void wifi_util_print(wifi_log_level_t level, wifi_dbg_type_t module, char *forma
             snprintf(module_filename, sizeof(module_filename), "wifiTransientClientMgmtCtrl");
             break;
         }
+        case WIFI_EC: {
+            snprintf(filename_dbg_enable, sizeof(filename_dbg_enable), LOG_PATH_PREFIX, "wifiEc");
+            snprintf(module_filename, sizeof(module_filename), "wifiEc");
+            break;
+        }
         default:
             return;
     }

--- a/source/utils/wifi_util.h
+++ b/source/utils/wifi_util.h
@@ -58,7 +58,8 @@ typedef enum {
     WIFI_BLASTER,
     WIFI_OCS,
     WIFI_BUS,
-    WIFI_TCM
+    WIFI_TCM,
+    WIFI_EC,
 } wifi_dbg_type_t;
 
 typedef enum {


### PR DESCRIPTION
For publishing EasyConnect data relevant to third party applications (such as publishing frames containing CCE IEs for EasyMesh DPP). This is a replacement PR for #60 
See comments on that PR for previous discussion

-------------------------------

For testing:

```bash
cd Onewifi
# First, add -DONEWIFI_EASYCONNECT_APP_SUPPORT to `CFLAGS` in `build/linux/makefile`
export ONEWIFI_EASYCONNECT_APP_SUPPORT=1 && make -f build/linux/makefile all -j
```

A patch to pump hard-coded scan results onto each radio from the control thread:


```c
diff --git a/source/core/wifi_ctrl.c b/source/core/wifi_ctrl.c
index 8e0c136..19d7ddc 100644
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -282,6 +282,60 @@ bool is_sta_enabled(void)
         ctrl->eth_bh_status == false);
 }
 
+#if 1
+static void send_fake_scan_event(wifi_ctrl_t *ctrl, int radio_index) {
+    wifi_bss_info_t *bss_info = malloc(sizeof(wifi_bss_info_t));
+    if (!bss_info) {
+        printf("Failed to allocate wifi_bss_info_t!\n");
+        return;
+    }
+    memset(bss_info, 0, sizeof(wifi_bss_info_t));
+    char ssid[32] = { 0 };
+    snprintf(ssid, sizeof(ssid), "TestSSID_%d", radio_index);
+    memcpy(bss_info->bssid, (uint8_t[]){0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, sizeof(bssid_t));
+    strncpy(bss_info->ssid, ssid, sizeof(bss_info->ssid));
+    bss_info->rssi = -45;
+    bss_info->freq = 5180; // 5 GHz channel 36 (USA)
+
+    // Construct CCE IE
+    uint8_t cce_ie[] = { 
+            0xDD, 0x04,            // Vendor-Specific IE ID (0xDD), Length (4)
+            0x50, 0x6F, 0x9A, 0x1E // Wi-Fi Alliance OUI (50:6F:9A), CCE Type 0x1E
+    };
+
+
+    memcpy(bss_info->ie, cce_ie, sizeof(cce_ie));
+    bss_info->ie_len = sizeof(cce_ie);
+    scan_results_t scan_result;
+    memset(&scan_result, 0, sizeof(scan_results_t));
+    scan_result.num = 1;
+    scan_result.radio_index = radio_index;
+    memcpy(&scan_result.bss[0], bss_info, sizeof(*bss_info));
+
+    // Allocate event structure
+    wifi_event_t *fake_event = malloc(sizeof(wifi_event_t));
+    if (!fake_event) {
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: Failed to allocate wifi_event_t!\n", __func__, __LINE__);
+        free(bss_info);
+        return;
+    }
+    memset(fake_event, 0, sizeof(wifi_event_t));
+
+    fake_event->u.core_data.msg = malloc(sizeof(scan_results_t));
+    if (!fake_event->u.core_data.msg) {
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: Failed to allocate scan_results_t!\n", __func__, __LINE__);
+        free(fake_event);
+        free(bss_info);
+        return;
+    }
+    memcpy(fake_event->u.core_data.msg, &scan_result, sizeof(scan_result));
+    fake_event->u.core_data.len = sizeof(scan_result);
+    fake_event->event_type = wifi_event_type_hal_ind;
+    fake_event->sub_type = wifi_event_scan_results;
+    apps_mgr_event(&ctrl->apps_mgr, fake_event);
+}
+#endif
+
 void ctrl_queue_loop(wifi_ctrl_t *ctrl)
 {
     struct timespec time_to_wait;
@@ -341,6 +395,14 @@ void ctrl_queue_loop(wifi_ctrl_t *ctrl)
                         break;
                 }
 
+
+                #if 1
+                    // Publish fake scan event on each radio
+                    for (int i = 0; i < getNumberRadios(); i++) {
+                        send_fake_scan_event(ctrl, i);
+                    }
+                #endif
+
                 if (event->event_type != wifi_event_type_webconfig) {
                     // now forward the event to apps manager
                     apps_mgr_event(&ctrl->apps_mgr, event);
```

A client process for testing subscription / publishing:
```c
#include "bus.h"
#include <stdbool.h>
#include <stdio.h>
#include <string.h>

#ifndef MAC2STR
#define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
#endif // MAC2STR

#ifndef MACSTRFMT
#define MACSTRFMT "%02x:%02x:%02x:%02x:%02x:%02x"
#endif // MACSTRFMT

int callback(char *event_name, raw_data_t *data) {
    printf("Callback fired, event: %s\n", event_name);
    if (!data) {
        printf("Data is NULL!\n");
        return -1;
    }
    printf("Data contains %zu bytes\n", data->raw_data_len);
    wifi_bss_info_t *bss_info = (wifi_bss_info_t *)data->raw_data.bytes;
    printf("CCE IE found in frame from BSSID " MACSTRFMT "\n", MAC2STR(bss_info->bssid));
    return 0;
}


int main(int argc, char *argv[])
{
    bus_handle_t handle;
    memset(&handle, 0, sizeof(bus_handle_t));
    // Also initializes the bus descriptor
    bus_error_t rc = bus_init(&handle);
    if (rc != bus_error_success) {
        printf("bus_init failed with error: %d\n", rc);
        return EXIT_FAILURE;
    }

    wifi_bus_desc_t *desc = get_bus_descriptor();
    if (desc == NULL) {
        printf("get_bus_descriptor failed\n");
        return EXIT_FAILURE;
    }

    char *comp_name = "CCESubscriptionTest";
    rc = desc->bus_open_fn(&handle, comp_name);
    if (rc != bus_error_success) {
        printf("bus_open failed with error: %d\n", rc);
        return EXIT_FAILURE;
    }

    const char *paths[] = {"Device.WiFi.Radio.1.CCEInd", NULL};
    for (const char **path = paths; *path; path++) {
        printf("Subscribing to path %s\n", *path);
        if (desc->bus_event_subs_fn(&handle, *path, callback, NULL, 0) != bus_error_success) {
            printf("Failed to subscribe to %s\n", *path);
            desc->bus_close_fn(&handle);
            return EXIT_FAILURE;
        }
    }
    while (1) {
        ;;
    }

    desc->bus_close_fn(&handle);
    return EXIT_SUCCESS;
}
```

A Makefile for building the test app:
```make
##########################################################################
 # Copyright 2023 Comcast Cable Communications Management, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
##########################################################################

include build/linux/makefile.inc

#
# program
#

PROGRAM = $(INSTALLDIR)/bin/cce

INCLUDEDIRS = \
	-I$(WIFI_HAL_INTERFACE) \
	-I$(ONE_WIFI_HOME)/source/utils \
	-I$(ONE_WIFI_HOME)/include \
    	-I$(ONE_WIFI_HOME)/lib/bus/inc \
    	-I$(ONE_WIFI_HOME)/lib/log \
    	-I$(ONE_WIFI_HOME)/lib/ds \
    	-I$(ONE_WIFI_HOME)/source/platform/linux \
    	-I$(ONE_WIFI_HOME)/source/platform/common \
    	-I$(ONE_WIFI_HOME)/source/platform/linux/he_bus/inc \
        -I$(ONE_WIFI_HOME)/source/ccsp

CFLAGS = $(INCLUDEDIRS) -g
LDFLAGS = $(LIBDIRS) $(LIBS)
LIBDIRS = \
    -L$(INSTALLDIR)/lib \
    -L$(ONE_WIFI_HOME)/install/lib/ \
    -L/usr/local/lib \
    -L/usr/lib 

# Update LIBS - move cJSON earlier in link order
LIBS = -lcjson -lhebus -lm -lpthread -ldl -luuid -lssl -lcrypto -lwebconfig

CCE_SOURCES = 	$(ONE_WIFI_HOME)/source/utils/collection.c \
    			$(ONE_WIFI_HOME)/lib/common/util.c \
    			$(ONE_WIFI_HOME)/source/platform/linux/bus.c \
				$(ONE_WIFI_HOME)/source/test_apps/test_cce.c

CCE_OBJECTS = $(CCE_SOURCES:.c=.o)

all: $(BUS_LIBRARY) $(PROGRAM)

$(PROGRAM): $(CCE_OBJECTS)
	$(CC) -o $@ $(CCE_OBJECTS) $(LDFLAGS) $(LIBS)

$(CCE_OBJECTS): %.o: %.c
	$(CC) $(CFLAGS) -o $@ -c $<


# Clean target: "make -f Makefile.Linux clean" to remove unwanted objects and executables.
#

	
clean:
	$(RM) $(CCE_OBJECTS) $(PROGRAM)

#
# Run target: "make -f Makefile.Linux run" to execute the application
#             You will need to add $(VARIABLE_NAME) for any command line parameters 
#             that you defined earlier in this file.
# 

run:
	./$(PROGRAM) 
```

To build the test app:
```bash
mkdir -p OneWifi/source/test_apps
touch OneWiFi/source/test_apps/test_cce.c
# <copy test code into source file>
touch build/linux/makefile/cce_makefile
# <copy makefile into cce_makefile>
make -f build/linux/cce_makefile
```

To test:
Terminal 1:
```bash
cd install/bin
sudo ./OneWifi
```

Terminal 2:
```bash
cd install/bin
./cce
```

In Terminal 2, you should see the client process successfully subscribe and parse frames which contain CCE IEs:
```bash
tpolomik@raspberrypi:~/rdk-easymesh-dev/OneWifi/install/bin $ ./cce 
Subscribing to path Device.WiFi.Radio.1.CCEInd
Callback fired, event: Device.WiFi.Radio.1.CCEInd
Data contains 364 bytes
CCE IE found in frame from BSSID 00:11:22:33:44:55
```



