### PR TITLE
RDKB-58993 Handle Downgrade and RFC case for WPA3-Compatibility

### DIFF
--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -306,6 +306,15 @@
             "min": 0,
             "max": 1
           }
+        },
+        "security_mode_new": {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": 1
+          }
         }
       },
     "isRoot": true

--- a/lib/inc/schema_gen.h
+++ b/lib/inc/schema_gen.h
@@ -95,6 +95,7 @@
         PJS_OVS_INT(identity_req_retry_interval)\
         PJS_OVS_INT(server_retries)\
         PJS_OVS_BOOL(wpa3_transition_disable)\
+        PJS_OVS_INT(security_mode_new)\
     )
 
 #define PJS_SCHEMA_Wifi_VAP_Config \
@@ -2013,7 +2014,8 @@
     COLUMN(blacklist_table_timeout)\
     COLUMN(identity_req_retry_interval)\
     COLUMN(server_retries)\
-    COLUMN(wpa3_transition_disable)
+    COLUMN(wpa3_transition_disable)\
+    COLUMN(security_mode_new)
 
 #define SCHEMA__Wifi_VAP_Config "Wifi_VAP_Config"
 #define SCHEMA_COLUMN__Wifi_VAP_Config(COLUMN) \
@@ -3360,6 +3362,7 @@
 #define SCHEMA__Wifi_Security_Config__identity_req_retry_interval "identity_req_retry_interval"
 #define SCHEMA__Wifi_Security_Config__server_retries "server_retries"
 #define SCHEMA__Wifi_Security_Config__wpa3_transition_disable "wpa3_transition_disable"
+#define SCHEMA__Wifi_Security_Config__security_mode_new "security_mode_new"
 
 #define SCHEMA__Wifi_VAP_Config__vap_name "vap_name"
 #define SCHEMA__Wifi_VAP_Config__radio_name "radio_name"

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3095,14 +3095,6 @@ void process_rsn_override_rfc(bool type)
             vapInfo->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
             vapInfo->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
         } else {
-            if(rfc_param->wpa3_rfc) {
-                vapInfo->u.bss_info.security.mode = wifi_security_mode_wpa3_transition;
-                vapInfo->u.bss_info.security.wpa3_transition_disable = false;
-                vapInfo->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
-                vapInfo->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
-	        break;
-            }
-
             if (vapInfo->u.bss_info.security.mode == wifi_security_mode_wpa2_personal) {
                 continue;
             }
@@ -3110,6 +3102,13 @@ void process_rsn_override_rfc(bool type)
             if ((radio_params->band == WIFI_FREQUENCY_2_4_BAND) || (radio_params->band == WIFI_FREQUENCY_5_BAND)) {
                     vapInfo->u.bss_info.security.mode = wifi_security_mode_wpa2_personal;
                     vapInfo->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
+            }
+
+	    if(rfc_param->wpa3_rfc) {
+                vapInfo->u.bss_info.security.mode = wifi_security_mode_wpa3_transition;
+                vapInfo->u.bss_info.security.wpa3_transition_disable = false;
+                vapInfo->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
+                vapInfo->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
             }
         }
         memset(&tgt_vap_map, 0, sizeof(wifi_vap_info_map_t));

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3100,6 +3100,7 @@ void process_rsn_override_rfc(bool type)
                 vapInfo->u.bss_info.security.wpa3_transition_disable = false;
                 vapInfo->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
                 vapInfo->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
+	        break;
             }
 
             if (vapInfo->u.bss_info.security.mode == wifi_security_mode_wpa2_personal) {

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3083,7 +3083,7 @@ void process_rsn_override_rfc(bool type)
         }
 
         if (radio_params->band == WIFI_FREQUENCY_6_BAND) {
-            wifi_util_info_print(WIFI_DB,"%s: %d 6GHz radio supports only WPA3 personal mode. WPA3-RFC: %d\n",__FUNCTION__,__LINE__,type);
+            wifi_util_info_print(WIFI_CTRL,"%s: %d 6GHz radio supports only WPA3 personal mode. WPA3-RFC: %d\n",__FUNCTION__,__LINE__,type);
             continue;
         }
 
