### PR TITLE
RDKB-58535: XCAM2 not able to connect(wifi7 interoperability)

### DIFF
--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -84,7 +84,9 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
             cfg.channelWidth = WIFI_CHANNELBANDWIDTH_20MHZ;
             cfg.variant = WIFI_80211_VARIANT_G | WIFI_80211_VARIANT_N;
 #ifdef CONFIG_IEEE80211BE
+#if !(defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_))
             cfg.variant |= WIFI_80211_VARIANT_BE;
+#endif /* !(defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)) */
 #endif /* CONFIG_IEEE80211BE */
             break;
         case WIFI_FREQUENCY_5_BAND:

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4321,7 +4321,10 @@ static void wifidb_radio_config_upgrade(unsigned int index, wifi_radio_operation
     if (g_wifidb->db_version < ONEWIFI_DB_VERSION_IEEE80211BE_FLAG) {
         wifi_util_info_print(WIFI_DB, "%s:%d upgrade radio=%d config, old db version: %d total radios: %u\n",
             __func__, __LINE__, index, g_wifidb->db_version, total_radios);
-        config->variant |= WIFI_80211_VARIANT_BE;
+#if defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+        if (config->band != WIFI_FREQUENCY_2_4_BAND)
+#endif /*defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)*/
+            config->variant |= WIFI_80211_VARIANT_BE;
         if(wifidb_update_wifi_radio_config(index, config, rdk_config) != RETURN_OK) {
             wifi_util_error_print(WIFI_DB,"%s:%d error in updating radio config\n", __func__,__LINE__);
             return;
@@ -6236,7 +6239,9 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
             cfg.variant |= WIFI_80211_VARIANT_AX;
 #endif /* NEWPLATFORM_PORT */
 #ifdef CONFIG_IEEE80211BE
+#if !(defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_))
             cfg.variant |= WIFI_80211_VARIANT_BE;
+#endif /* !(defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)) */
 #endif /* CONFIG_IEEE80211BE */
 #if defined (_PP203X_PRODUCT_REQ_)
             cfg.beaconInterval = 200;


### PR DESCRIPTION
Reason for change: Enable AKM suite selector 00-0F-AC:24 and GCMP-256 for pairwise cipher.
Test Procedure: 
1. Load build
2. Verify wifi-5/wifi-6/wifi-7 client connectios in below modes

                   WPA3-Personal-Transition with 802.11be ON
                   WPA3-Personal-Transition with 802.11be OFF
                   WPA3-Personal with 802.11be ON
                   WPA3-Personal with 802.11be OFF
Priority: P1
Risks: Low