### PR TITLE
REFPLTB-3245 REFPLTB-3246 REFPLTB-3244: Potential memory leak in method initial_sync at rbus_get

### DIFF
--- a/source/sampleapps/webconfig_consumer_apis.c
+++ b/source/sampleapps/webconfig_consumer_apis.c
@@ -1811,6 +1811,7 @@ int get_device_network_mode_from_ctrl_thread(webconfig_consumer_t *consumer, uns
     }
 
     str = rbusValue_GetString(value, &len);
+    rbusValue_Release(value);
     if (str == NULL) {
         printf("%s Null pointer,Rbus set string len=%d\n",__FUNCTION__,len);
         return -1;
@@ -2309,6 +2310,7 @@ int get_rbus_sta_interface_name(const char *paramNames)
 
     printf(":%s:%d Sta interface name = [%s]\n", __func__, __LINE__, rbusValue_GetString(value, NULL));
 
+    rbusValue_Release(value);
     return 0;
 }
 

--- a/source/sampleapps/wifi_webconfig_consumer.c
+++ b/source/sampleapps/wifi_webconfig_consumer.c
@@ -361,6 +361,7 @@ int initial_sync(webconfig_consumer_t *consumer)
     printf("%s:%d: init cache trigger successful\n", __func__, __LINE__);
 
     str = rbusValue_GetString(value, &len);
+    rbusValue_Release(value);
     if (str == NULL) {
         printf("%s Null pointer,Rbus set string len=%d\n",__FUNCTION__,len);
         return -1;

--- a/source/sampleapps/wifievents_consumer_sample.c
+++ b/source/sampleapps/wifievents_consumer_sample.c
@@ -80,16 +80,17 @@ static void wifievents_get_device_vaps()
 {
     char cmd[200];
     int i;
-    rbusValue_t value;
     int rc = RBUS_ERROR_SUCCESS;
 
     for (i = 0; i < MAX_VAP; i++) {
+        rbusValue_t value;
         snprintf(cmd, sizeof(cmd), "Device.WiFi.SSID.%d.Enable", i + 1);
         rc = rbus_get(g_handle, cmd, &value);
         if (rc != RBUS_ERROR_SUCCESS) {
             g_device_vaps_list[i] = -1;
         } else {
             g_device_vaps_list[i] = i + 1;
+            rbusValue_Release(value);
         }
     }
 }


### PR DESCRIPTION
Reason for change: Added code to release the memory. Test Procedure: 1) Execute below command from the console,
                   valgrind --tool=memcheck --leak-check=yes --show-reachable=yes --num-callers=20 --log-file="/tmp/test.txt" --track-fds=yes /usr/bin/onewifi_component_test_app -d
                2) After the execution, you can see the cli mode of the test app
                3) Go to "/tmp/test.txt" and check for the definitely lost record in the file. Able to see the leak caused due to rbus_get call.
Risks: None