### PR TITLE
RDKBDEV-3061 REFPLTB-3230 REFPLTB-3233 REFPLTB-3234: Potential memory leak at PSM_Get_Record_Value2 call

### DIFF
--- a/source/ccsp/ccsp.c
+++ b/source/ccsp/ccsp.c
@@ -79,7 +79,7 @@ void CcspTraceDebugRdkb(char *format, ...)
 
 }
 
-char *psm_get_value_Rdkb(char *recName, char *strValue)
+char *psm_get_value_Rdkb(char *recName, char *strValue, unsigned int str_size)
 {
     return NULL;
 }

--- a/source/ccsp/ccsp.h
+++ b/source/ccsp/ccsp.h
@@ -55,7 +55,7 @@ typedef void (* wifi_ccsp_trace_alert_t) (char *format, ...);
 typedef void (* wifi_ccsp_trace_notice_t) (char *format, ...);
 typedef void (* wifi_ccsp_trace_info_t) (char *format, ...);
 typedef void (* wifi_ccsp_trace_debug_t) (char *format, ...);
-typedef char * (* psm_get_value_t) (char *recName, char *strValue);
+typedef char * (* psm_get_value_t) (char *recName, char *strValue, unsigned int str_size);
 typedef int (* psm_set_value_t) (char *recName, char *strValue);
 typedef int (* get_partner_id_t) (char *partner_id);
 
@@ -101,7 +101,7 @@ typedef struct {
     syslog_event("OneWifi", LOG_NOTICE, "%s", logmsg);              \
 }
 
-char *psm_get_value_Rdkb(char *recName, char *strValue);
+char *psm_get_value_Rdkb(char *recName, char *strValue, unsigned int str_size);
 int psm_set_value_Rdkb(char *recName, char *strValue);
 int get_partner_id_Rdkb(char *partner_id);
 

--- a/source/ccsp/ccsp_api.c
+++ b/source/ccsp/ccsp_api.c
@@ -25,6 +25,7 @@
 #include "util.h"
 #include "wifi_hal.h"
 #include "wifi_util.h"
+#include "cosa_dbus_api.h"
 #include <stdarg.h>
 
 extern void* bus_handle;
@@ -131,16 +132,19 @@ void CcspTraceDebugRdkb(char *format, ...)
     va_end(args);
 }
 