@@ -3127,9 +3127,9 @@ void process_rsn_override_rfc(bool type)
         apps_mgr_analytics_event(&ctrl->apps_mgr, wifi_event_type_webconfig, wifi_event_webconfig_hal_result, update_status);
 
         if (ret != RETURN_OK) {
-            wifi_util_error_print(WIFI_DB,"%s:%d: Private vaps service update_fn failed \n",__func__, __LINE__);
+            wifi_util_error_print(WIFI_CTRL,"%s:%d: Private vaps service update_fn failed \n",__func__, __LINE__);
         } else {
-            wifi_util_dbg_print(WIFI_DB,"%s:%d: Updating security mode for apIndex %d secmode %d \n",__func__, __LINE__,apIndex,vapInfo->u.bss_info.security.mode);
+            wifi_util_dbg_print(WIFI_CTRL,"%s:%d: Updating security mode for apIndex %d secmode %d \n",__func__, __LINE__,apIndex,vapInfo->u.bss_info.security.mode);
         }
     }
 }

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -149,9 +149,12 @@ static int validate_private_home_security_param(char *mode_enabled, char *encryp
     }
 
     if( (strcmp(mode_enabled, "WPA3-Personal-Compatibility") == 0) && !rfc_param->wpa3_compatibility_enable) {
-        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d RFC for WPA3-Personal-Compatibility is not enabled \n",
+        wifi_util_error_print(WIFI_CTRL, "%s:%d RFC for WPA3-Personal-Compatibility is not enabled \n",
             __func__, __LINE__);
-        return webconfig_error_decode;
+        if (execRetVal) {
+            strncpy(execRetVal->ErrorMsg,"Invalid Security Mode, RFC for WPA3-Personal-Compatibility is not enabled\n",sizeof(execRetVal->ErrorMsg)-1);
+        }
+        return RETURN_ERR;
     }
 
      wifi_util_info_print(WIFI_CTRL,"%s: securityparam validation passed \n",__FUNCTION__);

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -5772,13 +5772,14 @@ int wifidb_update_wifi_security_config(char *vap_name, wifi_vap_security_t *sec)
         wifi_util_error_print(WIFI_DB,"%s:%d: %s invalid vap name \n",__func__, __LINE__,vap_name);
         return RETURN_ERR;
     }
+
+    cfg_sec.security_mode = sec->mode;
     if( sec->mode == WPA3_COMPATIBILITY ) {
         cfg_sec.security_mode = sec->mode;
         int sec_mode_old = 0;
 	cfg_sec.security_mode = wifidb_get_wifi_security_config_old_mode(vap_name, sec, &sec_mode_old);
 	wifi_util_error_print(WIFI_DB,"%s:%d: security_mode:%d \n",__func__, __LINE__, cfg_sec.security_mode);
     }
-    cfg_sec.security_mode = (sec->mode == WPA3_COMPATIBILITY) ? (wifi_security_modes_t)wifi_security_mode_wpa2_personal : sec->mode;
     cfg_sec.encryption_method = sec->encr;
     convert_security_mode_integer_to_string(sec->mfp,(char *)&cfg_sec.mfp_config);
     strncpy(cfg_sec.vap_name,vap_name,(sizeof(cfg_sec.vap_name)-1));

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -5775,9 +5775,10 @@ int wifidb_update_wifi_security_config(char *vap_name, wifi_vap_security_t *sec)
     if( sec->mode == WPA3_COMPATIBILITY ) {
         cfg_sec.security_mode = sec->mode;
         int sec_mode_old = 0;
-	    cfg_sec.security_mode = wifidb_get_wifi_security_config_old_mode(vap_name, sec, &sec_mode_old);
-	    wifi_util_error_print(WIFI_DB,"%s:%d: security_mode:%d \n",__func__, __LINE__, cfg_sec.security_mode);
+	cfg_sec.security_mode = wifidb_get_wifi_security_config_old_mode(vap_name, sec, &sec_mode_old);
+	wifi_util_error_print(WIFI_DB,"%s:%d: security_mode:%d \n",__func__, __LINE__, cfg_sec.security_mode);
     }
