### PR TITLE
RDKB-56764 RDKB-58193: ACL over NL80211 - 2.

### DIFF
--- a/source/core/services/vap_svc_public.c
+++ b/source/core/services/vap_svc_public.c
@@ -207,10 +207,17 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
         }
         p_tgt_vap_map->vap_array[0].u.bss_info.enabled = enabled;
         if (greylist_rfc || ((pcfg != NULL && pcfg->prefer_private))) {
+#ifdef NL80211_ACL
+            wifi_hal_set_acl_mode(p_tgt_vap_map->vap_array[0].vap_index, 2);
+#else
             wifi_setApMacAddressControlMode(p_tgt_vap_map->vap_array[0].vap_index, 2);
-        }
-        else {
+#endif
+        } else {
+#ifdef NL80211_ACL
+            wifi_hal_set_acl_mode(p_tgt_vap_map->vap_array[0].vap_index, 0);
+#else
             wifi_setApMacAddressControlMode(p_tgt_vap_map->vap_array[0].vap_index, 0);
+#endif
         }
         wifi_util_info_print(WIFI_CTRL,"%s: wifi vap create success: radio_index:%d vap_index:%d greylist_rfc:%d\n",__FUNCTION__,
                                                 radio_index, map->vap_array[i].vap_index,greylist_rfc);
@@ -318,10 +325,17 @@ void add_mac_mode_to_public_vaps(bool mac_mode)
                 continue;
             }
             if (mac_mode) {
+#ifdef NL80211_ACL
+                wifi_hal_set_acl_mode(rdk_vap_info->vap_index, 2);
+#else
                 wifi_setApMacAddressControlMode(rdk_vap_info->vap_index, 2);
-            }
-            else {
+#endif // NL80211_ACL
+            } else {
+#ifdef NL80211_ACL
+                wifi_hal_set_acl_mode(rdk_vap_info->vap_index, 0);
+#else
                 wifi_setApMacAddressControlMode(rdk_vap_info->vap_index, 0);
+#endif // NL80211_ACL
             }
         }
     }

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -1015,8 +1015,14 @@ int process_maclist_timeout(void *arg)
         } else {
             filtermode  = 0;
         }
-        if (wifi_setApMacAddressControlMode(kick->vap_index, filtermode) != RETURN_OK) {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d: wifi_setApMacAddressControlMode failed vap_index %d", __func__, __LINE__);
+#ifdef NL80211_ACL
+        if (wifi_hal_set_acl_mode(kick->vap_index, filtermode) != RETURN_OK)
+#else
+        if (wifi_setApMacAddressControlMode(kick->vap_index, filtermode) != RETURN_OK)
+#endif // NL80211_ACL
+        {
+            wifi_util_error_print(WIFI_CTRL,
+                "%s:%d: wifi_setApMacAddressControlMode failed vap_index %d", __func__, __LINE__);
         }
         rdk_vap_info->kick_device_config_change = FALSE;
     }
@@ -1199,8 +1205,15 @@ void process_kick_assoc_devices_event(void *data)
     timeout = atoi(s_timeout);
 
     if (vap_info->u.bss_info.mac_filter_enable == FALSE) {
-        if (wifi_setApMacAddressControlMode(vap_index, 2) != RETURN_OK) {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d: wifi_setApMacAddressControlMode failed vap_index %d", __func__, __LINE__, vap_index);
+#ifdef NL80211_ACL
+        if (wifi_hal_set_acl_mode(vap_index, 2) != RETURN_OK)
+#else
+        if (wifi_setApMacAddressControlMode(vap_index, 2) != RETURN_OK)
+#endif // NL80211_ACL
+        {
+            wifi_util_error_print(WIFI_CTRL,
+                "%s:%d: set ACL failed failed vap_index %d", __func__, __LINE__,
+                vap_index);
             free(str_dup);
             return;
         }


### PR DESCRIPTION
Reason for change: OneWifi changes for setting mode. Test Procedure: ACL set should work over Netlink.
Risks: Low
Priority:P0