### PR TITLE
RDKB-58602: [OneWifi]: MultiVAP, WiFi Backhaul as AL_MAC

### DIFF
--- a/build/linux/EasymeshCfg.json
+++ b/build/linux/EasymeshCfg.json
@@ -1,0 +1,16 @@
+{
+    "_comment": [
+        "This is a sample JSON file of Easymesh configuration to be read by OneWifi",
+        "and will be configured in /nvram as part of either",
+        " a) Wifi-reset by the controller, in case of collocated agent OR",
+        " b) as part of DPP Onboarding, in case of remote agent.",
+        "The AL_MAC_ADDR is the mac address of interface on which IEEE1905 packets are transmitted",
+        "Colocated_mode is to indicate whether OneWifi is part of local or remote agent."
+        "The backhaul SSID and KeyPassphrase will be used for configuring Mesh backhaul",
+        "or connecting to Mesh backhaul in case of backhaul STA"
+    ],
+    "AL_MAC_ADDR":  "d8:3a:dd:a2:05:5c",
+    "Colocated_mode": 0,
+    "Backhaul_SSID": "Mesh_Backhaul",
+    "Backhaul_KeyPassphrase": "test-backhaul"
+}

--- a/build/linux/MultiVap_InterfaceMap.json
+++ b/build/linux/MultiVap_InterfaceMap.json
@@ -1,0 +1,82 @@
+{
+    "_comment": [
+        "This is a sample JSON configuration for Raspberry PI with below assumptions:",
+        " 1) External USB wifi adapter being used is Canakit usb wifi adapter, which supports 8 2.4G VAPs.",
+        "     Link: https://www.canakit.com/raspberry-pi-wifi.html",
+        " 2) Interfaces specified in InterfaceName have already been created seperately and",
+        "     this file is only providing the interface mapping associated for that interface.",
+        " 3) Built in Wifi of Rpi is using interface wlan0.",
+        "Some details on the outline of the elements:",
+        "PhyList is an array of phys supported on device with Index specifying the actual phy index.",
+        "Each phy has an array of RadioList which depicts the radios supported on that phy.",
+        "The index in the RadioList specifies the radio type 0 means 2.4G, 1 means 5G and 2 means 6G.",
+        "The RadioName in the RadioList specifies the primary interface associate with that radio.",
+        "The fields in InterfaceList is self-explanatory with vapName specifying the type of VAP."
+    ],
+    "PhyList": [
+        {
+            "Index": 0,
+            "RadioList": [
+                {
+                    "Index": 1,
+                    "RadioName": "wlan0",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wlan0",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 1,
+                            "vapName": "private_ssid_5g"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Index": 1,
+            "RadioList": [
+                {
+                    "Index": 0,
+                    "RadioName": "wlan1",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wlan1.1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 2,
+                            "vapName": "private_ssid_2g"
+                        },
+                        {
+                            "InterfaceName": "wlan1.2",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 3,
+                            "vapName": "iot_ssid_2g"
+                        },
+                        {
+                            "InterfaceName": "wlan1.3",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 4,
+                            "vapName": "lnf_psk_2g"
+                        },
+                        {
+                            "InterfaceName": "wlan1.4",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 5,
+                            "vapName": "mesh_backhaul_2g"
+                        },
+                        {
+                            "InterfaceName": "wlan1",
+                            "Bridge": "brlan0",
+                            "vlanId": 0,
+                            "vapIndex": 0,
+                            "vapName": "mesh_sta_2g"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/build/linux/create_virtual_intf.sh
+++ b/build/linux/create_virtual_intf.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+#This file creates virtual interfaces on the primary interface passed in argument#1
+#The number of interfaces created is specified in argument#2.
+
+#check whether number of input argument is 2
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <primary_interface> <number_of_interfaces>"
+    exit 1
+fi
+
+primary_intf=$1
+num_intf=$2
+
+#check if primary interface exists before proceeding
+if [ ! -e "/sys/class/net/$primary_intf" ]; then
+    echo "Error: Primary interface $primary_intf does not exist"
+    exit 1
+fi
+
+# Create virtual interfaces
+for i in $(seq 1 $num_intf); do
+    virtual_intf="${primary_intf}.$i"
+    sudo iw dev "$primary_intf" interface add "$virtual_intf" type managed
+    if [ -e "/sys/class/net/$virtual_intf" ]; then
+        echo "Created virtual interface: $virtual_intf"
+        sudo ifconfig "$virtual_intf" down
+    else
+        echo "Error: Unable to create virtual interface: $virtual_intf"
+        exit 1
+    fi
+done
+
+echo "Created $num_intf virtual interfaces based on $primary_intf"

--- a/build/linux/makefile
+++ b/build/linux/makefile
@@ -462,3 +462,7 @@ run:
 setup:
 	./build/linux/setup.sh
 
+vapsetup:
+	cp ./build/linux/MultiVap_InterfaceMap.json /nvram/InterfaceMap.json
+	cp ./build/linux/EasymeshCfg.json /nvram/EasymeshCfg.json
+	./build/linux/create_virtual_intf.sh wlan1 4

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -317,26 +317,7 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         }
 
         cfg.u.sta_info.scan_params.channel.band = band;
-
-        switch(band) {
-            case WIFI_FREQUENCY_2_4_BAND:
-                cfg.u.sta_info.scan_params.channel.channel = 1;
-                break;
-            case WIFI_FREQUENCY_5_BAND:
-            case WIFI_FREQUENCY_5L_BAND:
-                cfg.u.sta_info.scan_params.channel.channel = 44;
-                break;
-            case WIFI_FREQUENCY_5H_BAND:
-                cfg.u.sta_info.scan_params.channel.channel = 157;
-                break;
-            case WIFI_FREQUENCY_6_BAND:
-                cfg.u.sta_info.scan_params.channel.channel = 5;
-                break;
-            default:
-                wifi_util_error_print(WIFI_DB,"%s:%d invalid band %d\n", __func__, __LINE__, band);
-                break;
-        }
-
+        cfg.u.sta_info.scan_params.channel.channel = 0;
         cfg.u.sta_info.conn_status = wifi_connection_status_disabled;
         memset(&cfg.u.sta_info.bssid, 0, sizeof(cfg.u.sta_info.bssid));
     } else {
@@ -438,13 +419,14 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
                 strcpy(cfg.u.bss_info.wps.pin, "12345678");
             }
         }
-        else if (isVapHotspot(vap_index)) {
+        else if (isVapHotspot(vap_index) || isVapMeshBackhaul(vap_index)) {
             cfg.u.bss_info.showSsid = true;
         } else {
             cfg.u.bss_info.showSsid = false;
         }
-        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index)) {
-             cfg.u.bss_info.enabled = true;
+        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index) ||
+            isVapMeshBackhaul(vap_index) || isVapXhs(vap_index)) {
+            cfg.u.bss_info.enabled = true;
         }
 
         if (isVapPrivate(vap_index)) {
@@ -457,7 +439,6 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
 
         if (wifi_hal_get_default_ssid(ssid, vap_index) == 0) {
             strcpy(cfg.u.bss_info.ssid, ssid);
-
         } else {
            strcpy(cfg.u.bss_info.ssid, vap_name);
         }
@@ -647,7 +628,59 @@ void wifidb_print(char *format, ...)
 int wifidb_get_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
     rdk_wifi_vap_info_t *rdk_config)
 {
-    return 0;
+    wifi_platform_property_t *wifi_prop = NULL;
+    int ret = RETURN_OK;
+
+    wifi_prop = &((wifi_mgr_t *)get_wifimgr_obj())->hal_cap.wifi_prop;
+    if (vap_name == NULL || config == NULL || wifi_prop == NULL) {
+        wifi_util_error_print(WIFI_DB, "%s:%d Failed to Get VAP info - Null pointer\n", __func__,
+            __LINE__);
+        return RETURN_ERR;
+    }
+    config->vap_index = convert_vap_name_to_index(wifi_prop, vap_name);
+    config->radio_index = convert_vap_name_to_radio_array_index(wifi_prop, vap_name);
+    strncpy(config->vap_name, vap_name, (sizeof(config->vap_name) - 1));
+    ret = get_bridgename_from_vapname(wifi_prop, vap_name, config->bridge_name,
+        sizeof(config->bridge_name));
+
+    rdk_config->exists = TRUE;
+
+    if (isVapSTAMesh(config->vap_index)) {
+        strncpy(config->u.sta_info.ssid, "Mesh_Backhaul", (sizeof(config->u.sta_info.ssid) - 1));
+        config->u.sta_info.enabled = TRUE;
+        config->u.sta_info.scan_params.period = 10;
+        config->u.sta_info.scan_params.channel.channel = 0;
+        config->u.sta_info.scan_params.channel.band = WIFI_FREQUENCY_2_4_BAND |
+            WIFI_FREQUENCY_5_BAND | WIFI_FREQUENCY_6_BAND;
+    } else {
+        strncpy(config->u.bss_info.ssid, "Mesh_Backhaul ", (sizeof(config->u.bss_info.ssid) - 1));
+        config->u.bss_info.enabled = TRUE;
+        config->u.bss_info.showSsid = TRUE;
+        config->u.bss_info.isolation = FALSE;
+        config->u.bss_info.mgmtPowerControl = 100;
+        config->u.bss_info.bssMaxSta = 32;
+        config->u.bss_info.bssTransitionActivated = FALSE;
+        config->u.bss_info.nbrReportActivated = FALSE;
+        config->u.bss_info.network_initiated_greylist = FALSE;
+        config->u.bss_info.connected_building_enabled = FALSE;
+        config->u.bss_info.rapidReconnectEnable = FALSE;
+        config->u.bss_info.rapidReconnThreshold = 0;
+        config->u.bss_info.vapStatsEnable = TRUE;
+        config->u.bss_info.mac_filter_enable = FALSE;
+        config->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_white_list;
+        config->u.bss_info.wmm_enabled = TRUE;
+        config->u.bss_info.UAPSDEnabled = TRUE;
+        config->u.bss_info.beaconRate = WIFI_BITRATE_DEFAULT;
+        config->u.bss_info.wmmNoAck = 0;
+        config->u.bss_info.wepKeyLength = 0;
+        config->u.bss_info.bssHotspot = FALSE;
+        config->u.bss_info.wpsPushButton = FALSE;
+        config->u.bss_info.wps.methods = WIFI_ONBOARDINGMETHODS_EASYCONNECT | WIFI_ONBOARDINGMETHODS_PUSHBUTTON;
+        config->u.bss_info.wps.enable = TRUE;
+        config->u.bss_info.hostap_mgt_frame_ctrl = TRUE;
+        config->u.bss_info.mbo_enabled = TRUE;
+    }
+    return ret;
 }
 
 int wifidb_update_wifi_macfilter_config(char *macfilter_key, acl_entry_t *config, bool add)

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -30,6 +30,12 @@
 #include <netinet/in.h>
 #include <time.h>
 #include <openssl/sha.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <linux/if_packet.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <ifaddrs.h>
 
 #define  ARRAY_SZ(x)    (sizeof(x) / sizeof((x)[0]))
 /* enable PID in debug logs */
@@ -4392,4 +4398,62 @@ int get_partner_id(char *partner_id)
     }
 
     return ret;
+}
+
+// This routine will take mac address from the user and returns interfacename
+int interfacename_from_mac(const mac_address_t *mac, char *ifname)
+{
+    struct ifaddrs *ifaddr = NULL, *tmp = NULL;
+    struct sockaddr *addr;
+    struct sockaddr_ll *ll_addr;
+    bool found = false;
+
+    if (getifaddrs(&ifaddr) != 0) {
+        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: Failed to get interfae information\n", __func__, __LINE__);
+        return -1;
+    }
+
+    tmp = ifaddr;
+    while (tmp != NULL) {
+        addr = tmp->ifa_addr;
+        ll_addr = (struct sockaddr_ll*)tmp->ifa_addr;
+        if ((addr != NULL) && (addr->sa_family == AF_PACKET) && (memcmp(ll_addr->sll_addr, mac, sizeof(mac_address_t)) == 0)) {
+            strncpy(ifname, tmp->ifa_name, strlen(tmp->ifa_name));
+            found = true;
+            break;
+        }
+
+        tmp = tmp->ifa_next;
+    }
+
+    freeifaddrs(ifaddr);
+
+    return (found == true) ? 0:-1;
+}
+
+// This routine will take interfacename and return mac address
+int mac_address_from_name(const char *ifname, mac_address_t mac)
+{
+    int sock;
+    struct ifreq ifr;
+
+    if ((sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP)) < 0) {
+        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: Failed to create socket\n", __func__, __LINE__);
+        return -1;
+    }
+
+    memset(&ifr, 0, sizeof(struct ifreq));
+    ifr.ifr_addr.sa_family = AF_INET;
+    strcpy(ifr.ifr_name, ifname);
+    if (ioctl(sock, SIOCGIFHWADDR, &ifr) != 0) {
+        close(sock);
+        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: ioctl failed to get hardware address for interface:%s\n", __func__, __LINE__, ifname);
+        return -1;
+    }
+
+    memcpy(mac, (unsigned char *)ifr.ifr_hwaddr.sa_data, sizeof(mac_address_t));
+
+    close(sock);
+
+    return 0;
 }

