### PR TITLE
XB10-1190: Unable to set operating mode "g,n,ax" on some of the devic…

### DIFF
--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -1131,11 +1131,9 @@ WiFi_SetParamBoolValue
     }
     if (AnscEqualString(ParamName, "2G80211axEnable", TRUE))
     {
-#ifndef ALWAYS_ENABLE_AX_2G
         if(bValue != rfc_pcfg->twoG80211axEnable_rfc) {
             push_rfc_dml_cache_to_one_wifidb(bValue,wifi_event_type_twoG80211axEnable_rfc);
         }
-#endif
         return TRUE;
     }
 


### PR DESCRIPTION
…es using tr181

Reason for change: Revert "RDKB-56975: Always enable 'ax' mode for 2.4GHz radio". Some of the Xb10s are not taking the operating mode "g,n,ax" for 2.4G Test Procedure: Set operating mode "g,x,ax" using tr181 Priority: P0
Risks: low