### PR TITLE
LTE-2475: fixed two STA connection scan timers

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1017,7 +1017,7 @@ int start_wifi_health_monitor_thread(void)
 int scan_results_callback(int radio_index, wifi_bss_info_t **bss, unsigned int *num)
 {
     scan_results_t  res;
-    wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
+
     memset(&res, 0, sizeof(scan_results_t));
 
     res.radio_index = radio_index;
@@ -1030,7 +1030,7 @@ int scan_results_callback(int radio_index, wifi_bss_info_t **bss, unsigned int *
         res.num = *num;
         memcpy((unsigned char *)res.bss, (unsigned char *)(*bss), (*num)*sizeof(wifi_bss_info_t));
     }
-    if (ctrl->network_mode == rdk_dev_mode_type_ext) {
+    if (is_sta_enabled()) {
         push_event_to_ctrl_queue(&res, sizeof(scan_results_t), wifi_event_type_hal_ind,
             wifi_event_scan_results, NULL);
     }


### PR DESCRIPTION
Reason for change:
 - Scan result wait timer is started two times:
   1. Scan started for 3 radios.
   2. First scan result starts scan_result_wait_timeout timer
   3. Second scan result overwrites timer id and starts another scan_result_wait_timeout timer
   4. Switch to GW mode cancels all timers but first timer still running
   5. The timer starts STA connection while interface is in AP mode and fails
 - Radio reset selfheal mechanism causes deadlock therefore removed:
   1. recv_data_frame - lock hal lock - wpa_supplicant_event - wifi_drv_sta_set_flags - nl80211_read_sta_data - get_sta_handler - device_associated - wait for ctrl lock
   2. ctrl lock - process_ext_connect_event_timeout - ext_reset_radios - wifi_radio_set_enable - wifi_hal_setRadioOperatingParameters - update_hostap_config_params - wait hal lock
 - Scan results are not received in GW mode with Device.X_RDK_GatewayManagement.ExternalGatewayPresent enabled

Test Procedure:
Risks: Low
Priority: P1