### PR TITLE
Change the location of halinterface to refer to rdkcentral

### DIFF
--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -8,7 +8,7 @@ SRCREV_2_10="9d07b9447e76059a2ddef2a879c57d0934634188"
 #git clone other wifi related components
 cd ..
 git clone https://github.com/rdkcentral/rdk-wifi-hal.git rdk-wifi-hal
-git clone https://github.com/Aniket0606/rdkb-halif-wifi.git halinterface
+git clone https://github.com/rdkcentral/rdkb-halif-wifi.git halinterface
 cd $ONEWIFI_DIR
 mkdir -p install/bin
 mkdir -p install/lib


### PR DESCRIPTION
halinterface was earlier pointing to a fork of rdkcentral. It is now changed to point to rdkcentral inline with other repos.