### PR TITLE
RDKBACCL-566 : OneWifi is crashing on 1st boot and FR in BPI platform

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4603,7 +4603,7 @@ void *start_wifidb_func(void *arg)
             strncpy(last_reboot_reason, (char *)data.raw_data.bytes, data.raw_data_len);
             get_bus_descriptor()->bus_data_free_fn(&data);
         } else {
-            get_wifi_last_reboot_reason_psm_value(last_reboot_reason);
+	    syscfg_get( NULL, "X_RDKCENTRAL-COM_LastRebootReason", last_reboot_reason, sizeof(last_reboot_reason));
         }
         wifi_util_info_print(WIFI_DB, "%s:%d last_reboot_reason:%s \n", __func__, __LINE__,
             last_reboot_reason);


### PR DESCRIPTION
Reason for change: As per the rdkb design, LastRebootReason value should be get from syscfg db instead of PSM.
Observing below BT when we did FR and 1st boot,

Core was generated by `/usr/bin/OneWifi -subsys eRT.'. Program terminated with signal SIGSEGV, Segmentation fault. [Current thread is 1 (LWP 8919)]
(gdb) bt
#0  0x0000007fb182bc54 in PSM_Get_Record_Value () from /usr/lib/libccsp_common.so.0
#1  0x0000007fb182c668 in PSM_Get_Record_Value2 () from /usr/lib/libccsp_common.so.0
#2  0x000000000047c194 in psm_get_value_Rdkb (recName=0x4eb1d3 "Device.DeviceInfo.X_RDKCENTRAL-COM_LastRebootReason", 
    strValue=<optimized out>) at ../../../git/source/core/../../source/ccsp/ccsp_api.c:140
#3  0x0000000000462a54 in get_wifi_last_reboot_reason_psm_value (last_reboot_reason=last_reboot_reason@entry=0x7f9f7ee220 "")
    at ../../../git/source/core/../../source/db/wifi_db_apis.c:8350
#4  0x0000000000462d84 in start_wifidb_func (arg=<optimized out>) at ../../../git/source/core/../../source/db/wifi_db_apis.c:4603
#5  0x0000007fb0b806b8 in ?? () from /lib/libc.so.6
#6  0x0000007fb0be7d9c in ?? () from /lib/libc.so.6
(gdb) q
Test Procedure: no wifi core observed at Initial boot and FR 
Risks: Low