### PR TITLE
XB10-1307 : Fix warnings treated as errors

### DIFF
--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -668,7 +668,7 @@ bus_error_t webconfig_set_subdoc(char *event_name, raw_data_t *p_data)
 
 static void MarkerListConfigHandler (char *event_name, raw_data_t *p_data)
 {
-    marker_list_t list_type;
+    wifi_event_subtype_t list_type;
     const char *pTmp = NULL;
 
     if (strcmp(event_name, WIFI_NORMALIZED_RSSI_LIST) == 0) {

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -404,7 +404,7 @@ WiFi_GetParamBoolValue
             }
             wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Log_upload got %s and val=%d\n", __FUNCTION__,__LINE__,path,val);
         }
-        fclose(fp);
+        pclose(fp);
         return TRUE;
     }
 

--- a/source/platform/rdkb/bus.c
+++ b/source/platform/rdkb/bus.c
@@ -1004,7 +1004,7 @@ bus_error_t bus_init(bus_handle_t *handle)
 
 static bus_error_t bus_open(bus_handle_t *handle, char *component_name)
 {
-    rbusError_t rc = bus_error_success;
+    rbusError_t rc = RBUS_ERROR_SUCCESS;
     VERIFY_NULL_WITH_RC(handle);
     VERIFY_NULL_WITH_RC(component_name);
 
@@ -1050,7 +1050,7 @@ static bus_error_t bus_get_trace_context(bus_handle_t *handle, char *traceParent
 
 static bus_error_t bus_set(bus_handle_t *handle, char const *name, raw_data_t *data)
 {
-    rbusError_t rc = bus_error_success;
+    rbusError_t rc = RBUS_ERROR_SUCCESS;
     VERIFY_NULL_WITH_RC(name);
 
     rbusHandle_t p_rbus_handle = handle->u.rbus_handle;
@@ -1290,7 +1290,7 @@ static bool remove_substring(char *str, const char *sub)
 bus_error_t bus_reg_data_elements(bus_handle_t *handle, bus_data_element_t *data_element,
     uint32_t num_of_element)
 {
-    rbusError_t rc = bus_error_success;
+    rbusError_t rc = RBUS_ERROR_SUCCESS;
     bus_name_string_t name = { 0 };
     rbusHandle_t p_rbus_handle = handle->u.rbus_handle;
     rbusDataElement_t *rbus_dataElements;
@@ -1441,7 +1441,7 @@ bus_error_t bus_method_invoke(bus_handle_t *handle, void *paramName, char *event
 bus_error_t bus_event_subscribe(bus_handle_t *handle, char const *event_name, void *cb,
     void *userData, int timeout)
 {
-    rbusError_t rc = bus_error_success;
+    rbusError_t rc = RBUS_ERROR_SUCCESS;
     rbusHandle_t p_rbus_handle = handle->u.rbus_handle;
     rbus_sub_callback_table_t rbus_cb = { 0 };
     bus_sub_callback_table_t  user_cb;
@@ -1459,7 +1459,7 @@ bus_error_t bus_event_subscribe(bus_handle_t *handle, char const *event_name, vo
 bus_error_t bus_event_subscribe_ex(bus_handle_t *handle, bus_event_sub_t *l_sub_info_map,
     int num_sub, int timeout)
 {
-    rbusError_t ret = bus_error_success;
+    rbusError_t ret = RBUS_ERROR_SUCCESS;
     rbusHandle_t p_rbus_handle = handle->u.rbus_handle;
     rbusEventSubscription_t *sub_info_map;
     rbus_sub_callback_table_t rbus_cb = {0};
@@ -1500,7 +1500,7 @@ bus_error_t bus_event_subscribe_ex(bus_handle_t *handle, bus_event_sub_t *l_sub_
 bus_error_t bus_event_subscribe_ex_async(bus_handle_t *handle, bus_event_sub_t *l_sub_info_map,
     int num_sub, void *l_sub_handler, int timeout)
 {
-    rbusError_t ret = bus_error_success;
+    rbusError_t ret = RBUS_ERROR_SUCCESS;
     rbusHandle_t p_rbus_handle = handle->u.rbus_handle;
     rbusEventSubscription_t *sub_info_map;
     rbus_sub_callback_table_t rbus_cb = {0};

--- a/source/sampleapps/webconfig_consumer_apis.c
+++ b/source/sampleapps/webconfig_consumer_apis.c
@@ -114,7 +114,7 @@ webconfig_error_t   app_free_macfilter_entries(webconfig_subdoc_data_t *data)
     return webconfig_error_none;
 }
 
-int push_data_to_consumer_queue(const void *msg, unsigned int len, wifi_event_type_t type, wifi_event_subtype_t sub_type)
+int push_data_to_consumer_queue(const void *msg, unsigned int len, consumer_event_type_t type, consumer_event_subtype_t sub_type)
 {
     consumer_event_t *data;
     webconfig_consumer_t *consumer = &webconfig_consumer;
@@ -1661,7 +1661,7 @@ void consumer_app_trigger_subdoc_test( webconfig_consumer_t *consumer, consumer_
 
         case consumer_test_start_band_steer_client_subdoc:
             consumer->steer_client_test_pending_count = 0;
-            consumer->test_state = consumer_test_start_band_steer_client_subdoc;
+            consumer->test_state = consumer_test_state_band_steer_client_test_pending;
             test_steeringclient_subdoc_change(consumer);
             break;
 
@@ -1673,7 +1673,7 @@ void consumer_app_trigger_subdoc_test( webconfig_consumer_t *consumer, consumer_
 
        case consumer_test_start_vif_neighbors_subdoc:
             consumer->vif_neighbors_test_pending_count = 0;
-            consumer->test_state = consumer_test_start_vif_neighbors_subdoc;
+            consumer->test_state = consumer_test_state_vif_neighbors_test_pending;
             test_vif_neighbors_subdoc_change(consumer);
             break;
 


### PR DESCRIPTION
Reason for change: Fix warnings treated as errors in Kirkstone build.
Test Procedure: None
Risks: None
Priority: P1

Change-Id: I48813c8736c818708503566a76eaab6661c70dc3