--- a/source/utils/wifi_util.h
+++ b/source/utils/wifi_util.h
@@ -394,6 +394,8 @@ bool is_vap_param_config_changed(wifi_vap_info_t *vap_info_old, wifi_vap_info_t 
     rdk_wifi_vap_info_t *rdk_old, rdk_wifi_vap_info_t *rdk_new, bool isSta);
 int update_radio_operating_classes(wifi_radio_operationParam_t *oper);
 int get_partner_id(char *partner_id);
+int interfacename_from_mac(const mac_address_t *mac, char *ifname);
+int mac_address_from_name(const char *ifname, mac_address_t mac);
 #ifdef __cplusplus
 }
 #endif

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -69,63 +69,6 @@ void convert_vap_name_to_hault_type(em_haul_type_t *haultype, char *vapname)
         }
 }
 
-// This routine will take mac adderess from the user and returns interfacename
-int interfacename_from_mac(const mac_address_t *mac, char *ifname)
-{
-    struct ifaddrs *ifaddr = NULL, *tmp = NULL;
-    struct sockaddr *addr;
-    struct sockaddr_ll *ll_addr;
-    bool found = false;
-
-    if (getifaddrs(&ifaddr) != 0) {
-        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: Failed to get interfae information\n", __func__, __LINE__);
-        return -1;
-    }
-
-    tmp = ifaddr;
-    while (tmp != NULL) {
-        addr = tmp->ifa_addr;
-        ll_addr = (struct sockaddr_ll*)tmp->ifa_addr;
-        if ((addr != NULL) && (addr->sa_family == AF_PACKET) && (memcmp(ll_addr->sll_addr, mac, sizeof(mac_address_t)) == 0)) {
-            strncpy(ifname, tmp->ifa_name, strlen(tmp->ifa_name));
-            found = true;
-            break;
-        }
-
-        tmp = tmp->ifa_next;
-    }
-
-    freeifaddrs(ifaddr);
-
-    return (found == true) ? 0:-1;
-}
-
-// This routine will take mac adderess from the user and returns interfacename
-int mac_address_from_name(const char *ifname, mac_address_t mac)
-{
-    int sock;
-    struct ifreq ifr;
-
-    if ((sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP)) < 0) {
-        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: Failed to create socket\n", __func__, __LINE__);
-        return -1;
-    }
-
-    memset(&ifr, 0, sizeof(struct ifreq));
-    ifr.ifr_addr.sa_family = AF_INET;
-    strcpy(ifr.ifr_name, ifname);
-    if (ioctl(sock, SIOCGIFHWADDR, &ifr) != 0) {
-        close(sock);
-        wifi_util_info_print(WIFI_WEBCONFIG,"%s:%d: ioctl failed to get hardware address for interface:%s\n", __func__, __LINE__, ifname);
-        return -1;
-    }
-
-    memcpy(mac, (unsigned char *)ifr.ifr_hwaddr.sa_data, sizeof(mac_address_t));
-
-    close(sock);
-
-    return 0;
-}
 // webconfig_easymesh_decode() will convert the onewifi structures to easymesh structures
 webconfig_error_t webconfig_easymesh_decode(webconfig_t *config, const char *str,
         webconfig_external_easymesh_t *data,


### PR DESCRIPTION
Reason for change: Support for configuring Onewifi to support below VAP configuration in Raspberry Pi
1) Private_5G using built-in Raspberry Pi Wifi adapter. 2) Raspberry Pi External Wifi adapter with SKU:RSP-PI-WIFI1 (Link: https://www.canakit.com/raspberry-pi-wifi.html) to support following VAP
	- Mesh sta backhaul 2G
	- Private_2G
	- Guest AP using iot_ssid vap
	- DPP configurator on lnf_psk vap
	- Mesh VAP backhaul 2G 3) Necessary sample Json file for multivap configuration 4) Linux Makefile change to include label "vapsetup" to copy the configuration to appropriate location.
5) Change for sending bus error message in case of wrong configuration, in easymesh mode or easymesh colocated mode based on almac address.

Test Procedure:
Tested configuration with Canakit adapter and almac address being set to eth0, wlan0. Requires additional dependent changes in rdk-wifi-hal, unified-wifi-mesh and halinterface for all the scenarios to work.