### PR TITLE
Adding 320MHz channel bandwith case in OneWifi

### DIFF
--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -193,6 +193,9 @@ get_sub_string(wifi_channelBandwidth_t bandwidth, char *dest)
         case WIFI_CHANNELBANDWIDTH_160MHZ:
             strncpy(dest, "160", 4);
         break;
+        case WIFI_CHANNELBANDWIDTH_320MHZ:
+            strncpy(dest, "320", 4);
+        break;
         case WIFI_CHANNELBANDWIDTH_80_80MHZ:
             /* TODO */
             strncpy(dest, "80", 3);


### PR DESCRIPTION
RDKB-59064: 6G_chan_width_split value is missing in wifihealth.txt

Reason for change: 6G_chan_width_split value is missing in wifihealth.txt
Test Procedure: Run command: cat /rdklogs/logs/wifihealth.txt | grep chan_width_split
Risks: Low
Priority: P1