### PR TITLE
RDKB-58443 RDKB-58446 Add WPA3-Compatibility Configuration and Telemetry

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1087,7 +1087,7 @@ void telemetry_event_wpa3_enhanced(int vapindex, char *mac, int rsnvariant, fram
              "%d,%s,%d,%d,%d,%d,%s", vapindex, mac, rsnvariant, frame_type, key_mgmt, mode, status);
     strncpy(telemetry_buff_str, telemetry_buff, sizeof(telemetry_buff_str) - 1);
     telemetry_buff_str[sizeof(telemetry_buff_str) - 1] = '\0';
-    wifi_util_info_print(WIFI_MON, "%s:%s\n", telemetry_buff_str, telemetry_val);
+    wifi_util_dbg_print(WIFI_MON, "%s:%s\n", telemetry_buff_str, telemetry_val);
     get_stubs_descriptor()->t2_event_s_fn(telemetry_buff, telemetry_val);
 }
 


### PR DESCRIPTION
Impacted Platforms:
Tech-XB7, Tech-XB8, CBRv2

Reason for change: To add WPA3-Personal-Compatibility mode in onewifi and rdk-wifi-hal

Test Procedure: Enable WPA3-Compatibility RFC and set security mode as
                WPA3-Personal-Compatibility.
                Check Client connectivity and internet

Risks: Medium
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com
Signed-off-by:Harshavardhan_Pulluru@comcast.com