### PR TITLE
RDKB-58211

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1087,7 +1087,7 @@ void telemetry_event_wpa3_enhanced(int vapindex, char *mac, int rsnvariant, fram
              "%d,%s,%d,%d,%d,%d,%s", vapindex, mac, rsnvariant, frame_type, key_mgmt, mode, status);
     strncpy(telemetry_buff_str, telemetry_buff, sizeof(telemetry_buff_str) - 1);
     telemetry_buff_str[sizeof(telemetry_buff_str) - 1] = '\0';
-    wifi_util_info_print(WIFI_MON, "%s:%s\n", telemetry_buff_str, telemetry_val);
+    wifi_util_dbg_print(WIFI_MON, "%s:%s\n", telemetry_buff_str, telemetry_val);
     get_stubs_descriptor()->t2_event_s_fn(telemetry_buff, telemetry_val);
 }
 

--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -855,10 +855,11 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
                 return RETURN_OK;
             }
         }
-        if (get_on_channel_scan_list(radioOperation->band, radioOperation->channelWidth, radioOperation->channel, on_chan_list, &onchan_num_channels) != 0) {
-            onchan_num_channels = 1;
-            on_chan_list[0] = radioOperation->channel;
-        }
+        if (get_on_channel_scan_list(radioOperation->band, radioOperation->channelWidth,
+		radioOperation->channel, on_chan_list, &onchan_num_channels) != 0) {
+		onchan_num_channels = 1;
+		on_chan_list[0] = radioOperation->channel;
+	}
         if ((unsigned int)args->channel_list.channels_list[0] == radioOperation->channel &&
             args->channel_list.num_channels > 1) {
             channels[0] = args->channel_list.channels_list[1];
@@ -874,7 +875,7 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
                     break;
                 }
             }
-            if (unmatched){
+            if (unmatched) {
                 channels[new_num_channels++] = args->channel_list.channels_list[i];
             }
         }

--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -774,6 +774,9 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
     int bytes_written = 0;
     int count = 0;
     int id = 0;
+    int on_chan_list[MAX_CHANNELS] = {0};
+    int onchan_num_channels = 0;
+    int new_num_channels = 0;
     wifi_mon_stats_args_t *args = NULL;
 
     if (c_elem == NULL) {
@@ -852,13 +855,28 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
                 return RETURN_OK;
             }
         }
-
+	if (get_on_channel_scan_list(radioOperation->band, radioOperation->channelWidth, radioOperation->channel, on_chan_list, &onchan_num_channels) != 0) {
+	    onchan_num_channels = 1;
+	    on_chan_list[0] = radioOperation->channel;
+    }
         if ((unsigned int)args->channel_list.channels_list[0] == radioOperation->channel &&
             args->channel_list.num_channels > 1) {
             channels[0] = args->channel_list.channels_list[1];
         } else {
             channels[0] = args->channel_list.channels_list[0];
         }
+	// skip on-channel scan list
+	for (int i = 0; i < args->channel_list.num_channels; i++) {
+		int unmatched = 1;
+		for (int j = 0; j < onchan_num_channels; j++) {
+			if ((int)args->channel_list.channels_list[i] == on_chan_list[j]) {
+			                unmatched = 0;
+            }
+        }
+		if (unmatched){
+        channels[new_num_channels++] = args->channel_list.channels_list[i];
+		}
+    }
         for (i = 0; i < args->channel_list.num_channels; i++) {
             if (mon_data->last_scanned_channel[args->radio_index] ==
                 args->channel_list.channels_list[i]) {

--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -855,29 +855,29 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
                 return RETURN_OK;
             }
         }
-	if (get_on_channel_scan_list(radioOperation->band, radioOperation->channelWidth, radioOperation->channel, on_chan_list, &onchan_num_channels) != 0) {
-	    onchan_num_channels = 1;
-	    on_chan_list[0] = radioOperation->channel;
-    }
+        if (get_on_channel_scan_list(radioOperation->band, radioOperation->channelWidth, radioOperation->channel, on_chan_list, &onchan_num_channels) != 0) {
+            onchan_num_channels = 1;
+            on_chan_list[0] = radioOperation->channel;
+        }
         if ((unsigned int)args->channel_list.channels_list[0] == radioOperation->channel &&
             args->channel_list.num_channels > 1) {
             channels[0] = args->channel_list.channels_list[1];
         } else {
             channels[0] = args->channel_list.channels_list[0];
         }
-	// skip on-channel scan list
-	for (int i = 0; i < args->channel_list.num_channels; i++) {
-		int unmatched = 1;
-		for (int j = 0; j < onchan_num_channels; j++) {
-			if ((int)args->channel_list.channels_list[i] == on_chan_list[j]) {
-			                unmatched = 0;
-					break;
+        // skip on-channel scan list
+        for (int i = 0; i < args->channel_list.num_channels; i++) {
+            int unmatched = 1;
+            for (int j = 0; j < onchan_num_channels; j++) {
+                if ((int)args->channel_list.channels_list[i] == on_chan_list[j]) {
+                    unmatched = 0;
+                    break;
+                }
+            }
+            if (unmatched){
+                channels[new_num_channels++] = args->channel_list.channels_list[i];
             }
         }
-		if (unmatched){
-        channels[new_num_channels++] = args->channel_list.channels_list[i];
-		}
-    }
         for (i = 0; i < args->channel_list.num_channels; i++) {
             if (mon_data->last_scanned_channel[args->radio_index] ==
                 args->channel_list.channels_list[i]) {

--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -871,6 +871,7 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
 		for (int j = 0; j < onchan_num_channels; j++) {
 			if ((int)args->channel_list.channels_list[i] == on_chan_list[j]) {
 			                unmatched = 0;
+					break;
             }
         }
 		if (unmatched){


### PR DESCRIPTION
RDKB-58211-Removing OCS (off channel scanning) for secondary channels
Reason for change: Removed secondary channels from the list of channels for Off channel scanning.

Test Procedure: 
1. Load the custom build
2. Verify that NOC push table "Wifi_Stats_Config" 
`/usr/opensync/tools/ovsh s Wifi_Stats_Config  -w radio_type==5G`
3. Check the correct working channel 
`wl -i wl1.1 chanspec`
4. check if the current working channel is DFS if yes disable the DFS 
`dmcli eRT getv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DFS.Enable`
5. For testing purpose reduce sampling and reporting interval for 5G OCS
```
/usr/opensync/tools/ovsh u Wifi_Stats_Config -w survey_type==off-chan -w radio_type==5G -w stats_type==neighbor reporting_interval:=60
/usr/opensync/tools/ovsh u Wifi_Stats_Config -w survey_type==off-chan -w radio_type==5G -w stats_type==survey reporting_interval:=120 sampling_interval:=10
```
6. Enable WiFiMon logs and WiFiSM logs
```
touch /nvram/wifiSM
tail -F /tmp/wifiSM

touch /nvram/wifiMonDbg
tail -F /tmp/wifiMon
```
7. Analyze WiFiMon and SMApp logs

Priority: P1
Risks: Low
Signed-off-by: Sneha Kannan<sneha_kannan@comcast.com>