+    cfg_sec.security_mode = (sec->mode == WPA3_COMPATIBILITY) ? (wifi_security_modes_t)wifi_security_mode_wpa2_personal : sec->mode;
     cfg_sec.encryption_method = sec->encr;
     convert_security_mode_integer_to_string(sec->mfp,(char *)&cfg_sec.mfp_config);
     strncpy(cfg_sec.vap_name,vap_name,(sizeof(cfg_sec.vap_name)-1));

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -5736,7 +5736,6 @@ int wifidb_get_wifi_security_config_old_mode(char *vap_name, int vap_index)
         return wifi_security_mode_wpa2_personal;
     }
     sec_mode_old = (isVapPrivate(vap_index) && !pcfg->security_mode) ? wifi_security_mode_wpa2_personal : pcfg->security_mode;
-    wifi_util_error_print(WIFI_DB,"%s:%d: sec_mode_old:%d security_mode:%d \n",__func__, __LINE__, sec_mode_old, pcfg->security_mode);
 
     return sec_mode_old;
 }
@@ -5776,7 +5775,7 @@ int wifidb_update_wifi_security_config(char *vap_name, wifi_vap_security_t *sec)
     cfg_sec.security_mode = sec->mode;
     if( sec->mode == WPA3_COMPATIBILITY ) {
 	cfg_sec.security_mode = wifidb_get_wifi_security_config_old_mode(vap_name, vap_index);
-	wifi_util_error_print(WIFI_DB,"%s:%d: security_mode:%d \n",__func__, __LINE__, cfg_sec.security_mode);
+	wifi_util_info_print(WIFI_DB,"%s:%d: security_mode:%d \n",__func__, __LINE__, cfg_sec.security_mode);
     }
     cfg_sec.encryption_method = sec->encr;
     convert_security_mode_integer_to_string(sec->mfp,(char *)&cfg_sec.mfp_config);

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -5720,7 +5720,7 @@ int wifidb_get_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
     return RETURN_OK;
 }
 
