### PR TITLE
RDKB-58768: OVSM changes to handle WPA3-PC (Personal Compatibility) mode

### DIFF
--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -1968,6 +1968,7 @@ int key_mgmt_conversion_legacy(wifi_security_modes_t *mode_enum, wifi_encryption
             snprintf(str_encryp, encryp_len, "SAE");
             break;
         case wifi_security_mode_wpa3_transition:
+        case wifi_security_mode_wpa3_compatibility:
             snprintf(str_mode, mode_len, "2");
             snprintf(str_encryp, encryp_len, "WPA-PSK SAE");
             break;
@@ -1987,8 +1988,8 @@ int key_mgmt_conversion_legacy(wifi_security_modes_t *mode_enum, wifi_encryption
 
 int key_mgmt_conversion(wifi_security_modes_t *enum_sec, char *str_sec, char *str_sec2, int sec_len, int sec_len2, unsigned int conv_type, int *len)
 {
-    char arr_str[][MAX_SEC_LEN] = {"wpa-psk", "wpa2-psk", "wpa2-eap", "sae", "wpa2-psk sae", "aes", "wpa-eap wpa2-eap", "enhanced-open", "wpa-eap", "wpa-psk wpa2-psk"};
-    wifi_security_modes_t  arr_num[] = {wifi_security_mode_wpa_personal, wifi_security_mode_wpa2_personal, wifi_security_mode_wpa2_enterprise, wifi_security_mode_wpa3_personal, wifi_security_mode_wpa3_transition, wifi_security_mode_wpa3_enterprise, wifi_security_mode_wpa_wpa2_enterprise, wifi_security_mode_enhanced_open, wifi_security_mode_wpa_enterprise, wifi_security_mode_wpa_wpa2_personal};
+    char arr_str[][MAX_SEC_LEN] = {"wpa-psk", "wpa2-psk", "wpa2-eap", "sae", "wpa2-psk sae", "wpa2-psk sae", "aes", "wpa-eap wpa2-eap", "enhanced-open", "wpa-eap", "wpa-psk wpa2-psk"};
+    wifi_security_modes_t  arr_num[] = {wifi_security_mode_wpa_personal, wifi_security_mode_wpa2_personal, wifi_security_mode_wpa2_enterprise, wifi_security_mode_wpa3_personal, wifi_security_mode_wpa3_transition, wifi_security_mode_wpa3_compatibility, wifi_security_mode_wpa3_enterprise, wifi_security_mode_wpa_wpa2_enterprise, wifi_security_mode_enhanced_open, wifi_security_mode_wpa_enterprise, wifi_security_mode_wpa_wpa2_personal};
     unsigned int i = 0;
 
     if ((enum_sec == NULL) || (str_sec == NULL)) {
@@ -2011,7 +2012,9 @@ int key_mgmt_conversion(wifi_security_modes_t *enum_sec, char *str_sec, char *st
     } else if (conv_type == ENUM_TO_STRING) {
         for (i = 0; i < ARRAY_SIZE(arr_num); i++) {
             if (arr_num[i]  == *enum_sec) {
-                if ((*enum_sec == wifi_security_mode_wpa3_transition) || (*enum_sec == wifi_security_mode_wpa_wpa2_enterprise) || (*enum_sec == wifi_security_mode_wpa_wpa2_personal)) {
+                if ((*enum_sec == wifi_security_mode_wpa3_transition) || (*enum_sec == wifi_security_mode_wpa3_compatibility)
+                    || (*enum_sec == wifi_security_mode_wpa_wpa2_enterprise) || (*enum_sec == wifi_security_mode_wpa_wpa2_personal))
+                {
                     *len = 2;
                     char *sec_safe;
                     char *sec1 = strtok_r(arr_str[i], " ", &sec_safe);

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -1229,6 +1229,7 @@ webconfig_error_t decode_security_object(const cJSON *security, wifi_vap_securit
 
     if (band == WIFI_FREQUENCY_6_BAND &&
         security_info->mode != wifi_security_mode_wpa3_personal &&
+        security_info->mode != wifi_security_mode_wpa3_compatibility &&
         security_info->mode != wifi_security_mode_wpa3_enterprise &&
         security_info->mode != wifi_security_mode_enhanced_open) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d invalid security mode for 6G interface: %d\n",

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -1006,6 +1006,7 @@ webconfig_error_t encode_security_object(const wifi_vap_security_t *security_inf
 
     if (is_6g &&
         security_info->mode != wifi_security_mode_wpa3_personal &&
+        security_info->mode != wifi_security_mode_wpa3_compatibility &&
         security_info->mode != wifi_security_mode_wpa3_enterprise &&
         security_info->mode != wifi_security_mode_enhanced_open) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d invalid security mode %d for 6G interface\n",

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -594,7 +594,7 @@ void get_translator_config_wpa_mfp(
 {
     if (vap->u.bss_info.security.mode == wifi_security_mode_wpa3_personal || vap->u.bss_info.security.mode == wifi_security_mode_wpa3_enterprise) {
         vap->u.bss_info.security.mfp = wifi_mfp_cfg_required;
-    } else if (vap->u.bss_info.security.mode == wifi_security_mode_wpa3_transition) {
+    } else if (vap->u.bss_info.security.mode == wifi_security_mode_wpa3_transition || vap->u.bss_info.security.mode == wifi_security_mode_wpa3_compatibility) {
         vap->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
     } else {
         vap->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
@@ -1819,7 +1819,7 @@ BOOL update_secmode_for_wpa3(wifi_vap_info_t *vap_info, char *mode_str, int mode
     }
 
     if (to_ovsdb) {
-        if ((vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_transition) || (vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_personal)) {
+        if ((vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_transition) || (vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_personal) || (vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_compatibility)) {
             snprintf(mode_str, mode_len, "2");
             snprintf(encrypt_str, encrypt_len, "WPA-PSK");
             ret = true;
@@ -1835,6 +1835,7 @@ BOOL update_secmode_for_wpa3(wifi_vap_info_t *vap_info, char *mode_str, int mode
         }
     } else {
         if ((vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_transition) || (vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_personal)
+        || (vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_compatibility)
         || (vap_info->u.bss_info.security.mode == wifi_security_mode_wpa3_enterprise) || (vap_info->u.bss_info.security.mode == wifi_security_mode_enhanced_open)) {
             ret = true;
         }
@@ -1874,7 +1875,8 @@ static inline bool is_personal_sec(wifi_security_modes_t mode)
         mode == wifi_security_mode_wpa2_personal ||
         mode == wifi_security_mode_wpa_wpa2_personal ||
         mode == wifi_security_mode_wpa3_personal ||
-        mode == wifi_security_mode_wpa3_transition;
+        mode == wifi_security_mode_wpa3_transition ||
+        mode == wifi_security_mode_wpa3_compatibility;
 }
 
 static inline bool is_enterprise_sec(wifi_security_modes_t mode)
@@ -3505,6 +3507,17 @@ webconfig_error_t translate_ovsdb_to_vap_info_radius_settings(const struct schem
     return webconfig_error_none;
 }
 
+static bool is_security_mode_updated(wifi_security_modes_t old, wifi_security_modes_t new)
+{
+    /*
+     * WPA3-Personal Compatibility is mapped to WPA3-Personal Transition for opensync.
+     * Thus, if ovsm is pushing WPA3-PT over OneWifi cached WPA3-PC, this change MUST be ignored.
+     * For Gateway devices, Opensync Mesh Controller will not push VAP security configuration,
+     * however, OVSM may push a config if it restarts. In this case, OneWifi cache contains a proper value.
+     */
+    return (old != wifi_security_mode_wpa3_compatibility || new != wifi_security_mode_wpa3_transition);
+}
+
 static webconfig_error_t translate_ovsdb_to_vap_info_sec_legacy(const struct
     schema_Wifi_VIF_Config *vap_row, wifi_vap_info_t *vap)
 {
@@ -3540,8 +3553,11 @@ static webconfig_error_t translate_ovsdb_to_vap_info_sec_legacy(const struct
                 __func__, __LINE__, str_mode);
             return webconfig_error_translate_from_ovsdb;
         }
-        vap->u.bss_info.security.mode = mode_enum;
-        vap->u.bss_info.security.encr = encryp_enum;
+
+        if (is_security_mode_updated(vap->u.bss_info.security.mode, mode_enum)) {
+            vap->u.bss_info.security.mode = mode_enum;
+            vap->u.bss_info.security.encr = encryp_enum;
+        }
     }
 
     if (!is_personal_sec(vap->u.bss_info.security.mode)) {
@@ -3593,7 +3609,9 @@ static webconfig_error_t translate_ovsdb_to_vap_info_sec_new(const struct
                 __func__, __LINE__, vap_row->wpa_key_mgmt[0] ? vap_row->wpa_key_mgmt[0] : "NULL");
             return webconfig_error_translate_from_ovsdb;
         }
-        vap->u.bss_info.security.mode = enum_sec;
+        if (is_security_mode_updated(vap->u.bss_info.security.mode, enum_sec)) {
+            vap->u.bss_info.security.mode = enum_sec;
+        }
     }
 
     get_translator_config_wpa_mfp(vap);


### PR DESCRIPTION
Reason for change: WPA3-PC (Personal Compatibility) should be mapped to WPA3-PT (Personal Transition)
Test Procedure: Enable WPA3-PC RFC and check OVSDB tables are updated properly with the same values as WPA3-PT.
Risks: Medium
Priority: P1

Change-Id: I030bbeeaa9bffa0b125506e69cb86e6b28e7bdb5