### PR TITLE
RDKB-58559: Address crash seen in stringtohex function

### DIFF
--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -2882,7 +2882,7 @@ unsigned char *stringtohex(unsigned int in_len, char *in, unsigned int out_len, 
         return NULL;
     }
 
-    for (i = 0; i < in_len; i++) {
+    for (i = 0; i < in_len / 2; i++) {
         if (in[2 * i] <= '9') {
             tmp1 = (unsigned char)in[2 * i] - 0x30;
         } else {


### PR DESCRIPTION
Reason for change: Crash was due to buffer overflow in accessing the input buffer.
Test Procedure: Checked connection and assoc data being encoded and decoded appropriately with easymesh agent and controller Risks: Low
Priority: P1