-int wifidb_get_wifi_security_config_old_mode(int vap_index)
+int wifidb_get_wifi_security_config_old_mode(char *vap_name, int vap_index)
 {
     struct schema_Wifi_Security_Config  *pcfg;
     json_t *where;
@@ -5775,7 +5775,7 @@ int wifidb_update_wifi_security_config(char *vap_name, wifi_vap_security_t *sec)
 
     cfg_sec.security_mode = sec->mode;
     if( sec->mode == WPA3_COMPATIBILITY ) {
-	cfg_sec.security_mode = wifidb_get_wifi_security_config_old_mode(vap_index);
+	cfg_sec.security_mode = wifidb_get_wifi_security_config_old_mode(vap_name, vap_index);
 	wifi_util_error_print(WIFI_DB,"%s:%d: security_mode:%d \n",__func__, __LINE__, cfg_sec.security_mode);
     }
     cfg_sec.encryption_method = sec->encr;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -613,6 +613,7 @@ void callback_Wifi_Security_Config(ovsdb_update_monitor_t *mon,
 
         pthread_mutex_lock(&g_wifidb->data_cache_lock);
         l_security_cfg->mode = new_rec->security_mode;
+        l_security_cfg->mode = new_rec->security_mode_new;
         l_security_cfg->encr = new_rec->encryption_method;
 
         convert_security_mode_string_to_integer(&mfp,(char *)&new_rec->mfp_config);
@@ -659,7 +660,18 @@ void callback_Wifi_Security_Config(ovsdb_update_monitor_t *mon,
                 strncpy(l_security_cfg->u.radius.daskey,new_rec->das_key,sizeof(l_security_cfg->u.radius.daskey)-1);
             }
         }
-        wifi_util_dbg_print(WIFI_DB,"%s:%d: Get Wifi_Security_Config table Sec_mode=%d enc_mode=%d r_ser_ip=%s r_ser_port=%d rs_ser_ip=%s rs_ser_ip sec_rad_ser_port=%d mfg=%s cfg_key_type=%d vap_name=%s rekey_interval = %d strict_rekey  = %d eapol_key_timeout  = %d eapol_key_retries  = %d eap_identity_req_timeout  = %d eap_identity_req_retries  = %d eap_req_timeout = %d eap_req_retries = %d disable_pmksa_caching = %d max_auth_attempts=%d blacklist_table_timeout=%d identity_req_retry_interval=%d server_retries=%d das_ip = %s das_port=%d wpa3_transition_disable=%d\n",__func__, __LINE__,new_rec->security_mode,new_rec->encryption_method,new_rec->radius_server_ip,new_rec->radius_server_port,new_rec->secondary_radius_server_ip,new_rec->secondary_radius_server_port,new_rec->mfp_config,new_rec->key_type,new_rec->vap_name,new_rec->rekey_interval,new_rec->strict_rekey,new_rec->eapol_key_timeout,new_rec->eapol_key_retries,new_rec->eap_identity_req_timeout,new_rec->eap_identity_req_retries,new_rec->eap_req_timeout,new_rec->eap_req_retries,new_rec->disable_pmksa_caching,new_rec->max_auth_attempts,new_rec->blacklist_table_timeout,new_rec->identity_req_retry_interval,new_rec->server_retries,new_rec->das_ip,new_rec->das_port,new_rec->wpa3_transition_disable);
+        wifi_util_dbg_print(WIFI_DB,"%s:%d: Get Wifi_Security_Config table Sec_mode=%d enc_mode=%d r_ser_ip=%s r_ser_port=%d "
+                "rs_ser_ip=%s rs_ser_ip sec_rad_ser_port=%d mfg=%s cfg_key_type=%d vap_name=%s rekey_interval = %d strict_rekey  = %d "
+                "eapol_key_timeout  = %d eapol_key_retries  = %d eap_identity_req_timeout  = %d eap_identity_req_retries  = %d "
+                "eap_req_timeout = %d eap_req_retries = %d disable_pmksa_caching = %d max_auth_attempts=%d blacklist_table_timeout=%d "
+                "identity_req_retry_interval=%d server_retries=%d das_ip = %s das_port=%d wpa3_transition_disable=%d security_mode_new=%d\n",
+                __func__, __LINE__,new_rec->security_mode,new_rec->encryption_method,new_rec->radius_server_ip,new_rec->radius_server_port,
+                new_rec->secondary_radius_server_ip,new_rec->secondary_radius_server_port,new_rec->mfp_config,new_rec->key_type,new_rec->vap_name,
+                new_rec->rekey_interval,new_rec->strict_rekey,new_rec->eapol_key_timeout,new_rec->eapol_key_retries,new_rec->eap_identity_req_timeout,
+                new_rec->eap_identity_req_retries,new_rec->eap_req_timeout,new_rec->eap_req_retries,new_rec->disable_pmksa_caching,
+                new_rec->max_auth_attempts,new_rec->blacklist_table_timeout,new_rec->identity_req_retry_interval,new_rec->server_retries,
+                new_rec->das_ip,new_rec->das_port,new_rec->wpa3_transition_disable,new_rec->security_mode_new);
+
         pthread_mutex_unlock(&g_wifidb->data_cache_lock);
         vap_index = convert_vap_name_to_index(&g_wifidb->hal_cap.wifi_prop, new_rec->vap_name);
         if (vap_index == -1) {
@@ -4409,6 +4421,7 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
                 config->vap_array[i].u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
                 wifi_util_info_print(WIFI_DB, "%s Update security mode:%d mfp:%d \n", __func__, config->vap_array[i].u.bss_info.security.mode,
                         config->vap_array[i].u.bss_info.security.mfp);
+                wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i], &rdk_config[i]);
             }
         }
     }
