### PR TITLE
RDKBDEV-3060 REFPLTB-3245 REFPLTB-3246 REFPLTB-3244: Potential memory leak in method initial_sync at rbus_get

### DIFF
--- a/source/sampleapps/webconfig_consumer_apis.c
+++ b/source/sampleapps/webconfig_consumer_apis.c
@@ -1813,6 +1813,7 @@ int get_device_network_mode_from_ctrl_thread(webconfig_consumer_t *consumer, uns
     str = rbusValue_GetString(value, &len);
     if (str == NULL) {
         printf("%s Null pointer,Rbus set string len=%d\n",__FUNCTION__,len);
+        rbusValue_Release(value);
         return -1;
     }
 
@@ -1827,6 +1828,7 @@ int get_device_network_mode_from_ctrl_thread(webconfig_consumer_t *consumer, uns
         *device_network_mode = consumer->config.global_parameters.device_network_mode;
     }
 
+    rbusValue_Release(value);
     webconfig_data_free(&data);
 
     return 0;
@@ -2309,6 +2311,7 @@ int get_rbus_sta_interface_name(const char *paramNames)
 
     printf(":%s:%d Sta interface name = [%s]\n", __func__, __LINE__, rbusValue_GetString(value, NULL));
 
+    rbusValue_Release(value);
     return 0;
 }
 

--- a/source/sampleapps/wifi_webconfig_consumer.c
+++ b/source/sampleapps/wifi_webconfig_consumer.c
@@ -363,11 +363,13 @@ int initial_sync(webconfig_consumer_t *consumer)
     str = rbusValue_GetString(value, &len);
     if (str == NULL) {
         printf("%s Null pointer,Rbus set string len=%d\n",__FUNCTION__,len);
+        rbusValue_Release(value);
         return -1;
     }
 
     printf("%s:%d data send to consumer event len : %d\n",__FUNCTION__, __LINE__, len);
     handle_webconfig_consumer_event(consumer, str, len, consumer_event_webconfig_set_data);
+    rbusValue_Release(value);
 
     return 0;
 }

--- a/source/sampleapps/wifievents_consumer_sample.c
+++ b/source/sampleapps/wifievents_consumer_sample.c
@@ -80,16 +80,17 @@ static void wifievents_get_device_vaps()
 {
     char cmd[200];
     int i;
-    rbusValue_t value;
     int rc = RBUS_ERROR_SUCCESS;
 
     for (i = 0; i < MAX_VAP; i++) {
+        rbusValue_t value;
         snprintf(cmd, sizeof(cmd), "Device.WiFi.SSID.%d.Enable", i + 1);
         rc = rbus_get(g_handle, cmd, &value);
         if (rc != RBUS_ERROR_SUCCESS) {
             g_device_vaps_list[i] = -1;
         } else {
             g_device_vaps_list[i] = i + 1;
+            rbusValue_Release(value);
         }
     }
 }


### PR DESCRIPTION
Reason for change: Added code to release the memory. Test Procedure: 1) Execute below command from the console,
                   valgrind --tool=memcheck --leak-check=yes --show-reachable=yes --num-callers=20 --log-file="/tmp/test.txt" --track-fds=yes /usr/bin/onewifi_component_test_app -d
                2) After the execution, you can see the cli mode of the test app
                3) Go to "/tmp/test.txt" and check for the definitely lost record in the file. Able to see the leak caused due to rbus_get call.
Risks: None