-char *psm_get_value_Rdkb(char *recName, char *strValue)
+char *psm_get_value_Rdkb(char *recName, char *strValue, unsigned int str_size)
 {
     int retry = 0;
     int ret_psm_get = RETURN_ERR;
+    char *strVal = NULL;
 
     while (retry++ < 2) {
-        ret_psm_get = PSM_Get_Record_Value2(bus_handle, g_Subsystem, recName, NULL, &strValue);
+        ret_psm_get = PSM_Get_Record_Value2(bus_handle, g_Subsystem, recName, NULL, &strVal);
         if (ret_psm_get == RDKB_CCSP_SUCCESS) {
             wifi_util_dbg_print(WIFI_MGR,"%s:%d ret_psm_get success for %s and strValue is %s\n", __func__,
                 __LINE__, recName, strValue);
+            snprintf(strValue, str_size, "%s", strVal);
+            ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(strVal);
             return strValue;
         } else if (ret_psm_get == CCSP_CR_ERR_INVALID_PARAM) {
             wifi_util_dbg_print(WIFI_MGR,"%s:%d PSM_Get_Record_Value2 (%s) returned error %d \n", __func__,

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4265,7 +4265,7 @@ static void wifidb_global_config_upgrade()
         wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade global config, old db version %d \n", __func__, __LINE__, g_wifidb->db_version);
 
         memset(strValue, 0, sizeof(strValue));
-        str = (char *) p_ccsp_desc->psm_get_value_fn(WhixLoginterval, strValue);
+        str = (char *) p_ccsp_desc->psm_get_value_fn(WhixLoginterval, strValue, sizeof(strValue));
         if (str != NULL) {
             g_wifidb->global_config.global_parameters.whix_log_interval = atoi(str);
             wifi_util_dbg_print(WIFI_DB,"whix_log_interval is %d and str is %s \n", g_wifidb->global_config.global_parameters.whix_log_interval, str);
@@ -4278,7 +4278,7 @@ static void wifidb_global_config_upgrade()
         wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade global config, old db version %d \n", __func__, __LINE__, g_wifidb->db_version);
 
         memset(strValue, 0, sizeof(strValue));
-        str = (char *) p_ccsp_desc->psm_get_value_fn(WhixChUtilityLoginterval, strValue);
+        str = (char *) p_ccsp_desc->psm_get_value_fn(WhixChUtilityLoginterval, strValue, sizeof(strValue));
         if (str != NULL) {
             g_wifidb->global_config.global_parameters.whix_chutility_loginterval = atoi(str);
             wifi_util_dbg_print(WIFI_DB,"%s:%d whix_chutility_loginterval is %d and str is %s \n", __func__, __LINE__, g_wifidb->global_config.global_parameters.whix_chutility_loginterval, str);
@@ -7382,7 +7382,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
 
     memset(strValue, 0, sizeof(strValue));
 #ifndef NEWPLATFORM_PORT
-    str = p_ccsp_desc->psm_get_value_fn(WiFivAPStatsFeatureEnable, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WiFivAPStatsFeatureEnable, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &global_cfg->vap_stats_feature);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->vap_stats_feature; is %d and str is %s\n", global_cfg->vap_stats_feature, str);
@@ -7391,7 +7391,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WifiVlanCfgVersion, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WifiVlanCfgVersion, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->vlan_cfg_version = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->vlan_cfg_version is %d and str is %s and atoi(str) is %d\n", global_cfg->vlan_cfg_version, str, atoi(str));
@@ -7400,7 +7400,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(PreferPrivate, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(PreferPrivate, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->prefer_private = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->prefer_private is %d and str is %s and atoi(str) is %d\n", global_cfg->prefer_private, str, atoi(str));
@@ -7409,7 +7409,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(NotifyWiFiChanges, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(NotifyWiFiChanges, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &global_cfg->notify_wifi_changes);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->notify_wifi_changes is %d and str is %s\n", global_cfg->notify_wifi_changes, str);
@@ -7418,7 +7418,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(DiagnosticEnable, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(DiagnosticEnable, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->diagnostic_enable = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->diagnostic_enable is %d and str is %s and atoi(str) is %d\n", global_cfg->diagnostic_enable, str, atoi(str));
@@ -7427,7 +7427,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(GoodRssiThreshold, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(GoodRssiThreshold, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->good_rssi_threshold = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->good_rssi_threshold is %d and str is %s and atoi(str) is %d\n", global_cfg->good_rssi_threshold, str, atoi(str));
@@ -7436,7 +7436,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(AssocCountThreshold, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(AssocCountThreshold, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->assoc_count_threshold = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->assoc_count_threshold is %d and str is %s and atoi(str) is %d\n", global_cfg->assoc_count_threshold, str, atoi(str));
@@ -7445,7 +7445,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(AssocMonitorDuration, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(AssocMonitorDuration, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->assoc_monitor_duration = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->assoc_monitor_duration is %d and str is %s and atoi(str) is %d\n", global_cfg->assoc_monitor_duration, str, atoi(str));
@@ -7454,7 +7454,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(AssocGateTime, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(AssocGateTime, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->assoc_gate_time = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->assoc_gate_time is %d and str is %s and atoi(str) is %d\n", global_cfg->assoc_gate_time, str, atoi(str));
@@ -7463,7 +7463,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WhixLoginterval, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WhixLoginterval, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->whix_log_interval = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->whix_log_interval is %d and str is %s and atoi(str) is %d\n", global_cfg->whix_log_interval, str, atoi(str));
@@ -7472,7 +7472,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WhixChUtilityLoginterval, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WhixChUtilityLoginterval, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->whix_chutility_loginterval = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"%s:%d global_cfg->whix_chutility_log_interval is %d and str is %s and atoi(str) is %d\n", __func__, __LINE__, global_cfg->whix_chutility_loginterval, str, atoi(str));
@@ -7481,7 +7481,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(RapidReconnectIndicationEnable, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(RapidReconnectIndicationEnable, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &global_cfg->rapid_reconnect_enable);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->rapid_reconnect_enable is %d and str is %s\n", global_cfg->rapid_reconnect_enable, str);
@@ -7490,7 +7490,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(FeatureMFPConfig, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(FeatureMFPConfig, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->mfp_config_feature = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->mfp_config_feature is %d and str is %s and atoi(str) is %d\n", global_cfg->mfp_config_feature, str, atoi(str));
@@ -7499,7 +7499,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WiFiTxOverflowSelfheal, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WiFiTxOverflowSelfheal, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &global_cfg->tx_overflow_selfheal);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->tx_overflow_selfheal is %d and str is %s\n", global_cfg->tx_overflow_selfheal, str);
@@ -7508,7 +7508,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WiFiForceDisableWiFiRadio, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WiFiForceDisableWiFiRadio, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &global_cfg->force_disable_radio_feature);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->force_disable_radio_feature is %d and str is %s\n", global_cfg->force_disable_radio_feature, str);
@@ -7517,7 +7517,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WiFiForceDisableRadioStatus, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WiFiForceDisableRadioStatus, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->force_disable_radio_status = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->force_disable_radio_status is %d and str is %s and atoi(str) is %d\n", global_cfg->force_disable_radio_status, str, atoi(str));
@@ -7526,7 +7526,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(ValidateSSIDName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(ValidateSSIDName, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->validate_ssid = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->validate_ssid is %d and str is %s and atoi(str) is %d\n", global_cfg->validate_ssid, str, atoi(str));
@@ -7535,7 +7535,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(FixedWmmParams, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(FixedWmmParams, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->fixed_wmm_params = atoi(strValue);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->fixed_wmm_params is %d and str is %s and atoi(str) is %d\n", global_cfg->fixed_wmm_params, str, atoi(str));
@@ -7545,7 +7545,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
 
     memset(strValue, 0, sizeof(strValue));
 #endif // NEWPLATFORM_PORT
-    str = p_ccsp_desc->psm_get_value_fn(TR181_WIFIREGION_Code, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(TR181_WIFIREGION_Code, strValue, sizeof(strValue));
     if (str != NULL) {
         strcpy(global_cfg->wifi_region_code, str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->wifi_region_code is %s and str is %s \n", global_cfg->wifi_region_code, str);
@@ -7555,7 +7555,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
 
 #ifndef NEWPLATFORM_PORT
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WpsPin, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WpsPin, strValue, sizeof(strValue));
     if (str != NULL) {
         //global_cfg->wps_pin = atoi(str);
         strcpy(global_cfg->wps_pin, str);
@@ -7565,7 +7565,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(PreferPrivateConfigure, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(PreferPrivateConfigure, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->prefer_private_configure = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->prefer_private_configure is %d and str is %s and atoi(str) is %d\n", global_cfg->prefer_private_configure, str, atoi(str));
@@ -7574,7 +7574,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(FactoryReset, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(FactoryReset, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->factory_reset = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->factory_reset is %d and str is %s and atoi(str) is %d\n", global_cfg->factory_reset, str, atoi(str));
@@ -7583,7 +7583,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(BandSteer_Enable, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(BandSteer_Enable, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->bandsteering_enable = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->bandsteering_enable is %d and str is %s and atoi(str) is %d\n", global_cfg->bandsteering_enable, str, atoi(str));
@@ -7592,7 +7592,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(InstWifiClientEnabled, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(InstWifiClientEnabled, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->inst_wifi_client_enabled = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->inst_wifi_client_enabled is %d and str is %s and atoi(str) is %d\n", global_cfg->inst_wifi_client_enabled, str, atoi(str));
@@ -7601,7 +7601,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(InstWifiClientReportingPeriod, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(InstWifiClientReportingPeriod, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->inst_wifi_client_reporting_period = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->inst_wifi_client_reporting_period is %d and str is %s and atoi(str) is %d\n", global_cfg->inst_wifi_client_reporting_period, str, atoi(str));
@@ -7610,7 +7610,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(InstWifiClientMacAddress, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(InstWifiClientMacAddress, strValue, sizeof(strValue));
     if (str != NULL) {
         str_to_mac_bytes(str, global_cfg->inst_wifi_client_mac);
         //strncpy(global_cfg->inst_wifi_client_mac,str,sizeof(global_cfg->inst_wifi_client_mac)-1);
@@ -7620,7 +7620,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(InstWifiClientDefReportingPeriod, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(InstWifiClientDefReportingPeriod, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->inst_wifi_client_def_reporting_period = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->inst_wifi_client_def_reporting_period is %d and str is %s and atoi(str) is %d\n", global_cfg->inst_wifi_client_def_reporting_period, str, atoi(str));
@@ -7629,7 +7629,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WiFiActiveMsmtEnabled, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WiFiActiveMsmtEnabled, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &global_cfg->wifi_active_msmt_enabled);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->wifi_active_msmt_enabled is %d and str is %s\r\n", global_cfg->wifi_active_msmt_enabled, str);
@@ -7638,7 +7638,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WiFiActiveMsmtPktSize, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WiFiActiveMsmtPktSize, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->wifi_active_msmt_pktsize = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->wifi_active_msmt_pktsize is %d and str is %s and atoi(str) is %d\n", global_cfg->wifi_active_msmt_pktsize, str, atoi(str));
@@ -7647,7 +7647,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WiFiActiveMsmtNumberOfSample, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WiFiActiveMsmtNumberOfSample, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->wifi_active_msmt_num_samples = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->wifi_active_msmt_num_samples is %d and str is %s and atoi(str) is %d\n", global_cfg->wifi_active_msmt_num_samples, str, atoi(str));
@@ -7656,7 +7656,7 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WiFiActiveMsmtSampleDuration, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WiFiActiveMsmtSampleDuration, strValue, sizeof(strValue));
     if (str != NULL) {
         global_cfg->wifi_active_msmt_sample_duration = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"global_cfg->wifi_active_msmt_sample_duration is %d and str is %s and atoi(str) is %d\n", global_cfg->wifi_active_msmt_sample_duration, str, atoi(str));
@@ -7680,14 +7680,16 @@ int get_total_mac_list_from_psm(int instance_number, unsigned int *total_entries
     int l_total_entries = 0;
     char recName[256] = {0};
     char strValue[256] = {0};
+    char mac_strValue[256] = {0};
     char *l_strValue = NULL;
     wifi_ccsp_desc_t *p_ccsp_desc = &get_wificcsp_obj()->desc;
 
     memset(recName, '\0', sizeof(recName));
     snprintf(recName, sizeof(recName), MacFilterList, instance_number);
     memset(strValue, 0, sizeof(strValue));
+    memset(mac_strValue, 0, sizeof(mac_strValue));
     wifi_util_dbg_print(WIFI_MGR, "%s:%d  recName: %s instance_number:%d\n",__func__, __LINE__, recName, instance_number);
-    l_strValue = p_ccsp_desc->psm_get_value_fn(recName, l_strValue);
+    l_strValue = p_ccsp_desc->psm_get_value_fn(recName, mac_strValue, sizeof(mac_strValue));
     if ((l_strValue != NULL) && (strlen(l_strValue) > 0))
     {
         wifi_util_dbg_print(WIFI_MGR, "%s:%d  mac list data:%s\n",__func__, __LINE__, l_strValue);
@@ -7726,7 +7728,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), Tscan, instance_number);
-        str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+        str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             radio_feat_cfg->OffChanTscanInMsec = atoi(str);
             wifi_util_dbg_print(WIFI_MGR,"radio_feat_cfg->OffChanTscanInMsec is %d and str is %s and atoi(str) is %d\n", radio_feat_cfg->OffChanTscanInMsec, str, atoi(str));
@@ -7737,7 +7739,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), Nscan, instance_number);
-        str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+        str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             radio_feat_cfg->OffChanNscanInSec = atoi(str);
             wifi_util_dbg_print(WIFI_MGR,"radio_feat_cfg->OffChanNscanInSec is %d and str is %s and atoi(str) is %d\n", radio_feat_cfg->OffChanNscanInSec, str, atoi(str));
@@ -7748,7 +7750,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), Tidle, instance_number);
-        str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+        str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             radio_feat_cfg->OffChanTidleInSec = atoi(str);
             wifi_util_dbg_print(WIFI_MGR,"radio_feat_cfg->OffChanTidleInSec is %d and str is %s and atoi(str) is %d\n", radio_feat_cfg->OffChanTidleInSec, str, atoi(str));
@@ -7761,7 +7763,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), CTSProtection, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->ctsProtection = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->ctsProtection is %d and str is %s and atoi(str) is %d\n", radio_cfg->ctsProtection, str, atoi(str));
@@ -7772,7 +7774,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), BeaconInterval, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->beaconInterval = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->beaconInterval is %d and str is %s and atoi(str) is %d\n", radio_cfg->beaconInterval, str, atoi(str));
@@ -7783,7 +7785,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), DTIMInterval, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->dtimPeriod = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->dtimPeriod is %d and str is %s and atoi(str) is %d\n", radio_cfg->dtimPeriod, str, atoi(str));
@@ -7794,7 +7796,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), FragThreshold, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->fragmentationThreshold = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->fragmentationThreshold is %d and str is %s and atoi(str) is %d\n", radio_cfg->fragmentationThreshold, str, atoi(str));
@@ -7805,7 +7807,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), RTSThreshold, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->rtsThreshold = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->rtsThreshold is %d and str is %s and atoi(str) is %d\n", radio_cfg->rtsThreshold, str, atoi(str));
@@ -7816,7 +7818,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), ObssCoex, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->obssCoex = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->obssCoex is %d and str is %s and atoi(str) is %d\n", radio_cfg->obssCoex, str, atoi(str));
@@ -7827,7 +7829,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), STBCEnable, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->stbcEnable = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->stbcEnable is %d and str is %s and atoi(str) is %d\n", radio_cfg->stbcEnable, str, atoi(str));
@@ -7838,7 +7840,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), GuardInterval, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->guardInterval = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->guardInterval is %d and str is %s and atoi(str) is %d\n", radio_cfg->guardInterval, str, atoi(str));
@@ -7849,7 +7851,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), GreenField, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->greenFieldEnable = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->greenFieldEnable is %d and str is %s and atoi(str) is %d\n", radio_cfg->greenFieldEnable, str, atoi(str));
@@ -7860,7 +7862,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), TransmitPower, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->transmitPower = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->transmitPower is %d and str is %s and atoi(str) is %d\n", radio_cfg->transmitPower, str, atoi(str));
@@ -7871,7 +7873,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), UserControl, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->userControl = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->userControl is %d and str is %s and atoi(str) is %d\n", radio_cfg->userControl, str, atoi(str));
@@ -7882,7 +7884,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), AdminControl, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->adminControl = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->adminControl is %d and str is %s and atoi(str) is %d\n", radio_cfg->adminControl, str, atoi(str));
@@ -7893,7 +7895,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), MeasuringRateRd, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->radioStatsMeasuringRate = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->chanUtilThreshold is %d and str is %s and ansc_atoi-str is %d\n", radio_cfg->chanUtilThreshold, str, atoi(str));
@@ -7904,7 +7906,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), MeasuringIntervalRd, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->radioStatsMeasuringInterval = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->radioStatsMeasuringInterval is %d and str is %s and atoi(str) is %d\n", radio_cfg->radioStatsMeasuringInterval, str, atoi(str));
@@ -7915,7 +7917,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), SetChanUtilThreshold, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->chanUtilThreshold = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->chanUtilThreshold is %d and str is %s and ansc_atoi-str is %d\n", radio_cfg->chanUtilThreshold, str, atoi(str));
@@ -7926,7 +7928,7 @@ void get_radio_params_from_psm(unsigned int radio_index, wifi_radio_operationPar
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), SetChanUtilSelfHealEnable, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         radio_cfg->chanUtilSelfHealEnable = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"radio_cfg->chanUtilSelfHealEnable is %d and str is %s and atoi(str) is %d\n", radio_cfg->chanUtilSelfHealEnable, str, atoi(str));
@@ -8009,7 +8011,7 @@ void get_psm_mac_list_entry(unsigned int instance_number, char *l_vap_name, unsi
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), MacFilterDevice, instance_number, index);
-        str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+        str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             strcpy(temp_psm_mac_param->device_name, str);
             wifi_util_dbg_print(WIFI_MGR,"psm get device_name is %s\r\n", str);
@@ -8020,7 +8022,7 @@ void get_psm_mac_list_entry(unsigned int instance_number, char *l_vap_name, unsi
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), MacFilter, instance_number, index);
-        str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+        str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             str_to_mac_bytes(str, temp_psm_mac_param->mac);
             wifi_util_dbg_print(WIFI_MGR,"psm get mac is %s\n", str);
@@ -8059,7 +8061,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), WmmEnable, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         bss_cfg->wmm_enabled = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->wmm_enabled is %d and str is %s and atoi(str) is %d\n", bss_cfg->wmm_enabled, str, atoi(str));
@@ -8070,7 +8072,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), UAPSDEnable, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         bss_cfg->UAPSDEnabled = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->UAPSDEnabled is %d and str is %s and atoi(str) is %d\n", bss_cfg->UAPSDEnabled, str, atoi(str));
@@ -8081,7 +8083,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), vAPStatsEnable, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, (bool *)&bss_cfg->vapStatsEnable);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->vapStatsEnable is %d and str is %s\n", bss_cfg->vapStatsEnable, str);
@@ -8092,7 +8094,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), WmmNoAck, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         bss_cfg->wmmNoAck = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->wmmNoAck is %d and str is %s and atoi(str) is %d\n", bss_cfg->wmmNoAck, str, atoi(str));
@@ -8103,7 +8105,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), BssMaxNumSta, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         if ((isVapPrivate(vap_config->vap_index)) && (atoi(str) == 0)) {
             bss_cfg->bssMaxSta = wifi_mgr->hal_cap.wifi_prop.BssMaxStaAllow;
@@ -8119,7 +8121,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), MacFilterMode, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         unsigned int mf_mode = atoi(str);
         if (mf_mode == 0) {
@@ -8140,7 +8142,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), ApIsolationEnable, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         bss_cfg->isolation = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->isolation is %d and str is %s and atoi(str) is %d\n", bss_cfg->isolation, str, atoi(str));
@@ -8151,7 +8153,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), BSSTransitionActivated, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, (bool *)&bss_cfg->bssTransitionActivated);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->bssTransitionActivated is %d and str is %s\n", bss_cfg->bssTransitionActivated, str);
@@ -8162,7 +8164,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), BssHotSpot, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         bss_cfg->bssHotspot = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->bssHotspot is %d and str is %s and atoi(str) is %d\n", bss_cfg->bssHotspot, str, atoi(str));
@@ -8173,7 +8175,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), WpsPushButton, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         bss_cfg->wpsPushButton = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->wpsPushButton is %d and str is %s and atoi(str) is %d\n", bss_cfg->wpsPushButton, str, atoi(str));
@@ -8184,7 +8186,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), RapidReconnThreshold, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         bss_cfg->rapidReconnThreshold = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->rapidReconnThreshold is %d and str is %s and atoi(str) is %d\n", bss_cfg->rapidReconnThreshold, str, atoi(str));
@@ -8195,7 +8197,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), RapidReconnCountEnable, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         bss_cfg->rapidReconnectEnable = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->rapidReconnectEnable is %d and str is %s and atoi(str) is %d\n", bss_cfg->rapidReconnectEnable, str, atoi(str));
@@ -8206,7 +8208,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), NeighborReportActivated, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, (bool *)&bss_cfg->nbrReportActivated);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->nbrReportActivated is %d and str is %s\n", bss_cfg->nbrReportActivated, str);
@@ -8217,7 +8219,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), ApMFPConfig, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     int security_mfp = 0;
     if (str != NULL) {
         convert_security_mode_string_to_integer((int *)&security_mfp, str);
@@ -8229,7 +8231,7 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
     snprintf(recName, sizeof(recName), BeaconRateCtl, instance_number);
-    str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(recName, strValue, sizeof(strValue));
     if (str != NULL) {
         strcpy(bss_cfg->beaconRateCtl,str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->beaconRateCtl is %s and str is %s \r\n", bss_cfg->beaconRateCtl, str);
@@ -8424,7 +8426,7 @@ int get_wifi_db_psm_enable_status(bool *wifi_psm_db_enabled)
     wifi_ccsp_desc_t *p_ccsp_desc = &get_wificcsp_obj()->desc;
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(WIFI_PSM_DB_NAMESPACE, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(WIFI_PSM_DB_NAMESPACE, strValue, sizeof(strValue));
     if (str != NULL) {
         *wifi_psm_db_enabled = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"str is %s and wifi_psm_db_enabled is %d\n", str, *wifi_psm_db_enabled);
@@ -8443,7 +8445,7 @@ int get_wifi_last_reboot_reason_psm_value(char *last_reboot_reason)
     wifi_ccsp_desc_t *p_ccsp_desc = &get_wificcsp_obj()->desc;
 
     memset(strValue, 0, sizeof(strValue));
-    str = p_ccsp_desc->psm_get_value_fn(LAST_REBOOT_REASON_NAMESPACE, strValue);
+    str = p_ccsp_desc->psm_get_value_fn(LAST_REBOOT_REASON_NAMESPACE, strValue, sizeof(strValue));
     if (str != NULL) {
         strcpy(last_reboot_reason, str);
         wifi_util_dbg_print(WIFI_MGR,"str is %s and last_reboot_reason is %s\n", str, last_reboot_reason);

--- a/source/dml/tr_181/ml/cosa_wifi_internal.c
+++ b/source/dml/tr_181/ml/cosa_wifi_internal.c
@@ -202,14 +202,17 @@ CosaWifiCreate
     return  (ANSC_HANDLE)pMyObject;
 }
 
-char* PSM_Get_Record_Status(char *recName, char *strValue)
+char* PSM_Get_Record_Status(char *recName, char *strValue, unsigned int str_size)
 {
     int retry = 0;
     int retPsmGet = CCSP_SUCCESS;
+    char *strVal = NULL;
     while(retry++ < 2) {
-        retPsmGet = PSM_Get_Record_Value2(bus_handle, g_Subsystem, recName, NULL, &strValue);
+        retPsmGet = PSM_Get_Record_Value2(bus_handle, g_Subsystem, recName, NULL, &strVal);
         if (retPsmGet == CCSP_SUCCESS) {
             wifi_util_dbg_print(WIFI_PSM,"%s:%d retPsmGet success for %s and strValue is %s\n", __FUNCTION__,__LINE__, recName, strValue);
+            snprintf(strValue, str_size, "%s", strVal);
+            ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(strVal);
             return strValue;
         } else if (retPsmGet == CCSP_CR_ERR_INVALID_PARAM) {
             wifi_util_dbg_print(WIFI_PSM,"%s:%d PSM_Get_Record_Value2 (%s) returned error %d \n",__FUNCTION__,__LINE__,recName,retPsmGet);
@@ -256,7 +259,7 @@ void psm_get_mac_list_entry(hash_map_t *psm_mac_map, unsigned int instance_numbe
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), MacFilterDevice, instance_number, index);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             strcpy(temp_psm_mac_param->device_name, str);
             wifi_util_dbg_print(WIFI_PSM,"psm get device_name is %s\r\n", str);
@@ -267,7 +270,7 @@ void psm_get_mac_list_entry(hash_map_t *psm_mac_map, unsigned int instance_numbe
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), MacFilter, instance_number, index);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             strcpy(temp_psm_mac_param->mac, str);
             str_tolower(temp_psm_mac_param->mac);
@@ -324,7 +327,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), Tscan, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_radio_feat_param->Tscan = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"psm_radio_feat_param->Tscan is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_feat_param->Tscan, str, _ansc_atoi(str));
@@ -336,7 +339,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), Nscan, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_radio_feat_param->Nscan = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"psm_radio_feat_param->Nscan is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_feat_param->Nscan, str, _ansc_atoi(str));
@@ -348,7 +351,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), Tidle, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_radio_feat_param->Tidle = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"psm_radio_feat_param->Tidle is %d and str is %s and _ansc_atoi(str) is %d\n",psm_radio_feat_param->Tidle, str, _ansc_atoi(str));
@@ -362,7 +365,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), CTSProtection, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->cts_protection = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"psm_radio_param->cts_protection is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->cts_protection, str, _ansc_atoi(str));
@@ -374,7 +377,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), BeaconInterval, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->beacon_interval = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->beacon_interval is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->beacon_interval, str, _ansc_atoi(str));
@@ -386,7 +389,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), DTIMInterval, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->dtim_period = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->dtim_period is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->dtim_period, str, _ansc_atoi(str));
@@ -398,7 +401,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), FragThreshold, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->fragmentation_threshold = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->fragmentation_threshold is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->fragmentation_threshold, str, _ansc_atoi(str));
@@ -410,7 +413,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), RTSThreshold, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->rts_threshold = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->rts_threshold is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->rts_threshold, str, _ansc_atoi(str));
@@ -422,7 +425,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), ObssCoex, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->obss_coex = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->obss_coex is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->obss_coex, str, _ansc_atoi(str));
@@ -434,7 +437,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), STBCEnable, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->stbc_enable = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->stbc_enable is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->stbc_enable, str, _ansc_atoi(str));
@@ -446,7 +449,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), GuardInterval, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->guard_interval = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->guard_interval is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->guard_interval, str, _ansc_atoi(str));
@@ -458,7 +461,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), GreenField, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->greenfield_enable = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->greenfield_enable is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->greenfield_enable, str, _ansc_atoi(str));
@@ -470,7 +473,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), TransmitPower, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->transmit_power = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->transmit_power is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->transmit_power, str, _ansc_atoi(str));
@@ -482,7 +485,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), UserControl, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->user_control = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->user_control is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->user_control, str, _ansc_atoi(str));
@@ -494,7 +497,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), AdminControl, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->admin_control = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->admin_control is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->admin_control, str, _ansc_atoi(str));
@@ -506,7 +509,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), MeasuringRateRd, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->radio_stats_measuring_rate = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->radio_stats_measuring_rate is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->radio_stats_measuring_rate, str, _ansc_atoi(str));
@@ -518,7 +521,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), MeasuringIntervalRd, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->radio_stats_measuring_interval = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->radio_stats_measuring_interval is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->radio_stats_measuring_interval, str, _ansc_atoi(str));
@@ -530,7 +533,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), SetChanUtilThreshold, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->chan_util_threshold = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->chan_util_threshold is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->chan_util_threshold, str, _ansc_atoi(str));
@@ -542,7 +545,7 @@ void CosaDmlWiFiGetFromPSM(void)
         memset(recName, 0, sizeof(recName));
         memset(strValue, 0, sizeof(strValue));
         snprintf(recName, sizeof(recName), SetChanUtilSelfHealEnable, instance_number);
