### PR TITLE
RDKB-58414: Dynamically update NAS

### DIFF
--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -37,7 +37,7 @@ patch_filenames="hostap-patches/0001-OneWifi-related-hostap-patch-for-2.10-based
 	hostap-patches/0002-radius_failover_2.10.patch \
 	hostap-patches/0003-mbssid_support_2.10.patch \
         hostap-patches/wpa3_compatibility_hostap_2_10.patch \
-        hostap-patches/Dynamic_NAS_IP_Update_2_10.patch"
+        hostap-patches/0005-RDKB-58414-Dynamically-update-NAS_2_10.patch"
 echo "Applying patches ..."
 git am $patch_filenames
 

--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -36,7 +36,8 @@ git clone https://github.com/rdkcentral/hostap-patches.git hostap-patches
 patch_filenames="hostap-patches/0001-OneWifi-related-hostap-patch-for-2.10-based-hostap.patch \
 	hostap-patches/0002-radius_failover_2.10.patch \
 	hostap-patches/0003-mbssid_support_2.10.patch \
-        hostap-patches/wpa3_compatibility_hostap_2_10.patch"
+        hostap-patches/wpa3_compatibility_hostap_2_10.patch \
+        hostap-patches/Dynamic_NAS_IP_Update_2_10.patch"
 echo "Applying patches ..."
 git am $patch_filenames
 


### PR DESCRIPTION
Impacted Platforms:
All OneWifi Platforms

Reason for change:We must dynamically update NAS IP to be in accordance with RADIUS IP Family.

Test Procedure: Enable Hotspot VAPs and connect clients. Simultaneously take erouter0 PCAPs. Check if NAS IP is updated properly as per RADIUS IP Family.

Risks: Low

Change-Id: I8f33dc2d45bef2dc10581c88d6b812a49f02dd9d Signed-off-by:Srijeyarankesh_JS@comcast.com