### PR TITLE
XER10-1020 : Fixing build failure

### DIFF
--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -163,7 +163,6 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
     wifi_platform_property_t *wifi_prop = get_wifi_hal_cap_prop();
     struct timespec tv_now, t_diff, t_tmp;
     unsigned int disconnected_time;
-    int rssi = 0;
 
     if (c_elem == NULL) {
         wifi_util_error_print(WIFI_MON, "%s:%d input arguments are NULL args : %p\n", __func__,


### PR DESCRIPTION
Removing unused variable 'rssi' to fix below build failure.

> 10:14:26  | ../../../git/source/core/../../source/stats/wifi_stats_assoc_client.c: In function 'execute_assoc_client_stats_api':
> 10:14:26  | ../../../git/source/core/../../source/stats/wifi_stats_assoc_client.c:166:9: error: unused variable 'rssi' [-Werror=unused-variable]
> 10:14:26  |   166 |     int rssi = 0;
> 10:14:26  |       |         ^~~~