### PR TITLE
RDKB-58864: OneWifi github build failure

### DIFF
--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -815,7 +815,7 @@ void wifi_util_print(wifi_log_level_t level, wifi_dbg_type_t module, char *forma
             break;
         }
         case WIFI_EC: {
-            snprintf(filename_dbg_enable, sizeof(filename_dbg_enable), LOG_PATH_PREFIX, "wifiEc");
+            snprintf(filename_dbg_enable, sizeof(filename_dbg_enable), LOG_PATH_PREFIX "wifiEc");
             snprintf(module_filename, sizeof(module_filename), "wifiEc");
             break;
         }


### PR DESCRIPTION
Reason for change: Fixing build failure in OneWifi github code
Priority: P1
Risks: Low

Signed-off-by: SathishKumar Gnanasekaran
<sathishkumar_gnanasekaran@comcast.com>

Failure caused by this commit https://github.com/rdkcentral/OneWifi/commit/81c5c56b7292f0efd8bd59a79713c4c979b56eef