### PR TITLE
RDKB-59259: Update right Operating Class variable in wifi_radio_operation_t structure

### DIFF
--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -78,7 +78,7 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
 
     switch (cfg.band) {
         case WIFI_FREQUENCY_2_4_BAND:
-            cfg.op_class = 12;
+            cfg.op_class = 81;
             cfg.operatingClass = 81;
             cfg.channel = 1;
             cfg.channelWidth = WIFI_CHANNELBANDWIDTH_20MHZ;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6299,7 +6299,7 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
 
     switch (cfg.band) {
         case WIFI_FREQUENCY_2_4_BAND:
-            cfg.op_class = 12;
+            cfg.op_class = 81;
             cfg.operatingClass = 81;
             cfg.channel = 1;
             cfg.channelWidth = WIFI_CHANNELBANDWIDTH_20MHZ;

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -340,8 +340,8 @@ webconfig_error_t translate_radio_object_to_easymesh_for_radio(webconfig_subdoc_
         em_op_class_info = proto->get_op_class_info(proto->data_model, no_of_opclass);
         mac_address_from_name(radio_iface_map->interface_name,em_op_class_info->id.ruid);
         em_op_class_info->id.type = em_op_class_type_current;
-        em_op_class_info->id.op_class = oper_param->operatingClass;
-        em_op_class_info->op_class = oper_param->operatingClass;
+        em_op_class_info->id.op_class = oper_param->op_class;
+        em_op_class_info->op_class = oper_param->op_class;
         em_op_class_info->channel = oper_param->channel;
         no_of_opclass++;
         proto->set_num_op_class(proto->data_model,no_of_opclass);
@@ -444,8 +444,8 @@ webconfig_error_t translate_radio_object_to_easymesh_for_dml(webconfig_subdoc_da
         em_op_class_info = proto->get_op_class_info(proto->data_model, op_class_count);
         mac_address_from_name(radio_iface_map->interface_name,em_op_class_info->id.ruid);
         em_op_class_info->id.type = 1;
-        em_op_class_info->op_class = oper_param->operatingClass;
-        em_op_class_info->id.op_class = oper_param->operatingClass;
+        em_op_class_info->op_class = oper_param->op_class;
+        em_op_class_info->id.op_class = oper_param->op_class;
         em_op_class_info->channel = oper_param->channel;
 
         //Incrementing the number of operating classes by one, as the dml lacks an operating class for current.

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -102,7 +102,7 @@ webconfig_error_t encode_radio_curr_operating_classes(const wifi_radio_operation
     // Add operating class and channel as first element in the array
     obj = cJSON_CreateObject();
     cJSON_AddItemToArray(obj_array, obj);
-    cJSON_AddNumberToObject(obj, "Class", oper->operatingClass);
+    cJSON_AddNumberToObject(obj, "Class", oper->op_class);
     cJSON_AddNumberToObject(obj, "Channel", oper->channel);
     return webconfig_error_none;
 }
@@ -249,7 +249,7 @@ webconfig_error_t encode_radio_object(const rdk_wifi_radio_t *radio, cJSON *radi
     cJSON_AddNumberToObject(radio_object, "DtimPeriod", radio_info->dtimPeriod);
 
     // OperatingClass
-    cJSON_AddNumberToObject(radio_object, "OperatingClass", radio_info->operatingClass);
+    cJSON_AddNumberToObject(radio_object, "OperatingClass", radio_info->op_class);
 
     // BasicDataTransmitRates
     cJSON_AddNumberToObject(radio_object, "BasicDataTransmitRates", radio_info->basicDataTransmitRates);


### PR DESCRIPTION
rdk-wifi-hal used op_class member variable of wifi_radio_operation_t structure for read/write of Operating Class. There were few places in OneWifi where this member variable was not used but operatingClass variable was used impacting mainly EasyMesh case. This commit is to correct that.