### PR TITLE
webconfig external proto changes for channel scanning (#163)

### DIFF
--- a/build/linux/makefile
+++ b/build/linux/makefile
@@ -330,6 +330,7 @@ WEBCONFIG_SOURCES = $(ONE_WIFI_HOME)/source/webconfig/wifi_decoder.c	\
         $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_radio_temperature.c    \
         $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_radiodiag_stats.c    \
         $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_multivap.c    \
+        $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_easymesh_config.c    \
         $(ONE_WIFI_HOME)/source/utils/wifi_util.c	\
 
 HEBUS_SOURCES = $(wildcard $(ONE_WIFI_HOME)/source/platform/linux/he_bus/src/*.c)  \

--- a/include/webconfig_external_proto_easymesh.h
+++ b/include/webconfig_external_proto_easymesh.h
@@ -42,6 +42,7 @@ typedef em_sta_info_t * (*ext_proto_get_next_sta_info_t)(void *data_model, em_st
 typedef em_sta_info_t * (*ext_proto_get_sta_info_t)(void *data_model, mac_address_t sta, bssid_t bssid, mac_address_t ruid, em_target_sta_map_t target);
 typedef void (*ext_proto_put_sta_info_t)(void *data_model, em_sta_info_t *sta_info, em_target_sta_map_t target);
 typedef em_bss_info_t * (*ext_proto_em_get_bss_info_with_mac_t)(void *data_model, mac_address_t mac);
+typedef void (*ext_proto_put_scan_results_t)(void *data_model, em_scan_result_t *scan_result);
 
 typedef struct {
     void *data_model; /* agent data model dm_easy_mesh_t */
@@ -66,6 +67,7 @@ typedef struct {
     ext_proto_get_sta_info_t   get_sta_info;
     ext_proto_put_sta_info_t   put_sta_info;
     ext_proto_em_get_bss_info_with_mac_t   get_bss_info_with_mac;
+    ext_proto_put_scan_results_t put_scan_results;
 } webconfig_external_easymesh_t;
 
 void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *data_model, void *m2ctrl_vapconfig, void *policy_config,
@@ -76,7 +78,8 @@ void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *d
         ext_proto_em_get_radio_info_t get_radio, ext_proto_em_get_ieee_1905_security_info_t get_sec,
         ext_proto_em_get_bss_info_t get_bss, ext_proto_em_get_op_class_info_t get_op_class,
         ext_proto_get_first_sta_info_t get_first_sta, ext_proto_get_next_sta_info_t get_next_sta,
-        ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_info_with_mac);
+        ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_info_with_mac,
+        ext_proto_put_scan_results_t put_scan_results);
 
 #ifdef __cplusplus
 }

--- a/include/wifi_webconfig.h
+++ b/include/wifi_webconfig.h
@@ -158,6 +158,7 @@ typedef enum {
     webconfig_subdoc_object_type_vif_neighbors,
     webconfig_subdoc_object_type_levl,
     webconfig_subdoc_object_type_cac,
+    webconfig_subdoc_object_type_em_config,
     webconfig_subdoc_object_max
 } webconfig_subdoc_object_type_t;
 
@@ -602,6 +603,15 @@ webconfig_error_t       decode_single_radio_subdoc(webconfig_t *config, webconfi
 webconfig_error_t       encode_single_radio_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data);
 webconfig_error_t       translate_to_single_radio_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data);
 webconfig_error_t       translate_from_single_radio_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data);
+
+// EM Config
+webconfig_error_t       init_em_config_subdoc(webconfig_subdoc_t *doc);
+webconfig_error_t       access_check_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data);
+webconfig_error_t       decode_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data);
+webconfig_error_t       encode_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data);
+webconfig_error_t       translate_to_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data);
+webconfig_error_t       translate_from_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -2225,7 +2225,8 @@ void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *d
         ext_proto_em_get_radio_info_t get_radio, ext_proto_em_get_ieee_1905_security_info_t get_sec,
         ext_proto_em_get_bss_info_t get_bss, ext_proto_em_get_op_class_info_t get_op_class,
         ext_proto_get_first_sta_info_t get_first_sta, ext_proto_get_next_sta_info_t get_next_sta,
