### PR TITLE
RDKB-55930 Failed to fetch proper BasicDataTransmitRates for 2.4GHz radio using dmcli

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6243,10 +6243,6 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
             cfg.variant |= WIFI_80211_VARIANT_BE;
 #endif /* !(defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)) */
 #endif /* CONFIG_IEEE80211BE */
-            if (is_device_type_sr213() == true) {
-                cfg.basicDataTransmitRates = WIFI_BITRATE_1MBPS | WIFI_BITRATE_2MBPS | \
-                    WIFI_BITRATE_5_5MBPS | WIFI_BITRATE_11MBPS;
-            }
 #if defined (_PP203X_PRODUCT_REQ_)
             cfg.beaconInterval = 200;
 #endif
@@ -6266,10 +6262,6 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
 #else
             cfg.variant = WIFI_80211_VARIANT_A | WIFI_80211_VARIANT_N | WIFI_80211_VARIANT_AC | WIFI_80211_VARIANT_AX;
 #endif
-            if (is_device_type_sr213() == true) {
-                cfg.basicDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_12MBPS | \
-                    WIFI_BITRATE_24MBPS;
-            }
 #ifdef CONFIG_IEEE80211BE
             cfg.variant |= WIFI_80211_VARIANT_BE;
 #endif /* CONFIG_IEEE80211BE */
@@ -6348,7 +6340,10 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
     cfg.chanUtilSelfHealEnable = 0;
     cfg.EcoPowerDown = false;
     cfg.factoryResetSsid = 0;
-    if (is_device_type_sr213() != true) {
+    if ((is_device_type_sr213() == true) && (WIFI_FREQUENCY_2_4_BAND == cfg.band)) {
+        cfg.basicDataTransmitRates = WIFI_BITRATE_1MBPS | WIFI_BITRATE_2MBPS |
+            WIFI_BITRATE_5_5MBPS | WIFI_BITRATE_11MBPS;
+    } else {
         cfg.basicDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_12MBPS | WIFI_BITRATE_24MBPS;
     }
     cfg.operationalDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_9MBPS | WIFI_BITRATE_12MBPS | WIFI_BITRATE_18MBPS | WIFI_BITRATE_24MBPS | WIFI_BITRATE_36MBPS | WIFI_BITRATE_48MBPS | WIFI_BITRATE_54MBPS;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6267,7 +6267,7 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
             cfg.variant = WIFI_80211_VARIANT_A | WIFI_80211_VARIANT_N | WIFI_80211_VARIANT_AC | WIFI_80211_VARIANT_AX;
 #endif
             if (is_device_type_sr213() == true) {
-                cfg.basicDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_12MBPS |
+                cfg.basicDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_12MBPS | \
                     WIFI_BITRATE_24MBPS;
             }
 #ifdef CONFIG_IEEE80211BE

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6243,6 +6243,10 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
             cfg.variant |= WIFI_80211_VARIANT_BE;
 #endif /* !(defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)) */
 #endif /* CONFIG_IEEE80211BE */
+            if (is_device_type_sr213() == true) {
+                cfg.basicDataTransmitRates = WIFI_BITRATE_1MBPS | WIFI_BITRATE_2MBPS | \
+                    WIFI_BITRATE_5_5MBPS | WIFI_BITRATE_11MBPS;
+            }
 #if defined (_PP203X_PRODUCT_REQ_)
             cfg.beaconInterval = 200;
 #endif
@@ -6262,7 +6266,10 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
 #else
             cfg.variant = WIFI_80211_VARIANT_A | WIFI_80211_VARIANT_N | WIFI_80211_VARIANT_AC | WIFI_80211_VARIANT_AX;
 #endif
-
+            if (is_device_type_sr213() == true) {
+                cfg.basicDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_12MBPS |
+                    WIFI_BITRATE_24MBPS;
+            }
 #ifdef CONFIG_IEEE80211BE
             cfg.variant |= WIFI_80211_VARIANT_BE;
 #endif /* CONFIG_IEEE80211BE */
@@ -6341,7 +6348,9 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
     cfg.chanUtilSelfHealEnable = 0;
     cfg.EcoPowerDown = false;
     cfg.factoryResetSsid = 0;
-    cfg.basicDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_12MBPS | WIFI_BITRATE_24MBPS;
+    if (is_device_type_sr213() != true) {
+        cfg.basicDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_12MBPS | WIFI_BITRATE_24MBPS;
+    }
     cfg.operationalDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_9MBPS | WIFI_BITRATE_12MBPS | WIFI_BITRATE_18MBPS | WIFI_BITRATE_24MBPS | WIFI_BITRATE_36MBPS | WIFI_BITRATE_48MBPS | WIFI_BITRATE_54MBPS;
     Fcfg.radio_index = radio_index;
     cfg.DFSTimer = DFS_DEFAULT_TIMER_IN_MIN;

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -2821,6 +2821,54 @@ Radio_GetParamStringValue
             }
         }
 
+        if (pcfg->basicDataTransmitRates & WIFI_BITRATE_1MBPS)
+        {
+            if (AnscSizeOfString(buf) != 0)
+            {
+                strcat(buf, ",1");
+            }
+            else
+            {
+                strcat(buf, "1");
+            }
+        }
+
+        if (pcfg->basicDataTransmitRates & WIFI_BITRATE_2MBPS)
+        {
+            if (AnscSizeOfString(buf) != 0)
+            {
+                strcat(buf, ",2");
+            }
+            else
+            {
+                strcat(buf, "2");
+            }
+        }
+
+        if (pcfg->basicDataTransmitRates & WIFI_BITRATE_5_5MBPS)
+        {
+            if (AnscSizeOfString(buf) != 0)
+            {
+                strcat(buf, ",5.5");
+            }
+            else
+            {
+                strcat(buf, "5.5");
+            }
+        }
+
+        if (pcfg->basicDataTransmitRates & WIFI_BITRATE_11MBPS)
+        {
+            if (AnscSizeOfString(buf) != 0)
+            {
+                strcat(buf, ",11");
+            }
+            else
+            {
+                strcat(buf, "11");
+            }
+        }
+
         if ( pcfg->basicDataTransmitRates & WIFI_BITRATE_24MBPS )
         {
             if (AnscSizeOfString(buf) != 0)


### PR DESCRIPTION
Reason for change: BasicDataTransmitRates were not handled for the standard 802.11b in HUB6.

Test Procedure:
1. Load the device with the above mentioned build.
2. Factory reset the device
3. Try to fetch the BasicDataTransmitrates param.

Priority: P2

Risks: Low 

Signed-off-by: Samyuktha Karthikeyan <samyuktha_karthikeyan@comcast.com>