### PR TITLE
RDKB-59209: EM App: Channel scan crash fix

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -78,11 +78,6 @@ extern "C" {
 #define WIFI_NOTIFY_DENY_TCM_ASSOCIATION               "Device.WiFi.ConnectionControl.TcmClientDenyAssociation"
 #define WIFI_STUCK_DETECT_FILE_NAME         "/nvram/wifi_stuck_detect"
 
-#define MAX_OPERATING_CLASS 48
-#define MAX_CHANNEL_BW_LEN 16
-#define MAX_NEIGHBORS 32
-#define MAX_RESULTS 32
-
 #define PLAN_ID_LENGTH     38
 #define MAX_STEP_COUNT  32 /*Active Measurement Step Count */
 #define  MAC_ADDRESS_LENGTH  13
@@ -1084,6 +1079,13 @@ typedef struct {
 } radio_data_t;
 
 #ifdef EM_APP
+
+#define EM_MAX_OPERATING_CLASS 48
+#define EM_MAX_CHANNEL_BW_LEN 16
+#define EM_MAX_NEIGHBORS 16
+#define EM_MAX_RESULTS 32
+#define EM_MAX_CHANNELS 64
+
 typedef char marker_name[32];
 
 typedef struct {
@@ -1091,10 +1093,10 @@ typedef struct {
     marker_name managed_client_marker;
 } ap_metrics_policy_t;
 
-#define MAX_DIS_STA 30
+#define EM_MAX_DIS_STA 30
 typedef struct {
     int sta_count;
-    mac_addr_t disallowed_sta[MAX_DIS_STA];
+    mac_addr_t disallowed_sta[EM_MAX_DIS_STA];
 } steering_disallowed_policy_t;
 
 typedef struct {
@@ -1117,10 +1119,10 @@ typedef struct {
     bool sta_status;
 } radio_metrics_policy_t;
 
-#define MAX_RADIO_POLICY 4
+#define EM_MAX_RADIO_POLICY 4
 typedef struct {
     int radio_count;
-    radio_metrics_policy_t radio_metrics_policy[MAX_RADIO_POLICY];
+    radio_metrics_policy_t radio_metrics_policy[EM_MAX_RADIO_POLICY];
 } radio_metrics_policies_t;
 
 typedef struct {
@@ -1138,11 +1140,11 @@ typedef struct {
     wifi_BeaconReport_t *beacon_repo;
 } wifi_hal_rrm_report_t;
 
-#define MAX_BR_DATA 400
+#define EM_MAX_BR_DATA 400
 typedef struct {
     mac_address_t mac_addr;
     unsigned int data_len;
-    unsigned char data[MAX_BR_DATA];
+    unsigned char data[EM_MAX_BR_DATA];
     unsigned int ap_index;
     unsigned int num_br_data;
     int sched_handler_id;
@@ -1152,7 +1154,7 @@ typedef struct {
 typedef struct {
     UCHAR operating_class;
     UINT num_channels;
-    UCHAR channels[MAX_CHANNELS];
+    UCHAR channels[EM_MAX_CHANNELS];
 } operating_class_t;
 
 typedef struct {
@@ -1160,14 +1162,14 @@ typedef struct {
     UINT num_radios;
     mac_address_t ruid;
     UINT num_operating_classes;
-    operating_class_t operating_classes[MAX_OPERATING_CLASS];
+    operating_class_t operating_classes[EM_MAX_OPERATING_CLASS];
 } channel_scan_request_t;
 
 typedef struct {
     bssid_t bssid;
     ssid_t ssid;
     CHAR signal_strength;
-    CHAR channel_bandwidth[MAX_CHANNEL_BW_LEN];
+    CHAR channel_bandwidth[EM_MAX_CHANNEL_BW_LEN];
     UCHAR bss_load_element_present;
     UCHAR bss_color;
     UCHAR channel_utilization;
@@ -1184,12 +1186,12 @@ typedef struct {
     UCHAR utilization;
     UCHAR noise;
     USHORT num_neighbors;
-    neighbor_bss_t neighbors[MAX_NEIGHBORS];
+    neighbor_bss_t neighbors[EM_MAX_NEIGHBORS];
 } channel_scan_result_t;
 
 typedef struct {
     UINT num_results;
-    channel_scan_result_t results[MAX_RESULTS];
+    channel_scan_result_t results[EM_MAX_RESULTS];
 } channel_scan_response_t;
 #endif
 

--- a/source/apps/em/wifi_em.c
+++ b/source/apps/em/wifi_em.c
@@ -246,7 +246,7 @@ static void em_prepare_scan_response_data(wifi_neighbor_ap2_t *wifi_scan_data, i
         }
 
         if (res_index == -1) {
-            if (scan_response->num_results >= MAX_RESULTS)
+            if (scan_response->num_results >= EM_MAX_RESULTS)
                 continue;
 
             res_index = scan_response->num_results;
@@ -262,7 +262,7 @@ static void em_prepare_scan_response_data(wifi_neighbor_ap2_t *wifi_scan_data, i
         }
 
         channel_scan_result_t *res = &scan_response->results[res_index];
-        if (res->num_neighbors < MAX_NEIGHBORS) {
+        if (res->num_neighbors < EM_MAX_NEIGHBORS) {
             neighbor_bss_t *neighbor = &res->neighbors[res->num_neighbors];
             sscanf(src->ap_BSSID, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &neighbor->bssid[0],
                 &neighbor->bssid[1], &neighbor->bssid[2], &neighbor->bssid[3], &neighbor->bssid[4],
@@ -270,7 +270,7 @@ static void em_prepare_scan_response_data(wifi_neighbor_ap2_t *wifi_scan_data, i
             strncpy(neighbor->ssid, src->ap_SSID, sizeof(ssid_t));
             neighbor->signal_strength = src->ap_SignalStrength;
             strncpy(neighbor->channel_bandwidth, src->ap_OperatingChannelBandwidth,
-                MAX_CHANNEL_BW_LEN);
+                EM_MAX_CHANNEL_BW_LEN);
             neighbor->channel_utilization = src->ap_ChannelUtilization;
             neighbor->bss_load_element_present = 0;
             neighbor->bss_color = 0;

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -4999,8 +4999,8 @@ webconfig_error_t decode_em_channel_stats_object(channel_scan_response_t **chan_
     num_results = cJSON_GetArraySize(channel_scan_arr);
     (*chan_stats)->num_results = num_results;
 
-    if (num_results > MAX_RESULTS) {
-        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Number of results exceeds MAX_RESULTS limit\n", __func__, __LINE__);
+    if (num_results > EM_MAX_RESULTS) {
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Number of results exceeds EM_MAX_RESULTS limit\n", __func__, __LINE__);
         return webconfig_error_decode;
     }
 
@@ -5036,8 +5036,8 @@ webconfig_error_t decode_em_channel_stats_object(channel_scan_response_t **chan_
             num_neighbors = cJSON_GetArraySize(neighbor_arr);
             result->num_neighbors = num_neighbors;
 
-            if (num_neighbors > MAX_NEIGHBORS) {
-                wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Number of neighbors exceeds MAX_NEIGHBORS limit\n", __func__, __LINE__);
+            if (num_neighbors > EM_MAX_NEIGHBORS) {
+                wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Number of neighbors exceeds EM_MAX_NEIGHBORS limit\n", __func__, __LINE__);
                 return webconfig_error_decode;
             }
 
@@ -5510,7 +5510,7 @@ webconfig_error_t decode_em_policy_object(const cJSON *em_cfg, em_config_t *em_c
     }
 
     em_config->local_steering_dslw_policy.sta_count = cJSON_GetArraySize(disallowed_sta_array);
-    for (int i = 0; (i < em_config->local_steering_dslw_policy.sta_count) && (i < MAX_DIS_STA);
+    for (int i = 0; (i < em_config->local_steering_dslw_policy.sta_count) && (i < EM_MAX_DIS_STA);
          i++) {
         sta_obj = cJSON_GetArrayItem(disallowed_sta_array, i);
         decode_param_allow_optional_string(sta_obj, "MAC", param);
@@ -5538,7 +5538,7 @@ webconfig_error_t decode_em_policy_object(const cJSON *em_cfg, em_config_t *em_c
     }
 
     em_config->btm_steering_dslw_policy.sta_count = cJSON_GetArraySize(disallowed_sta_array);
-    for (int i = 0; i < em_config->btm_steering_dslw_policy.sta_count && (i < MAX_DIS_STA); i++) {
+    for (int i = 0; i < em_config->btm_steering_dslw_policy.sta_count && (i < EM_MAX_DIS_STA); i++) {
         sta_obj = cJSON_GetArrayItem(disallowed_sta_array, i);
         decode_param_string(sta_obj, "MAC", param);
         str_to_mac_bytes(param->valuestring, em_config->btm_steering_dslw_policy.disallowed_sta[i]);


### PR DESCRIPTION
Reason for change: Easymesh agent supports max 16 neighbor scan results per scan results. Hence updating same in onewifi to fix the crash issue observed in easymesh agent due to buffer overflow. 
Test Procedure: Ensure channel scan results are received in agent side and then to controller cli upon request for channel scan. Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>