### PR TITLE
XER10-1020 : WIFI_GOODBADRSSI marker incorrect

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -2955,6 +2955,8 @@ int init_wifi_monitor()
     unsigned int uptimeval = 0;
     int rssi;
     UINT vap_index, radio;
+    wifi_global_param_t *global_param;
+
     //Initialize MQTTCM
     wifi_util_info_print(WIFI_MON,"%s:%d Monitor init\n", __func__, __LINE__);
 #ifdef MQTTCM
@@ -2976,11 +2978,9 @@ int init_wifi_monitor()
     chan_util_upload_period = get_chan_util_upload_period();
     wifi_util_dbg_print(WIFI_MON, "%s:%d system uptime val is %ld and upload period is %d in secs\n",
              __FUNCTION__,__LINE__,uptimeval,(g_monitor_module.upload_period*60));
-    if (get_vap_dml_parameters(RSSI_THRESHOLD, &rssi) != ANSC_STATUS_SUCCESS) {
-        g_monitor_module.sta_health_rssi_threshold = -65;
-    } else {
-        g_monitor_module.sta_health_rssi_threshold = rssi;
-    }
+
+    global_param = get_wifidb_wifi_global_param();
+    g_monitor_module.sta_health_rssi_threshold = global_param->good_rssi_threshold;
     for (i = 0; i < getTotalNumberVAPs(); i++) {
         UINT vap_index = VAP_INDEX(mgr->hal_cap, i);
         radio = RADIO_INDEX(mgr->hal_cap, i);

--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -343,12 +343,12 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
                     &t_diff);
             }
             // update thresholds if changed
-            if (get_vap_dml_parameters(RSSI_THRESHOLD, &rssi) == 0) {
-                mon_data->sta_health_rssi_threshold = rssi;
-                wifi_util_dbg_print(WIFI_MON, "%s:%d RSSI threshold updated to %d\n", __func__,
-                    __LINE__, mon_data->sta_health_rssi_threshold);
+            wifi_global_param_t *global_param = get_wifidb_wifi_global_param();
+            if (mon_data->sta_health_rssi_threshold != global_param->good_rssi_threshold) {
+                wifi_util_dbg_print(WIFI_MON, "%s:%d RSSI threshold updated to %d from %d\n", __func__,
+                    __LINE__, global_param->good_rssi_threshold, mon_data->sta_health_rssi_threshold);
+                mon_data->sta_health_rssi_threshold = global_param->good_rssi_threshold;
             }
-
             if (sta->dev_stats.cli_SignalStrength >= mon_data->sta_health_rssi_threshold) {
                 sta->good_rssi_time += t_diff.tv_sec;
             } else {


### PR DESCRIPTION
Reason for change: dml_parameters.rssi_threshold defined in wifi_mgr_t is not
                   initialized if NEWPLATFORM_PORT is defined.
                   This caused the wrong measurements for good and bad RSSI
                   times in WIFI_GOODBADRSSI_<AP index> in telemetry.
                   Also updating "Device.WiFi.X_RDKCENTRAL-COM_GoodRssiThreshold"
                   does not affect the time measurements.
                   Change the code to use GoodRssiThreshold directly in measurement.
Test Procedure: - Telemetry WIFI_GOODBADRSSI_<AP index> should contain correct
                  good and bad time measurements.
                - Change of "Device.WiFi.X_RDKCENTRAL-COM_GoodRssiThreshold"
                  should affect the time measurement.
Risks: None
Priority: P2