-        ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_with_mac)
+        ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_with_mac,
+        ext_proto_put_scan_results_t put_scan_res)
 {
     proto->data_model = data_model;
     proto->m2ctrl_radioconfig = m2ctrl_radioconfig;
@@ -2247,4 +2248,5 @@ void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *d
     proto->get_sta_info = get_sta;
     proto->put_sta_info = put_sta;
     proto->get_bss_info_with_mac = get_bss_with_mac;
+    proto->put_scan_results = put_scan_res;
 }

--- a/source/webconfig/wifi_webconfig.c
+++ b/source/webconfig/wifi_webconfig.c
@@ -694,6 +694,18 @@ webconfig_error_t webconfig_init(webconfig_t *config)
     config->subdocs[webconfig_subdoc_type_radio_6G].translate_to_subdoc = translate_to_single_radio_subdoc;
     config->subdocs[webconfig_subdoc_type_radio_6G].translate_from_subdoc = translate_from_single_radio_subdoc;
 
+    config->subdocs[webconfig_subdoc_type_em_config].type = webconfig_subdoc_type_em_config;
+    strcpy(config->subdocs[webconfig_subdoc_type_em_config].name, "Easymesh Config");
+    config->subdocs[webconfig_subdoc_type_em_config].major = 1;
+    config->subdocs[webconfig_subdoc_type_em_config].minor = 1;
+    config->subdocs[webconfig_subdoc_type_em_config].init_subdoc = init_em_config_subdoc;
+    config->subdocs[webconfig_subdoc_type_em_config].init_subdoc(&config->subdocs[webconfig_subdoc_type_em_config]);
+    config->subdocs[webconfig_subdoc_type_em_config].access_check_subdoc = access_check_em_config_subdoc;
+    config->subdocs[webconfig_subdoc_type_em_config].encode_subdoc = encode_em_config_subdoc;
+    config->subdocs[webconfig_subdoc_type_em_config].decode_subdoc = decode_em_config_subdoc;
+    config->subdocs[webconfig_subdoc_type_em_config].translate_to_subdoc = translate_to_em_config_subdoc;
+    config->subdocs[webconfig_subdoc_type_em_config].translate_from_subdoc = translate_from_em_config_subdoc;
+
     config->proto_desc.translate_to = translate_to_proto;
     config->proto_desc.translate_from = translate_from_proto;
 

--- a/source/webconfig/wifi_webconfig_easymesh_config.c
+++ b/source/webconfig/wifi_webconfig_easymesh_config.c
@@ -1,0 +1,75 @@
+/************************************************************************************
+  If not stated otherwise in this file or this component's LICENSE file the
+  following copyright and licenses apply:
+
+  Copyright 2018 RDK Management
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+**************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <pthread.h>
+#include <unistd.h>
+#include "collection.h"
+#include "wifi_monitor.h"
+#include "wifi_util.h"
+#include "wifi_ctrl.h"
+
+webconfig_subdoc_object_t   em_config_objects[3] = {
+    { webconfig_subdoc_object_type_version, "Version" },
+    { webconfig_subdoc_object_type_subdoc, "SubDocName" },
+    { webconfig_subdoc_object_type_em_config, "WifiEMConfig" },
+};
+
+webconfig_error_t init_em_config_subdoc(webconfig_subdoc_t *doc)
+{
+    return webconfig_error_none;
+}
+
+webconfig_error_t access_check_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data)
+{
+    return webconfig_error_none;
+}
+
+webconfig_error_t translate_from_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data)
+{
+    return webconfig_error_none;
+}
+
+webconfig_error_t translate_to_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data)
+{
+    if ((data->descriptor & webconfig_data_descriptor_translate_from_easymesh) == webconfig_data_descriptor_translate_from_easymesh) {
+        if (config->proto_desc.translate_from(webconfig_subdoc_type_em_config, data) != webconfig_error_none) {
+            if ((data->descriptor & webconfig_data_descriptor_translate_from_easymesh) == webconfig_data_descriptor_translate_from_easymesh) {
+                return webconfig_error_translate_from_easymesh;
+            }
+        }
+    } else {
+        // no translation required
+    }
+    return webconfig_error_none;
+}
+
+webconfig_error_t encode_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data)
+{
+    return webconfig_error_none;
+}
+
+webconfig_error_t decode_em_config_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data)
+{
+
+    return webconfig_error_none;
+}
+


### PR DESCRIPTION
webconfig external proto changes for channel scanning

Reason for change: webconfig external proto changes to support channel scanning translation for easymesh
Test Procedure: Ensure both onewifi and agent builds are successful
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E rakhilpe001@gmail.com