### PR TITLE
XER10-1020 : Fixing build failure

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -2953,7 +2953,6 @@ int init_wifi_monitor()
     pthread_condattr_t cond_attr;
     wifi_mgr_t *mgr = get_wifimgr_obj();
     unsigned int uptimeval = 0;
-    int rssi;
     UINT vap_index, radio;
     wifi_global_param_t *global_param;
 


### PR DESCRIPTION
Fixing below build failure.

> 17:23:13  | ../../../git/source/core/../../source/stats/wifi_monitor.c: In function 'init_wifi_monitor':
> 17:23:13  | ../../../git/source/core/../../source/stats/wifi_monitor.c:2956:9: error: unused variable 'rssi' [-Werror=unused-variable]
> 17:23:13  |  2956 |     int rssi;
> 17:23:13  |       |         ^~~~