@@ -5707,6 +5720,26 @@ int wifidb_get_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
     return RETURN_OK;
 }
 
+int wifidb_get_wifi_security_config_old_mode(char *vap_name, wifi_vap_security_t *sec, int *sec_mode_old)
+{
+    struct schema_Wifi_Security_Config  *pcfg;
+    json_t *where;
+    wifi_db_t *g_wifidb;
+    g_wifidb = (wifi_db_t*) get_wifidb_obj();
+    int count;
+
+    where = onewifi_ovsdb_tran_cond(OCLM_STR, "vap_name", OFUNC_EQ, vap_name);
+    pcfg = onewifi_ovsdb_table_select_where(g_wifidb->wifidb_sock_path, &table_Wifi_Security_Config, where, &count);
+
+    if (pcfg == NULL) {
+        wifidb_print("%s:%d Table table_Wifi_Security_Config table not found, entry count=%d \n",__func__, __LINE__, count);
+        return -1;
+    }
+    *sec_mode_old = pcfg->security_mode;
+    wifi_util_error_print(WIFI_DB,"%s:%d: sec_mode_old:%d security_mode:%d \n",__func__, __LINE__, *sec_mode_old, pcfg->security_mode);
+
+     return *sec_mode_old;
+}
 
 /************************************************************************************
  ************************************************************************************
@@ -5739,7 +5772,12 @@ int wifidb_update_wifi_security_config(char *vap_name, wifi_vap_security_t *sec)
         wifi_util_error_print(WIFI_DB,"%s:%d: %s invalid vap name \n",__func__, __LINE__,vap_name);
         return RETURN_ERR;
     }
-    cfg_sec.security_mode = sec->mode;
+    if( sec->mode == WPA3_COMPATIBILITY ) {
+        cfg_sec.security_mode = sec->mode;
+        int sec_mode_old = 0;
+	    cfg_sec.security_mode = wifidb_get_wifi_security_config_old_mode(vap_name, sec, &sec_mode_old);
+	    wifi_util_error_print(WIFI_DB,"%s:%d: security_mode:%d \n",__func__, __LINE__, cfg_sec.security_mode);
+    }
     cfg_sec.encryption_method = sec->encr;
     convert_security_mode_integer_to_string(sec->mfp,(char *)&cfg_sec.mfp_config);
     strncpy(cfg_sec.vap_name,vap_name,(sizeof(cfg_sec.vap_name)-1));
@@ -5753,6 +5791,7 @@ int wifidb_update_wifi_security_config(char *vap_name, wifi_vap_security_t *sec)
     cfg_sec.eap_req_retries = sec->eap_req_retries;
     cfg_sec.disable_pmksa_caching = sec->disable_pmksa_caching;
     cfg_sec.wpa3_transition_disable = sec->wpa3_transition_disable;
+    cfg_sec.security_mode_new = sec->mode;
 
     if (!security_mode_support_radius(sec->mode))
     {
@@ -5791,7 +5830,15 @@ int wifidb_update_wifi_security_config(char *vap_name, wifi_vap_security_t *sec)
         cfg_sec.das_port = sec->u.radius.dasport;
         strncpy(cfg_sec.das_key,sec->u.radius.daskey,sizeof(cfg_sec.das_key)-1);
     }
-    wifi_util_dbg_print(WIFI_DB,"%s:%d: Updatetable_Wifi_Security_Config table Sec_mode=%d enc_mode=%d r_ser_ip=%s r_ser_port=%d rs_ser_ip=%s rs_ser_ip sec_rad_ser_port=%d mfg=%s cfg_key_type=%d cfg_vap_name=%s rekey_interval = %d strict_rekey  = %d eapol_key_timeout  = %d eapol_key_retries  = %d eap_identity_req_timeout  = %d eap_identity_req_retries  = %d eap_req_timeout = %d eap_req_retries = %d disable_pmksa_caching = %d max_auth_attempts=%d blacklist_table_timeout=%d identity_req_retry_interval=%d server_retries=%d das_ip = %s das_port=%d wpa3_transition_disable=%d",__func__, __LINE__,cfg_sec.security_mode,cfg_sec.encryption_method,cfg_sec.radius_server_ip,cfg_sec.radius_server_port,cfg_sec.secondary_radius_server_ip,cfg_sec.secondary_radius_server_port,cfg_sec.mfp_config,cfg_sec.key_type,cfg_sec.vap_name,cfg_sec.rekey_interval,cfg_sec.strict_rekey,cfg_sec.eapol_key_timeout,cfg_sec.eapol_key_retries,cfg_sec.eap_identity_req_timeout,cfg_sec.eap_identity_req_retries,cfg_sec.eap_req_timeout,cfg_sec.eap_req_retries,cfg_sec.disable_pmksa_caching,cfg_sec.max_auth_attempts,cfg_sec.blacklist_table_timeout,cfg_sec.identity_req_retry_interval,cfg_sec.server_retries,cfg_sec.das_ip,cfg_sec.das_port,cfg_sec.wpa3_transition_disable);
+    wifi_util_dbg_print(WIFI_DB,"%s:%d: Update table_Wifi_Security_Config table Sec_mode=%d enc_mode=%d r_ser_ip=%s r_ser_port=%d"
+            "rs_ser_ip=%s rs_ser_ip sec_rad_ser_port=%d mfg=%s cfg_key_type=%d cfg_vap_name=%s rekey_interval = %d strict_rekey  = %d"
+            "eapol_key_timeout  = %d eapol_key_retries  = %d eap_identity_req_timeout  = %d eap_identity_req_retries  = %d eap_req_timeout = %d"
+            "eap_req_retries = %d disable_pmksa_caching = %d max_auth_attempts=%d blacklist_table_timeout=%d identity_req_retry_interval=%d server_retries=%d "
+            "das_ip = %s das_port=%d wpa3_transition_disable=%d security_mode_new=%d \n",__func__, __LINE__,cfg_sec.security_mode,cfg_sec.encryption_method,
+            cfg_sec.radius_server_ip, cfg_sec.radius_server_port,cfg_sec.secondary_radius_server_ip,cfg_sec.secondary_radius_server_port,cfg_sec.mfp_config,
+            cfg_sec.key_type, cfg_sec.vap_name,cfg_sec.rekey_interval,cfg_sec.strict_rekey,cfg_sec.eapol_key_timeout,cfg_sec.eapol_key_retries, cfg_sec.eap_identity_req_timeout,
+            cfg_sec.eap_identity_req_retries,cfg_sec.eap_req_timeout,cfg_sec.eap_req_retries,cfg_sec.disable_pmksa_caching,cfg_sec.max_auth_attempts, cfg_sec.blacklist_table_timeout,
+            cfg_sec.identity_req_retry_interval,cfg_sec.server_retries,cfg_sec.das_ip,cfg_sec.das_port,cfg_sec.wpa3_transition_disable, cfg_sec.security_mode_new);
 
     if(onewifi_ovsdb_table_upsert_with_parent(g_wifidb->wifidb_sock_path,&table_Wifi_Security_Config,&cfg_sec,false,filter_vapsec,SCHEMA_TABLE(Wifi_VAP_Config),onewifi_ovsdb_where_simple(SCHEMA_COLUMN(Wifi_VAP_Config,vap_name),vap_name),SCHEMA_COLUMN(Wifi_VAP_Config,security)) == false)
     {


### PR DESCRIPTION
Impacted Platforms: Tech-XB7, Tech-XB8, CBRv2, XB10
Reason for change: As WPA3-Compatibility is unknown in Downgrade case, handle DB accordingly during Downgrade.
                               When RFC is disabled, security mode should be updated according to WPA3-Transition RFC.

Test Procedure: Enable WPA3-Compatibility RFC and set security mode as WPA3-Personal-Compatibility.
                         Downgrade the device to old firmware and check device is working properly

Risks: Low
Priority:P1
Signed-off-by:Amalesh_Nandh@comcast.com