### PR TITLE
CBR2-2108: MaxAssociatedDevices and BssMaxNumSta having incorrect con…

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -178,7 +178,7 @@ typedef void *wifi_analytics_data_t;
 #define BSS_MAX_NUM_STA_SKY      64      /**< Max supported stations for SKY HUB specific platforms */
 #define BSS_MAX_NUM_STA_XB8      100     /**< Max supported stations for TCHX8 specific platform */
 #define BSS_MAX_NUM_STATIONS     100     /**< Max supported stations by RDK-B firmware which would varies based on platform */
-#define BSS_MAX_NUM_STA_CBRV2    15      /**< Max supported stations for CBRv2 specific platform */
+#define BSS_MAX_NUM_STA_HOTSPOT_CBRV2    15      /**< Max supported stations for hotspot CBRv2 specific platform */
 
 typedef unsigned char   mac_addr_t[MAC_ADDR_LEN];
 typedef signed short    rssi_t;

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -178,7 +178,7 @@ typedef void *wifi_analytics_data_t;
 #define BSS_MAX_NUM_STA_SKY      64      /**< Max supported stations for SKY HUB specific platforms */
 #define BSS_MAX_NUM_STA_XB8      100     /**< Max supported stations for TCHX8 specific platform */
 #define BSS_MAX_NUM_STATIONS     100     /**< Max supported stations by RDK-B firmware which would varies based on platform */
-#define BSS_MAX_NUM_STA_HOTSPOT_CBRV2    15      /**< Max supported stations for hotspot CBRv2 specific platform */
+#define BSS_MAX_NUM_STA_HOTSPOT_CBRV2    15      /**< Max supported stations for hotspot vaps in CBR2 platform */
 
 typedef unsigned char   mac_addr_t[MAC_ADDR_LEN];
 typedef signed short    rssi_t;

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -178,6 +178,7 @@ typedef void *wifi_analytics_data_t;
 #define BSS_MAX_NUM_STA_SKY      64      /**< Max supported stations for SKY HUB specific platforms */
 #define BSS_MAX_NUM_STA_XB8      100     /**< Max supported stations for TCHX8 specific platform */
 #define BSS_MAX_NUM_STATIONS     100     /**< Max supported stations by RDK-B firmware which would varies based on platform */
+#define BSS_MAX_NUM_STA_CBRV2    15      /**< Max supported stations for CBRv2 specific platform */
 
 typedef unsigned char   mac_addr_t[MAC_ADDR_LEN];
 typedef signed short    rssi_t;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6623,8 +6623,13 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
 #else
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
+            wifi_util_info_print(WIFI_DB, "%s:%d  vap_index:%d maxassoc:%d", __func__, __LINE__, vap_index, cfg.u.bss_info.bssMaxSta);
+        } else if (isVapHotspotOpen5g(vap_index) || isVapHotspotSecure5g(vap_index)) {
+            cfg.u.bss_info.bssMaxSta = 15;
+            wifi_util_info_print(WIFI_DB, "%s:%d vap_index:%d maxassoc:%d", __func__, __LINE__, vap_index, cfg.u.bss_info.bssMaxSta);
         } else {
-            cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_COMMON;
+            cfg.u.bss_info.bssMaxSta =  BSS_MAX_NUM_STA_COMMON;
+            wifi_util_info_print(WIFI_DB,"%s:%d  maxassoc:%d", __func__,__LINE__, cfg.u.bss_info.bssMaxSta);
         }
 #endif // NEWPLATFORM_PORT
 #endif //_SKY_HUB_COMMON_PRODUCT_REQ_

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6624,8 +6624,8 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
             wifi_util_info_print(WIFI_DB, "%s:%d  vap_index:%d maxassoc:%d", __func__, __LINE__, vap_index, cfg.u.bss_info.bssMaxSta);
-        } else if (isVapHotspotOpen5g(vap_index) || isVapHotspotSecure5g(vap_index)) {
-            cfg.u.bss_info.bssMaxSta = 15;
+        } else if (is_device_type_cbr2() && (isVapHotspotOpen5g(vap_index) || isVapHotspotSecure5g(vap_index))) {
+            cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_CBRV2;
             wifi_util_info_print(WIFI_DB, "%s:%d vap_index:%d maxassoc:%d", __func__, __LINE__, vap_index, cfg.u.bss_info.bssMaxSta);
         } else {
             cfg.u.bss_info.bssMaxSta =  BSS_MAX_NUM_STA_COMMON;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6625,7 +6625,7 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
             cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
             wifi_util_info_print(WIFI_DB, "%s:%d  vap_index:%d maxassoc:%d", __func__, __LINE__, vap_index, cfg.u.bss_info.bssMaxSta);
         } else if (is_device_type_cbr2() && (isVapHotspotOpen5g(vap_index) || isVapHotspotSecure5g(vap_index))) {
-            cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_CBRV2;
+            cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_HOTSPOT_CBRV2;
             wifi_util_info_print(WIFI_DB, "%s:%d vap_index:%d maxassoc:%d", __func__, __LINE__, vap_index, cfg.u.bss_info.bssMaxSta);
         } else {
             cfg.u.bss_info.bssMaxSta =  BSS_MAX_NUM_STA_COMMON;


### PR DESCRIPTION
…figs

Reason for change: MaxAssociatedDevice observed to be 15. Test Procedure: Executing the below mentioned dmcli command.
               1. Device.WiFi.AccessPoint.6.MaxAssociatedDevices
               2. Device.WiFi.AccessPoint.6.X_CISCO_COM_BssMaxNumSta
               3. Device.WiFi.AccessPoint.10.MaxAssociatedDevices
               4. Device.WiFi.AccessPoint.10.X_CISCO_COM_BssMaxNumSta
Priority: P1
Risks: Low
Signed-off-by: mothishree_mallaiyanjothimani@comcast.com