-        str = PSM_Get_Record_Status(recName, strValue);
+        str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
         if (str != NULL) {
             psm_radio_param->chan_util_selfheal_enable = _ansc_atoi(str);
             wifi_util_dbg_print(WIFI_PSM,"cfg->chan_util_selfheal_enable is %d and str is %s and _ansc_atoi(str) is %d\n", psm_radio_param->chan_util_selfheal_enable, str, _ansc_atoi(str));
@@ -573,7 +576,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), WmmEnable, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->wmm_enabled = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->wmm_enabled is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->wmm_enabled, str, _ansc_atoi(str));
@@ -585,7 +588,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), UAPSDEnable, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->uapsd_enabled = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->uapsd_enabled is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->uapsd_enabled, str, _ansc_atoi(str));
@@ -597,7 +600,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), vAPStatsEnable, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 convert_ascii_string_to_bool(str, &psm_vap_param->vap_stats_enable);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->vap_stats_enable is %d and str is %s\n", psm_vap_param->vap_stats_enable, str);
@@ -609,7 +612,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), WmmNoAck, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->wmm_noack = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->wmm_noack is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->wmm_noack, str, _ansc_atoi(str));
@@ -621,7 +624,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), BssMaxNumSta, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->bss_max_sta = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->bss_max_sta is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->bss_max_sta, str, _ansc_atoi(str));
@@ -633,7 +636,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), MacFilterMode, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 unsigned int mf_mode = _ansc_atoi(str);
                 if (mf_mode == 0) {
@@ -655,7 +658,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), ApIsolationEnable, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->isolation_enabled = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->isolation_enabled is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->isolation_enabled, str, _ansc_atoi(str));
@@ -667,7 +670,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), BSSTransitionActivated, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 convert_ascii_string_to_bool(str, &psm_vap_param->bss_transition_activated);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->bss_transition_activated is %d and str is %s\n", psm_vap_param->bss_transition_activated, str);
@@ -679,7 +682,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), BssHotSpot, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->bss_hotspot = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->bss_hotspot is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->bss_hotspot, str, _ansc_atoi(str));
@@ -691,7 +694,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), WpsPushButton, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->wps_push_button = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->wps_push_button is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->wps_push_button, str, _ansc_atoi(str));
@@ -703,7 +706,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), RapidReconnThreshold, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->rapid_connect_threshold = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->rapid_connect_threshold is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->rapid_connect_threshold, str, _ansc_atoi(str));
@@ -715,7 +718,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), RapidReconnCountEnable, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 psm_vap_param->rapid_connect_enable = _ansc_atoi(str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->rapid_connect_enable is %d and str is %s and _ansc_atoi(str) is %d\n", psm_vap_param->rapid_connect_enable, str, _ansc_atoi(str));
@@ -727,7 +730,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), NeighborReportActivated, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 convert_ascii_string_to_bool(str, &psm_vap_param->nbr_report_activated);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->nbr_report_activated is %d and str is %s\n", psm_vap_param->nbr_report_activated, str);
@@ -739,7 +742,7 @@ void CosaDmlWiFiGetFromPSM(void)
             memset(recName, 0, sizeof(recName));
             memset(strValue, 0, sizeof(strValue));
             snprintf(recName, sizeof(recName), ApMFPConfig, instance_number);
