### PR TITLE
XER10-905 : Multiple logs are flooding.

### DIFF
--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -93,9 +93,7 @@ extern "C" {
 
 #define ETH_BH_STATUS                      "Device.X_RDK_MeshAgent.EthernetBhaulUplink.Status"
 
-#if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
-#define TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED    "Device.X_RDK_Features.GatewayFailover.Enable"
-#endif
+#define TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED "Device.X_RDK_Features.GatewayFailover.Enable"
 
 #define WIFI_ALL_RADIO_INDICES             0xffff
 #define DEVICE_TUNNEL_UP                   1

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -93,6 +93,10 @@ extern "C" {
 
 #define ETH_BH_STATUS                      "Device.X_RDK_MeshAgent.EthernetBhaulUplink.Status"
 
+#if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
+#define TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED    "Device.X_RDK_Features.GatewayFailover.Enable"
+#endif
+
 #define WIFI_ALL_RADIO_INDICES             0xffff
 #define DEVICE_TUNNEL_UP                   1
 #define DEVICE_TUNNEL_DOWN                 0

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1500,14 +1500,38 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
 
 #if defined(GATEWAY_FAILOVER_SUPPORTED)
     if (ctrl->active_gateway_check_subscribed == false) {
-        if (bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_ACTIVE_GATEWAY_CHECK,
-                activeGatewayCheckHandler, NULL, 0) != bus_error_success) {
-            // wifi_util_dbg_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe
-            // failed\n",__FUNCTION__, __LINE__, WIFI_ACTIVE_GATEWAY_CHECK);
-        } else {
+#if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
+        //Check whether GFO is applicable or not. If not supported then no need to subscribe.
+        raw_data_t data;
+        bool       bGFOSuppportFlag = TRUE;
+
+        memset(&data, 0, sizeof(raw_data_t));
+        rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle, TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED, &data);
+        if (rc == bus_error_success)
+        {
+            bGFOSuppportFlag = data.raw_data.b;
+            wifi_util_info_print(WIFI_CTRL, "%s:%d bus: param:%s feature:%s\n",
+                __FUNCTION__, __LINE__, TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED, bGFOSuppportFlag?"SUPPORTED":"NOT SUPPORTED");
+        }
+
+        if( FALSE == bGFOSuppportFlag )
+        {
             ctrl->active_gateway_check_subscribed = true;
-            wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe success\n",
+            wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s ignoring subscribe due to GatewayFailOver feature not supported\n",
                 __FUNCTION__, __LINE__, WIFI_ACTIVE_GATEWAY_CHECK);
+        }
+        else
+#endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
+        {
+            if (bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_ACTIVE_GATEWAY_CHECK,
+                    activeGatewayCheckHandler, NULL, 0) != bus_error_success) {
+                // wifi_util_dbg_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe
+                // failed\n",__FUNCTION__, __LINE__, WIFI_ACTIVE_GATEWAY_CHECK);
+            } else {
+                ctrl->active_gateway_check_subscribed = true;
+                wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe success\n",
+                    __FUNCTION__, __LINE__, WIFI_ACTIVE_GATEWAY_CHECK);
+            }
         }
     }
 #endif

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1506,7 +1506,7 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
         bool       bGFOSuppportFlag = TRUE;
 
         memset(&data, 0, sizeof(raw_data_t));
-        rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle, TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED, &data);
+        int rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle, TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED, &data);
         if (rc == bus_error_success)
         {
             bGFOSuppportFlag = data.raw_data.b;

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1500,33 +1500,29 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
 
 #if defined(GATEWAY_FAILOVER_SUPPORTED)
     if (ctrl->active_gateway_check_subscribed == false) {
-#if defined(_RDKB_GLOBAL_PRODUCT_REQ_)
-        //Check whether GFO is applicable or not. If not supported then no need to subscribe.
+        // Check whether GFO is applicable or not. If not supported then no need to subscribe.
         raw_data_t data;
-        bool       bGFOSuppportFlag = TRUE;
+        bool bGFOSuppportFlag = TRUE;
 
         memset(&data, 0, sizeof(raw_data_t));
-        int rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle, TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED, &data);
-        if (rc == bus_error_success)
-        {
+        int rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle,
+            TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED, &data);
+        if (rc == bus_error_success) {
             bGFOSuppportFlag = data.raw_data.b;
-            wifi_util_info_print(WIFI_CTRL, "%s:%d bus: param:%s feature:%s\n",
-                __FUNCTION__, __LINE__, TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED, bGFOSuppportFlag?"SUPPORTED":"NOT SUPPORTED");
+            wifi_util_info_print(WIFI_CTRL, "%s:%d bus: param:%s feature:%s\n", __FUNCTION__,
+                __LINE__, TR181_GLOBAL_FEATURE_PARAM_GFO_SUPPORTED,
+                bGFOSuppportFlag ? "SUPPORTED" : "NOT SUPPORTED");
         }
 
-        if( FALSE == bGFOSuppportFlag )
-        {
+        if (FALSE == bGFOSuppportFlag) {
             ctrl->active_gateway_check_subscribed = true;
-            wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s ignoring subscribe due to GatewayFailOver feature not supported\n",
+            wifi_util_info_print(WIFI_CTRL,
+                "%s:%d bus: bus event:%s ignoring subscribe due to GatewayFailOver feature not "
+                "supported\n",
                 __FUNCTION__, __LINE__, WIFI_ACTIVE_GATEWAY_CHECK);
-        }
-        else
-#endif /** _RDKB_GLOBAL_PRODUCT_REQ_ */
-        {
+        } else {
             if (bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_ACTIVE_GATEWAY_CHECK,
                     activeGatewayCheckHandler, NULL, 0) != bus_error_success) {
-                // wifi_util_dbg_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe
-                // failed\n",__FUNCTION__, __LINE__, WIFI_ACTIVE_GATEWAY_CHECK);
             } else {
                 ctrl->active_gateway_check_subscribed = true;
                 wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe success\n",


### PR DESCRIPTION
Reason for change:
As UK version of XER10 doesn't support GFO(Gateway Fail Over) feature so GatewayManager process doesn't available. But we have seen GatewayManager related TR181 parameter requesting for subscription from OneWiFi/WiFiAgent/MeshAgent components. so we have introduced Device.X_RDK_Features.GatewayFailover.Enable TR181 for consumer.

Test Procedure:
1. PAM should work without any issue.
2. dmcli eRT getv Device.X_RDK_Features.GatewayFailover.Enable should provide result according to product support.

Risks: Low

Signed-off-by: Lakshminarayanan Shenbagaraj <lakshminarayanan.shenbagaraj2@sky.uk>