### PR TITLE
RDKB-59259: Change to use operatingClass variable of wifi_radio_operation_t

### DIFF
--- a/source/core/services/vap_svc_mesh_pod.c
+++ b/source/core/services/vap_svc_mesh_pod.c
@@ -454,7 +454,7 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
                     pthread_mutex_lock(&mgr->data_cache_lock);
                     radio_params->channel = sta_data->stats.channel;
                     radio_params->channelWidth = sta_data->stats.channelWidth;
-                    radio_params->op_class = sta_data->stats.op_class;
+                    radio_params->operatingClass = sta_data->stats.op_class;
                     pthread_mutex_unlock(&mgr->data_cache_lock);
 
                     mgr->ctrl.webconfig_state |= ctrl_webconfig_state_radio_cfg_rsp_pending;

--- a/source/services/mesh/wifi_service_mesh.c
+++ b/source/services/mesh/wifi_service_mesh.c
@@ -1393,7 +1393,7 @@ int process_ext_sta_conn_status(wifi_service_node_t *node, wifi_core_data_t *dat
                     pthread_mutex_lock(&mgr->data_cache_lock);
                     radio_params->channel = sta_data->stats.channel;
                     radio_params->channelWidth = sta_data->stats.channelWidth;
-                    radio_params->op_class = sta_data->stats.op_class;
+                    radio_params->operatingClass = sta_data->stats.op_class;
                     pthread_mutex_unlock(&mgr->data_cache_lock);
 
                     mgr->ctrl.webconfig_state |= ctrl_webconfig_state_radio_cfg_rsp_pending;

--- a/source/test/db/wifi_ovsdb_apis.c
+++ b/source/test/db/wifi_ovsdb_apis.c
@@ -81,25 +81,25 @@ int ovsdb_get_radio_params(unsigned int radio_index, wifi_radio_operationParam_t
 {
     if (radio_index == 0) {
         params->band = WIFI_FREQUENCY_2_4_BAND;
-        params->op_class = 12;
+        params->operatingClass = 12;
         params->channel = 3;
         params->channelWidth = WIFI_CHANNELBANDWIDTH_20MHZ;
         params->variant = WIFI_80211_VARIANT_G;
     } else if (radio_index == 1) {
         params->band = WIFI_FREQUENCY_2_4_BAND;
-        params->op_class = 12;
+        params->operatingClass = 12;
         params->channel = 3;
         params->channelWidth = WIFI_CHANNELBANDWIDTH_20MHZ;
         params->variant = WIFI_80211_VARIANT_G;
     } else if (radio_index == 2) {
         params->band = WIFI_FREQUENCY_2_4_BAND;
-        params->op_class = 12;
+        params->operatingClass = 12;
         params->channel = 3;
         params->channelWidth = WIFI_CHANNELBANDWIDTH_20MHZ;
         params->variant = WIFI_80211_VARIANT_N;
     } else if (radio_index == 3) {
         params->band = WIFI_FREQUENCY_2_4_BAND;
-        params->op_class = 12;
+        params->operatingClass = 12;
         params->channel = 3; 
         params->channelWidth = WIFI_CHANNELBANDWIDTH_20MHZ;
         params->variant = WIFI_80211_VARIANT_N;


### PR DESCRIPTION
Address missing changes related to removal of op_class usage and instead use operatingClass variable of wifi_radio_operation_t structure noticed as part of comcast platform compilation.

Test Procedure: ssid change, radio info change tested with Easymesh agent and controller.