-            str = PSM_Get_Record_Status(recName, strValue);
+            str = PSM_Get_Record_Status(recName, strValue, sizeof(strValue));
             if (str != NULL) {
                 strcpy(psm_vap_param->mfp, str);
                 wifi_util_dbg_print(WIFI_PSM,"cfg->mfp is %s and str is %s\n", psm_vap_param->mfp, str);
@@ -776,7 +779,7 @@ void CosaDmlWiFiGetFromPSM(void)
     wifidb_init_global_config_default(&global_cfg);
 
      memset(strValue, 0, sizeof(strValue));
-     str = PSM_Get_Record_Status(WiFivAPStatsFeatureEnable, strValue);
+     str = PSM_Get_Record_Status(WiFivAPStatsFeatureEnable, strValue, sizeof(strValue));
      if (str != NULL) {
          convert_ascii_string_to_bool(str, &psm_global_param->vap_stats_feature);
          wifi_util_dbg_print(WIFI_PSM,"cfg->vap_stats_feature is %d and str is %s\n", psm_global_param->vap_stats_feature, str);
@@ -792,7 +795,7 @@ void CosaDmlWiFiGetFromPSM(void)
     wifi_util_dbg_print(WIFI_PSM,":%s:%d set default value for PreferPrivate: %d : %d\r\n", __func__, __LINE__, global_cfg.prefer_private, psm_global_param->prefer_private);
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(NotifyWiFiChanges, strValue);
+    str = PSM_Get_Record_Status(NotifyWiFiChanges, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &psm_global_param->notify_wifi_changes);
         wifi_util_dbg_print(WIFI_PSM,"cfg->notify_wifi_changes is %d and str is %s\n", psm_global_param->notify_wifi_changes, str);
@@ -802,7 +805,7 @@ void CosaDmlWiFiGetFromPSM(void)
      }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(DiagnosticEnable, strValue);
+    str = PSM_Get_Record_Status(DiagnosticEnable, strValue, sizeof(strValue));
     if (str != NULL) {
         psm_global_param->diagnostic_enable = _ansc_atoi(str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->diagnostic_enable is %d and str is %s and _ansc_atoi(str) is %d\n", psm_global_param->diagnostic_enable, str, _ansc_atoi(str));
@@ -812,7 +815,7 @@ void CosaDmlWiFiGetFromPSM(void)
      }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(GoodRssiThreshold, strValue);
+    str = PSM_Get_Record_Status(GoodRssiThreshold, strValue, sizeof(strValue));
     if (str != NULL) {
         psm_global_param->good_rssi_threshold = _ansc_atoi(str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->good_rssi_threshold is %d and str is %s and _ansc_atoi(str) is %d\n", psm_global_param->good_rssi_threshold, str, _ansc_atoi(str));
@@ -822,7 +825,7 @@ void CosaDmlWiFiGetFromPSM(void)
      }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(AssocCountThreshold, strValue);
+    str = PSM_Get_Record_Status(AssocCountThreshold, strValue, sizeof(strValue));
     if (str != NULL) {
         psm_global_param->assoc_count_threshold = _ansc_atoi(str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->assoc_count_threshold is %d and str is %s and _ansc_atoi(str) is %d\n", psm_global_param->assoc_count_threshold, str, _ansc_atoi(str));
@@ -832,7 +835,7 @@ void CosaDmlWiFiGetFromPSM(void)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(AssocMonitorDuration, strValue);
+    str = PSM_Get_Record_Status(AssocMonitorDuration, strValue, sizeof(strValue));
     if (str != NULL) {
         psm_global_param->assoc_monitor_duration = _ansc_atoi(str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->assoc_monitor_duration is %d and str is %s and _ansc_atoi(str) is %d\n", psm_global_param->assoc_monitor_duration, str, _ansc_atoi(str));
@@ -842,7 +845,7 @@ void CosaDmlWiFiGetFromPSM(void)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(AssocGateTime, strValue);
+    str = PSM_Get_Record_Status(AssocGateTime, strValue, sizeof(strValue));
     if (str != NULL) {
         psm_global_param->assoc_gate_time = _ansc_atoi(str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->assoc_gate_time is %d and str is %s and _ansc_atoi(str) is %d\n", psm_global_param->assoc_gate_time, str, _ansc_atoi(str));
@@ -852,7 +855,7 @@ void CosaDmlWiFiGetFromPSM(void)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(RapidReconnectIndicationEnable, strValue);
+    str = PSM_Get_Record_Status(RapidReconnectIndicationEnable, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &psm_global_param->rapid_reconnect_enable);
         wifi_util_dbg_print(WIFI_PSM,"cfg->rapid_reconnect_enable is %d and str is %s\n", psm_global_param->rapid_reconnect_enable, str);
@@ -862,7 +865,7 @@ void CosaDmlWiFiGetFromPSM(void)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(FeatureMFPConfig, strValue);
+    str = PSM_Get_Record_Status(FeatureMFPConfig, strValue, sizeof(strValue));
     if (str != NULL) {
         psm_global_param->mfp_config_feature = _ansc_atoi(str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->mfp_config_feature is %d and str is %s and _ansc_atoi(str) is %d\n", psm_global_param->mfp_config_feature, str, _ansc_atoi(str));
@@ -872,7 +875,7 @@ void CosaDmlWiFiGetFromPSM(void)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(WiFiTxOverflowSelfheal, strValue);
+    str = PSM_Get_Record_Status(WiFiTxOverflowSelfheal, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &psm_global_param->tx_overflow_selfheal);
         wifi_util_dbg_print(WIFI_PSM,"cfg->tx_overflow_selfheal is %d and str is %s\n", psm_global_param->tx_overflow_selfheal, str);
@@ -882,7 +885,7 @@ void CosaDmlWiFiGetFromPSM(void)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(WiFiForceDisableWiFiRadio, strValue);
+    str = PSM_Get_Record_Status(WiFiForceDisableWiFiRadio, strValue, sizeof(strValue));
     if (str != NULL) {
         convert_ascii_string_to_bool(str, &psm_global_param->force_disable_radio_feature);
         wifi_util_dbg_print(WIFI_PSM,"cfg->force_disable_radio_feature is %d and str is %s\n", psm_global_param->force_disable_radio_feature, str);
@@ -892,7 +895,7 @@ void CosaDmlWiFiGetFromPSM(void)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(WiFiForceDisableRadioStatus, strValue);
+    str = PSM_Get_Record_Status(WiFiForceDisableRadioStatus, strValue, sizeof(strValue));
     if (str != NULL) {
         psm_global_param->force_disable_radio_status = _ansc_atoi(str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->force_disable_radio_status is %d and str is %s and _ansc_atoi(str) is %d\n", psm_global_param->force_disable_radio_status, str, _ansc_atoi(str));
@@ -902,7 +905,7 @@ void CosaDmlWiFiGetFromPSM(void)
     }
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(ValidateSSIDName, strValue);
+    str = PSM_Get_Record_Status(ValidateSSIDName, strValue, sizeof(strValue));
     if (str != NULL) {
         psm_global_param->validate_ssid = _ansc_atoi(str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->validate_ssid is %d and str is %s and _ansc_atoi(str) is %d\n", psm_global_param->validate_ssid, str, _ansc_atoi(str));
@@ -915,7 +918,7 @@ void CosaDmlWiFiGetFromPSM(void)
     wifi_util_dbg_print(WIFI_PSM,":%s:%d set default value for FixedWmmParams: %d : %d\r\n", __func__, __LINE__, global_cfg.fixed_wmm_params, psm_global_param->fixed_wmm_params);
 
     memset(strValue, 0, sizeof(strValue));
-    str = PSM_Get_Record_Status(TR181_WIFIREGION_Code, strValue);
+    str = PSM_Get_Record_Status(TR181_WIFIREGION_Code, strValue, sizeof(strValue));
     if (str != NULL) {
         strcpy(psm_global_param->wifi_region_code, str);
         wifi_util_dbg_print(WIFI_PSM,"cfg->wifi_region_code is %s and str is %s \n", psm_global_param->wifi_region_code, str);
@@ -1024,6 +1027,7 @@ void CosaDmlWiFiGetRFCDataFromPSM(void)
 
    // bool rfc;
     char recName[256] = {0x0};
+    char scan_strValue[256] = {0};
 
     memset(recName, 0, sizeof(recName));
 
@@ -1054,8 +1058,9 @@ void CosaDmlWiFiGetRFCDataFromPSM(void)
 #if defined (FEATURE_OFF_CHANNEL_SCAN_5G)
     bool q_offchannelscan_RFC;
     char *str1 = NULL;
+    memset(scan_strValue, 0, sizeof(scan_strValue));
     str1 = PSM_Get_Record_Status("Device.DeviceInfo.X_RDK_RFC.Feature.WifiOffChannelScan.Enable",
-        strValue);
+        scan_strValue, sizeof(scan_strValue));
     if (str1 != NULL) {
         q_offchannelscan_RFC = _ansc_atoi(str1);
     } else {
@@ -1067,8 +1072,9 @@ void CosaDmlWiFiGetRFCDataFromPSM(void)
 #endif // FEATURE_OFF_CHANNEL_SCAN_5G
     bool l_offchannelscan_RFC;
     char *str = NULL;
+    memset(scan_strValue, 0, sizeof(scan_strValue));
     str = PSM_Get_Record_Status("Device.DeviceInfo.X_RDK_RFC.Feature.OffChannelScan.Enable",
-        strValue);
+        scan_strValue, sizeof(scan_strValue));
     if (str != NULL) {
         l_offchannelscan_RFC = _ansc_atoi(str);
     } else {

--- a/source/dml/wifi_ssp/ssp_loop.c
+++ b/source/dml/wifi_ssp/ssp_loop.c
@@ -1050,7 +1050,8 @@ int get_psm_total_mac_list(int instance_number, unsigned int *total_entries, cha
     if((retPsmGet == CCSP_SUCCESS) && (strlen(l_strValue) > 0) )
     {
         wifi_util_dbg_print(WIFI_PSM, "%s:%d  mac list data:%s\n",__func__, __LINE__, l_strValue);
-        strncpy(strValue, l_strValue, (strlen(l_strValue) + 1));
+        snprintf(strValue, sizeof(strValue), "%s", l_strValue);
+        ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(l_strValue);
         sscanf(strValue, "%d:", &l_total_entries);
         wifi_util_dbg_print(WIFI_PSM, "%s:%d  recName: %s total entry:%d\n",__func__, __LINE__, recName, l_total_entries);
         if (l_total_entries != 0) {
@@ -1061,6 +1062,10 @@ int get_psm_total_mac_list(int instance_number, unsigned int *total_entries, cha
         }
     } else {
         wifi_util_dbg_print(WIFI_PSM, "%s:%d PSM maclist get failure:%d mac list data:%s\n",__func__, __LINE__, retPsmGet, l_strValue);
+        if(retPsmGet == CCSP_SUCCESS)
+        {
+            ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(l_strValue);
+        }
     }
 
     return RETURN_ERR;


### PR DESCRIPTION
Reason for change: Added code to release the memory.
Test Procedure: 1) Added the change suggested in the ticket to generate the leak in the api which is calling during the service start.
2) Valgrind command is added in service file as given below,
    ExecStart=/bin/sh -c 'valgrind --tool=memcheck --leak-check=yes --show-reachable=yes --num-callers=20 --track-fds=yes /usr/bin/OneWifi -subsys eRT.'
3) Increased the file size in journald.conf file
4) Stopped the service using systemctl command, it will be automatically try to restart using rpiwifiinitialized.path
5) Executed "journalctl -u onewifi" immediately with the stop command, redirected to some text file in the /tmp folder
    Console command: "systemctl stop onewifi.service;journalctl -u onewifi > /tmp/leak_report.txt"