### PR TITLE
RDKB-58478: Frame Data being absent in client subdoc not to be treated as error

### DIFF
--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -2913,15 +2913,15 @@ webconfig_error_t decode_frame_data(cJSON *obj_assoc_client, frame_data_t *frame
 
     value_object = cJSON_GetObjectItem(obj_assoc_client, "FrameData");
     if ((value_object == NULL) || (cJSON_IsString(value_object) == false)) {
-        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: FrameData Invalid or not present\n", __func__,
+        wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d: FrameData Invalid or not present\n", __func__,
             __LINE__);
-        return webconfig_error_decode;
+        return webconfig_error_none;
     }
 
     tmp_assoc_frame_string = cJSON_GetStringValue(value_object);
     if (tmp_assoc_frame_string == NULL || strlen(tmp_assoc_frame_string) == 0) {
-        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: FrameData empty\n", __func__, __LINE__);
-        return webconfig_error_decode;
+        wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d: FrameData empty\n", __func__, __LINE__);
+        return webconfig_error_none;
     }
 
     memset(frame, 0, sizeof(frame_data_t));


### PR DESCRIPTION
Reason for change: Frame Data absent in client subdoc is a valid scenario and should not be treated as error in decode. Frame Data will not be present in case of disassoc event.
Test Procedure: Ensured that the Error messages are not printed if framedata is absent.