### PR TITLE
webconfig external proto changes for channel scanning

### DIFF
--- a/include/webconfig_external_proto_easymesh.h
+++ b/include/webconfig_external_proto_easymesh.h
@@ -42,6 +42,9 @@ typedef em_sta_info_t * (*ext_proto_get_next_sta_info_t)(void *data_model, em_st
 typedef em_sta_info_t * (*ext_proto_get_sta_info_t)(void *data_model, mac_address_t sta, bssid_t bssid, mac_address_t ruid, em_target_sta_map_t target);
 typedef void (*ext_proto_put_sta_info_t)(void *data_model, em_sta_info_t *sta_info, em_target_sta_map_t target);
 typedef em_bss_info_t * (*ext_proto_em_get_bss_info_with_mac_t)(void *data_model, mac_address_t mac);
+typedef unsigned int (*ext_proto_get_num_scan_results_t)(void *data_model);
+typedef void (*ext_proto_set_num_scan_results_t)(void *data_model, unsigned int num);
+typedef em_scan_result_t * (*ext_proto_get_scan_result_info_t)(void *data_model, unsigned int index);
 
 typedef struct {
     void *data_model; /* agent data model dm_easy_mesh_t */
@@ -66,6 +69,9 @@ typedef struct {
     ext_proto_get_sta_info_t   get_sta_info;
     ext_proto_put_sta_info_t   put_sta_info;
     ext_proto_em_get_bss_info_with_mac_t   get_bss_info_with_mac;
+    ext_proto_get_num_scan_results_t get_num_scan_results;
+    ext_proto_set_num_scan_results_t set_num_scan_results;
+    ext_proto_get_scan_result_info_t get_scan_result_info;
 } webconfig_external_easymesh_t;
 
 void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *data_model, void *m2ctrl_vapconfig, void *policy_config,
@@ -76,7 +82,8 @@ void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *d
         ext_proto_em_get_radio_info_t get_radio, ext_proto_em_get_ieee_1905_security_info_t get_sec,
         ext_proto_em_get_bss_info_t get_bss, ext_proto_em_get_op_class_info_t get_op_class,
         ext_proto_get_first_sta_info_t get_first_sta, ext_proto_get_next_sta_info_t get_next_sta,
-        ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_info_with_mac);
+        ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_info_with_mac,
+        ext_proto_get_num_scan_results_t get_num_scan_res, ext_proto_set_num_scan_results_t set_num_scan_res, ext_proto_get_scan_result_info_t get_scan_result);
 
 #ifdef __cplusplus
 }

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -2207,7 +2207,8 @@ void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *d
         ext_proto_em_get_radio_info_t get_radio, ext_proto_em_get_ieee_1905_security_info_t get_sec,
         ext_proto_em_get_bss_info_t get_bss, ext_proto_em_get_op_class_info_t get_op_class,
         ext_proto_get_first_sta_info_t get_first_sta, ext_proto_get_next_sta_info_t get_next_sta,
-        ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_with_mac)
+        ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_with_mac,
+        ext_proto_get_num_scan_results_t get_num_scan_res, ext_proto_set_num_scan_results_t set_num_scan_res, ext_proto_get_scan_result_info_t get_scan_result)
 {
     proto->data_model = data_model;
     proto->m2ctrl_vapconfig = m2ctrl_vapconfig;
@@ -2229,4 +2230,7 @@ void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *d
     proto->get_sta_info = get_sta;
     proto->put_sta_info = put_sta;
     proto->get_bss_info_with_mac = get_bss_with_mac;
+    proto->get_num_scan_results = get_num_scan_res;
+    proto->set_num_scan_results = set_num_scan_res;
+    proto->get_scan_result_info = get_scan_result;
 }


### PR DESCRIPTION
webconfig external proto changes for channel scanning

Reason for change: webconfig external proto changes to support channel scanning translation for easymesh
Test Procedure: Ensure both onewifi and agent builds are successful
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>