### PR TITLE
RDKB-58058: Telemetry and Rbus for Transient Client Management

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -2785,6 +2785,12 @@ INSTMSMT_PH2 -->
                                     <syntax>string</syntax>
                                     <writable>true</writable>
                                 </parameter>
+                                <parameter>
+                                    <name>TcmClientDenyAssociation</name>
+                                    <type>string</type>
+                                    <syntax>string</syntax>
+                                    <writable>true</writable>
+                                </parameter>
                             </parameters>
                             <objects>
                                 <object>

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -75,6 +75,7 @@ extern "C" {
 #define WIFI_COLLECT_STATS_RADIO_TEMPERATURE           "Device.WiFi.CollectStats.Radio.{i}.RadioTemperatureStats"
 #define WIFI_COLLECT_STATS_VAP_TABLE                   "Device.WiFi.CollectStats.AccessPoint.{i}."
 #define WIFI_COLLECT_STATS_ASSOC_DEVICE_STATS          "Device.WiFi.CollectStats.AccessPoint.{i}.AssociatedDeviceStats"
+#define WIFI_NOTIFY_DENY_TCM_ASSOCIATION               "Device.WiFi.ConnectionControl.TcmClientDenyAssociation"
 #define WIFI_STUCK_DETECT_FILE_NAME         "/nvram/wifi_stuck_detect"
 
 #define PLAN_ID_LENGTH     38

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -392,6 +392,41 @@ int notify_LM_Lite(wifi_ctrl_t *ctrl, LM_wifi_hosts_t *phosts, bool sync)
     return RETURN_OK;
 }
 
+int tcm_notify_deny_association(wifi_ctrl_t *ctrl, int ap_index, mac_addr_str_t mac,
+    double threshold_val, double snr_gradient, char *exp_weight, int timeout,
+    int min_num_mgmt_frames, int current_mgmt_frames, int reason)
+{
+    bus_error_t rc;
+    char str[64];
+    wifi_vap_info_t *vap_info = NULL;
+
+    memset(str, 0, 64);
+
+    if (ctrl == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: NULL Pointer \n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+
+    vap_info = getVapInfo(ap_index);
+
+    snprintf(str, sizeof(str), "%d,%lf,%lf,%s,%d,%d,%d,%s,%d", (ap_index + 1), threshold_val,
+        snr_gradient, exp_weight, timeout, min_num_mgmt_frames, current_mgmt_frames, mac, reason);
+
+    if (vap_info != NULL) {
+        strncpy(vap_info->u.bss_info.preassoc.tcm_client_deny_assoc_info, str,
+            sizeof(vap_info->u.bss_info.preassoc.tcm_client_deny_assoc_info));
+    }
+
+    rc = get_bus_descriptor()->bus_set_string_fn(&ctrl->handle, WIFI_NOTIFY_DENY_TCM_ASSOCIATION,
+        str);
+    if (rc != bus_error_success) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: bus: bus_set_string_fn Failed %d\n", __func__,
+            __LINE__, rc);
+        return RETURN_ERR;
+    }
+    return RETURN_OK;
+}
+
 int webconfig_bus_apply_for_dml_thread_update(wifi_ctrl_t *ctrl,
     webconfig_subdoc_encoded_data_t *data)
 {

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -561,18 +561,6 @@ static bool is_preassoc_cac_config_changed(wifi_vap_info_t *old, wifi_vap_info_t
     }
 }
 
-static bool is_preassoc_tcm_config_changed(wifi_vap_info_t *old, wifi_vap_info_t *new)
-{
-    if ((IS_CHANGED(old->u.bss_info.preassoc.time_ms, new->u.bss_info.preassoc.time_ms))
-        || (IS_CHANGED(old->u.bss_info.preassoc.min_num_mgmt_frames, new->u.bss_info.preassoc.min_num_mgmt_frames))
-        || (IS_STR_CHANGED(old->u.bss_info.preassoc.tcm_exp_weightage, new->u.bss_info.preassoc.tcm_exp_weightage, sizeof(old->u.bss_info.preassoc.tcm_exp_weightage)))
-        || (IS_STR_CHANGED(old->u.bss_info.preassoc.tcm_gradient_threshold, new->u.bss_info.preassoc.tcm_gradient_threshold, sizeof(old->u.bss_info.preassoc.tcm_gradient_threshold)))) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
 static bool is_postassoc_cac_config_changed(wifi_vap_info_t *old, wifi_vap_info_t *new)
 {
     if ((IS_STR_CHANGED(old->u.bss_info.postassoc.rssi_up_threshold, new->u.bss_info.postassoc.rssi_up_threshold, sizeof(old->u.bss_info.postassoc.rssi_up_threshold)))
@@ -1319,8 +1307,7 @@ int webconfig_cac_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data
         for (vap_index = 0; vap_index < getNumberVAPsPerRadio(radio_index); vap_index++) {
             wifi_util_dbg_print(WIFI_CTRL,"Comparing cac config\n");
 
-            if (is_preassoc_tcm_config_changed(&l_vap_maps->vap_array[vap_index], &data->radios[radio_index].vaps.vap_map.vap_array[vap_index])
-                || is_preassoc_cac_config_changed(&l_vap_maps->vap_array[vap_index], &data->radios[radio_index].vaps.vap_map.vap_array[vap_index])
+            if (is_preassoc_cac_config_changed(&l_vap_maps->vap_array[vap_index], &data->radios[radio_index].vaps.vap_map.vap_array[vap_index])
                 || is_postassoc_cac_config_changed(&l_vap_maps->vap_array[vap_index], &data->radios[radio_index].vaps.vap_map.vap_array[vap_index])) {
                 // cac or tcm data changed apply
                 wifi_util_info_print(WIFI_CTRL, "%s:%d: Change detected in received cac config, applying new configuration for vap: %d\n",

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -9287,6 +9287,12 @@ ConnectionControl_GetParamStringValue
         return 0;
     }
 
+    if( AnscEqualString(ParamName, "TcmClientDenyAssociation", TRUE))
+    {
+        snprintf(pValue,*pUlSize,pcfg->u.bss_info.preassoc.tcm_client_deny_assoc_info);
+        return 0;
+    }
+
     return -1;
 }
 


### PR DESCRIPTION
Impacted Platforms:
OneWifi platforms

Reason for change: Implement Rbus functions for TCM as part of Epic

Test Procedure: Load the build and test the changes as per ACs

Risks: Low

Signed-off-by:Harshavardhan_Pulluru@comcast.com