### PR TITLE
XB10-1266,RDKB-56567 : `WIFI_RECONNECT` telemetry not available in wifihealth

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -400,7 +400,6 @@ typedef struct {
 
 typedef struct {
     int rssi_threshold;
-    bool ReconnectCountEnable[MAX_VAP];
     bool FeatureMFPConfig;
     int ChUtilityLogInterval;
     int DeviceLogInterval;

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -1711,32 +1711,27 @@ int upload_client_telemetry_data(wifi_app_t *app, unsigned int num_devs, unsigne
         wifi_util_error_print(WIFI_APPS, "%s: wrong vapIndex:%d \n", __FUNCTION__, vap_index);
     }
     if (sendIndication == true) {
-        bool bReconnectCountEnable = 0;
-        // check whether Reconnect Count is enabled or not fro individual vAP
-        get_multi_vap_dml_parameters(vap_index, RECONNECT_COUNT_STATUS, &bReconnectCountEnable);
-        if (bReconnectCountEnable == true) {
-            get_formatted_time(tmp);
-            memset(buff, 0, MAX_BUFF_SIZE);
-            memset(telemetryBuff, 0, MAX_BUFF_SIZE);
-            snprintf(buff, MAX_BUFF_SIZE - 1, "%s WIFI_RECONNECT_%d:", tmp, vap_index + 1);
-            for (i = 0; i < num_devs; i++) {
-                snprintf(tmp, CLIENT_TELEMETRY_PARAM_MAX_LEN, "%s,%d;",
-                    to_sta_key(sta[i].sta_mac, sta_key), sta[i].rapid_reconnects);
-                strncat(buff, tmp, MAX_BUFF_SIZE - strlen(buff) - 1);
-                strncat(telemetryBuff, tmp, MAX_BUFF_SIZE - strlen(buff) - 1);
-                sta[i].rapid_reconnects = 0;
-            }
-            strncat(buff, "\n", 2);
-            write_to_file(wifi_health_log, buff);
-            if (isVapPrivate(vap_index)) {
-                snprintf(eventName, sizeof(eventName), "WIFI_REC_%d_split", vap_index + 1);
-                get_stubs_descriptor()->t2_event_s_fn(eventName, telemetryBuff);
-            } else if (isVapLnfPsk(vap_index) && is_managed_wifi) {
-                snprintf(eventName, sizeof(eventName), "MG_REC_%d_split", vap_index + 1);
-                get_stubs_descriptor()->t2_event_s_fn(eventName, telemetryBuff);
-            }
-            wifi_util_dbg_print(WIFI_APPS, "%s", buff);
+        get_formatted_time(tmp);
+        memset(buff, 0, MAX_BUFF_SIZE);
+        memset(telemetryBuff, 0, MAX_BUFF_SIZE);
+        snprintf(buff, MAX_BUFF_SIZE - 1, "%s WIFI_RECONNECT_%d:", tmp, vap_index + 1);
+        for (i = 0; i < num_devs; i++) {
+            snprintf(tmp, CLIENT_TELEMETRY_PARAM_MAX_LEN, "%s,%d;",
+                to_sta_key(sta[i].sta_mac, sta_key), sta[i].rapid_reconnects);
+            strncat(buff, tmp, MAX_BUFF_SIZE - strlen(buff) - 1);
+            strncat(telemetryBuff, tmp, MAX_BUFF_SIZE - strlen(buff) - 1);
+            sta[i].rapid_reconnects = 0;
         }
+        strncat(buff, "\n", 2);
+        write_to_file(wifi_health_log, buff);
+        if (isVapPrivate(vap_index)) {
+            snprintf(eventName, sizeof(eventName), "WIFI_REC_%d_split", vap_index + 1);
+            get_stubs_descriptor()->t2_event_s_fn(eventName, telemetryBuff);
+        } else if (isVapLnfPsk(vap_index) && is_managed_wifi) {
+            snprintf(eventName, sizeof(eventName), "MG_REC_%d_split", vap_index + 1);
+            get_stubs_descriptor()->t2_event_s_fn(eventName, telemetryBuff);
+        }
+        wifi_util_dbg_print(WIFI_APPS, "%s", buff);
     }
 
     wifi_platform_property_t *wifi_prop = (wifi_platform_property_t *)get_wifi_hal_cap_prop();

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -2582,34 +2582,6 @@ int set_multi_radio_dml_parameters(uint8_t radio_index, char *str, void *value)
     return ret;
 }
 
-int get_multi_vap_dml_parameters(uint8_t ap_index, char *str, void *value)
-{
-    int ret = RETURN_OK;
-    wifi_mgr_t *l_wifi_mgr = get_wifimgr_obj();
-    wifi_util_dbg_print(WIFI_CTRL, "%s get multi vap structure data %s: ap_index:%d \n", __FUNCTION__, str, ap_index);
-    if ((strcmp(str, RECONNECT_COUNT_STATUS) == 0)) {
-        *(bool*)value = l_wifi_mgr->dml_parameters.ReconnectCountEnable[ap_index];
-    } else {
-        ret = RETURN_ERR;
-        wifi_util_dbg_print(WIFI_CTRL, "%s get multi vap structure data not match %s: ap_index:%d \n", __FUNCTION__, str, ap_index);
-    }
-    return ret;
-}
-
-int set_multi_vap_dml_parameters(uint8_t ap_index, char *str, void *value)
-{
-    int ret = RETURN_OK;
-    wifi_mgr_t *l_wifi_mgr = get_wifimgr_obj();
-    wifi_util_dbg_print(WIFI_CTRL, "%s set multi vap structure data %s: ap_index:%d \n", __FUNCTION__, str, ap_index);
-    if ((strcmp(str, RECONNECT_COUNT_STATUS) == 0)) {
-        l_wifi_mgr->dml_parameters.ReconnectCountEnable[ap_index] = *(bool*)value;
-    } else {
-        ret = RETURN_ERR;
-        wifi_util_dbg_print(WIFI_CTRL, "%s set multi vap structure data not match %s: ap_index:%d \n", __FUNCTION__, str, ap_index);
-    }
-    return ret;
-}
-
 int get_device_config_list(char *d_list, int size, char *str)
 {
     int ret = RETURN_OK;

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -56,7 +56,6 @@ extern "C" {
 #define MAX_LEVL_CSI_CLIENTS        5
 
 #define RSSI_THRESHOLD                     "RssiThresholdValue"
-#define RECONNECT_COUNT_STATUS             "ReconnectCountStatus"
 #define MFP_FEATURE_STATUS                 "MfpFeatureStatus"
 #define CH_UTILITY_LOG_INTERVAL            "ChUtilityLogInterval"
 #define DEVICE_LOG_INTERVAL                "DeviceLogInterval"

--- a/source/dml/tr_181/ml/cosa_wifi_internal.c
+++ b/source/dml/tr_181/ml/cosa_wifi_internal.c
@@ -932,7 +932,7 @@ void CosaDmlWiFiGetDataFromPSM(void)
 {
     uint8_t index;
     int rssi = 0;
-    bool bReconnectCountEnable = 0, bFeatureMFPConfig = 0;
+    bool bFeatureMFPConfig = 0;
     bool l_boolValue;
     int  l_intValue;
     char recName[256];
@@ -952,23 +952,6 @@ void CosaDmlWiFiGetDataFromPSM(void)
     }
     set_vap_dml_parameters(RSSI_THRESHOLD, &rssi);
     
-    for (index = 0; index < getTotalNumberVAPs(); index++)
-    {
-        UINT apIndex;
-
-        apIndex = VAP_INDEX(((webconfig_dml_t *)get_webconfig_dml())->hal_cap, index);
-        if (CosaDmlWiFi_GetRapidReconnectCountEnable(apIndex , (BOOLEAN *) &bReconnectCountEnable, false) != ANSC_STATUS_SUCCESS)
-        {
-            /* Set default value */
-            if (isVapPrivate(apIndex)) {
-                bReconnectCountEnable = 1;
-            } else {
-                bReconnectCountEnable = 0;
-            }
-        }
-        set_multi_vap_dml_parameters(apIndex, RECONNECT_COUNT_STATUS, &bReconnectCountEnable);
-    }
-
     if(CosaDmlWiFi_GetFeatureMFPConfigValue((BOOLEAN *) &bFeatureMFPConfig) != ANSC_STATUS_SUCCESS)
     {
         /* Set Default value */


### PR DESCRIPTION
**Reason for change:** Use global configuration instead of `get_multi_vap_dml_parameters` because `set_multi_vap_dml_parameters` is not called on new platform.
**Test Procedure:**
1. Load XB10 with latest stable2 image
2. Once XB10 is up, check if Device.WiFi.X_RDKCENTRAL-COM_vAPStatsEnable is enabled
3. Set the WIFI_TELEMETRY.LogInterval to 300 seconds
4. Check if wifihealth.txt is available under /rdklogs/logs and clear the contents of file
5. Then run the script /usr/ccsp/wifi/aphealth_log.sh
6. Connect client to 2/5/6G SSID
7. Check the wifihealth.txt file

**Priority:** P1
**Risks:** Low