### PR TITLE
RDKB-50264,XER10-1146 : ctrl lock refactoring

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -601,6 +601,7 @@ typedef struct {
     hash_map_t              *acl_map;
     hash_map_t              *associated_devices_map; //Full
     hash_map_t              *associated_devices_diff_map; //Add,Remove
+    pthread_mutex_t         *associated_devices_lock;
     int                     kick_device_task_counter;
     bool                    kick_device_config_change;
     bool                    is_mac_filter_initialized;

--- a/source/apps/blaster/wifi_blaster.c
+++ b/source/apps/blaster/wifi_blaster.c
@@ -160,7 +160,10 @@ bool is_blaster_device_associated(int ap_index, mac_address_t sta_mac)
         wifi_util_error_print(WIFI_BLASTER, "%s: Failed to get rdk_vap_info from vap index %d\n", __func__, ap_index);
         return false;
     }
+
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
     if (rdk_vap_info->associated_devices_map == NULL) {
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         wifi_util_error_print(WIFI_BLASTER,"%s:%d NULL  associated_devices_map  pointer  for  %d\n", __func__, __LINE__, rdk_vap_info->vap_index);
         return false;
     }
@@ -169,6 +172,7 @@ bool is_blaster_device_associated(int ap_index, mac_address_t sta_mac)
 
     to_sta_key(sta_mac, sta_key);
     sta = (assoc_dev_data_t *) hash_map_get(rdk_vap_info->associated_devices_map, sta_key);
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
     if (sta == NULL) {
         wifi_util_error_print(WIFI_BLASTER, "%s: Failed to get sta from vap index %d\n", __func__, ap_index);
         return false;

--- a/source/apps/harvester/wifi_harvester.c
+++ b/source/apps/harvester/wifi_harvester.c
@@ -95,7 +95,10 @@ bool is_harvester_device_associated(int ap_index, mac_address_t sta_mac)
         wifi_util_error_print(WIFI_HARVESTER, "%s: Failed to get rdk_vap_info from vap index %d\n", __func__, ap_index);
         return false;
     }
+
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
     if (rdk_vap_info->associated_devices_map == NULL) {
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         wifi_util_error_print(WIFI_HARVESTER,"%s:%d NULL  associated_devices_map  pointer  for  %d\n", __func__, __LINE__, rdk_vap_info->vap_index);
         return false;
     }
@@ -104,6 +107,7 @@ bool is_harvester_device_associated(int ap_index, mac_address_t sta_mac)
 
     to_sta_key(sta_mac, sta_key);
     sta = (assoc_dev_data_t *) hash_map_get(rdk_vap_info->associated_devices_map, sta_key);
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
     if (sta == NULL) {
         wifi_util_error_print(WIFI_HARVESTER, "%s: Failed to get sta from vap index %d\n", __func__, ap_index);
         return false;

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -73,7 +73,7 @@ void deinit_wifi_ctrl(wifi_ctrl_t *ctrl)
     }
 
     pthread_mutexattr_destroy(&ctrl->attr);
-    pthread_mutex_destroy(&ctrl->lock);
+    pthread_mutex_destroy(&ctrl->queue_lock);
     pthread_cond_destroy(&ctrl->cond);
     pthread_mutex_destroy(&ctrl->events_bus_data.events_bus_lock);
 }
@@ -146,12 +146,15 @@ int get_ap_index_from_clientmac(mac_address_t mac_addr)
                 wifi_util_error_print(WIFI_CTRL,"%s:%d NULL pointers\n", __func__,__LINE__);
                 return -1;
             }
+            pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
             if (rdk_vap_info->associated_devices_map) {
                 assoc_dev_data = hash_map_get(rdk_vap_info->associated_devices_map, mac_str);
                 if (assoc_dev_data != NULL) {
+                    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
                     return vap_index;
                 }
             }
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         }
     }
     return -1;
@@ -290,7 +293,7 @@ void ctrl_queue_loop(wifi_ctrl_t *ctrl)
     int rc = 0;
     wifi_event_t *event = NULL;
 
-    pthread_mutex_lock(&ctrl->lock);
+    pthread_mutex_lock(&ctrl->queue_lock);
     while (ctrl->exit_ctrl == false) {
 
         clock_gettime(CLOCK_MONOTONIC, &tv_now);
@@ -304,7 +307,10 @@ void ctrl_queue_loop(wifi_ctrl_t *ctrl)
             }
         }
 
-        rc = pthread_cond_timedwait(&ctrl->cond, &ctrl->lock, &time_to_wait);
+        rc = 0;
+        if (queue_count(ctrl->queue) == 0) {
+            rc = pthread_cond_timedwait(&ctrl->cond, &ctrl->queue_lock, &time_to_wait);
+        }
 
         if ((rc == 0) || (queue_count(ctrl->queue) != 0)) {
             while (queue_count(ctrl->queue)) {
@@ -312,7 +318,7 @@ void ctrl_queue_loop(wifi_ctrl_t *ctrl)
                 if (event == NULL) {
                     continue;
                 }
-                pthread_mutex_unlock(&ctrl->lock);
+                pthread_mutex_unlock(&ctrl->queue_lock);
                 switch (event->event_type) {
                     case wifi_event_type_webconfig:
                         handle_webconfig_event(ctrl, event->u.core_data.msg, event->u.core_data.len, event->sub_type);
@@ -349,9 +355,10 @@ void ctrl_queue_loop(wifi_ctrl_t *ctrl)
                 destroy_wifi_event(event);
 
                 clock_gettime(CLOCK_MONOTONIC, &ctrl->last_signalled_time);
-                pthread_mutex_lock(&ctrl->lock);
+                pthread_mutex_lock(&ctrl->queue_lock);
             }
         } else if (rc == ETIMEDOUT) {
+            pthread_mutex_unlock(&ctrl->queue_lock);
             clock_gettime(CLOCK_MONOTONIC, &ctrl->last_polled_time);
 
             /*
@@ -365,12 +372,13 @@ void ctrl_queue_loop(wifi_ctrl_t *ctrl)
 
             /*Run the scheduler*/
             scheduler_execute(ctrl->sched, ctrl->last_polled_time, (ctrl->poll_period*1000));
+            pthread_mutex_lock(&ctrl->queue_lock);
         } else {
             wifi_util_dbg_print(WIFI_CTRL,"RDK_LOG_WARN, WIFI %s: Invalid Return Status %d\n",__FUNCTION__,rc);
             continue;
         }
     }
-    pthread_mutex_unlock(&ctrl->lock);
+    pthread_mutex_unlock(&ctrl->queue_lock);
 
     return;
 }
@@ -1289,7 +1297,7 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
     pthread_condattr_destroy(&cond_attr);
     pthread_mutexattr_init(&ctrl->attr);
     pthread_mutexattr_settype(&ctrl->attr, PTHREAD_MUTEX_RECURSIVE);
-    pthread_mutex_init(&ctrl->lock, &ctrl->attr);
+    pthread_mutex_init(&ctrl->queue_lock, &ctrl->attr);
     pthread_mutex_init(&ctrl->events_bus_data.events_bus_lock, NULL);
 
     ctrl->poll_period = QUEUE_WIFI_CTRL_TASK_TIMEOUT;

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -113,6 +113,8 @@ extern "C" {
 
 #define BUS_DML_CONFIG_FILE "bus_dml_config.json"
 
+#define CTRL_QUEUE_SIZE_MAX 500
+
 typedef enum {
     ctrl_webconfig_state_none = 0,
     ctrl_webconfig_state_radio_cfg_rsp_pending = 0x0001,
@@ -208,7 +210,7 @@ typedef struct {
 typedef struct wifi_ctrl {
     bool                exit_ctrl;
     queue_t             *queue;
-    pthread_mutex_t     lock;
+    pthread_mutex_t     queue_lock;
     pthread_cond_t      cond;
     pthread_mutexattr_t attr;
     unsigned int        poll_period;

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -847,22 +847,26 @@ bus_error_t get_assoc_clients_data(char *event_name, raw_data_t *p_data)
         return bus_error_invalid_operation;
     }
 
-    pthread_mutex_lock(&ctrl->lock);
     for (itr = 0; itr < MAX_NUM_RADIOS; itr++) {
         for (itrj = 0; itrj < MAX_NUM_VAP_PER_RADIO; itrj++) {
-            if (mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map != NULL) {
-                assoc_dev_data = hash_map_get_first(
-                    mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map);
+            rdk_wifi_vap_info_t *rdk_vap_info = &mgr->radio_config[itr].vaps.rdk_vap_array[itrj];
+
+            if (rdk_vap_info->associated_devices_lock == NULL) {
+                continue;
+            }
+            pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
+            if (rdk_vap_info->associated_devices_map != NULL) {
+                assoc_dev_data = hash_map_get_first(rdk_vap_info->associated_devices_map);
                 while (assoc_dev_data != NULL) {
                     get_sta_stats_info(assoc_dev_data);
-                    assoc_dev_data = hash_map_get_next(
-                        mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map,
+                    assoc_dev_data = hash_map_get_next(rdk_vap_info->associated_devices_map,
                         assoc_dev_data);
                 }
             }
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         }
     }
-    pthread_mutex_unlock(&ctrl->lock);
+
     memset(&data, 0, sizeof(webconfig_subdoc_data_t));
 
     memcpy((unsigned char *)&data.u.decoded.radios, (unsigned char *)&mgr->radio_config,
@@ -1043,7 +1047,6 @@ int wifiapi_result_publish(void)
         status = bus_error_invalid_input;
         return status;
     }
-    pthread_mutex_lock(&ctrl->lock);
 
     if (ctrl->wifiapi.result == NULL) {
         len = strlen("Result not avaiable");
@@ -1059,7 +1062,6 @@ int wifiapi_result_publish(void)
     rdata.raw_data_len = len;
 
     rc = get_bus_descriptor()->bus_event_publish_fn(&ctrl->handle, WIFI_BUS_WIFIAPI_RESULT, &rdata);
-    pthread_mutex_unlock(&ctrl->lock);
 
     if (rc != bus_error_success) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d bus_event_publish_fn %s failed: %d\n", __func__,
@@ -1084,22 +1086,25 @@ char *get_assoc_devices_blob()
         return NULL;
     }
 
-    pthread_mutex_lock(&ctrl->lock);
     for (itr = 0; itr < MAX_NUM_RADIOS; itr++) {
         for (itrj = 0; itrj < MAX_NUM_VAP_PER_RADIO; itrj++) {
-            if (mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map != NULL) {
-                assoc_dev_data = hash_map_get_first(
-                    mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map);
+            rdk_wifi_vap_info_t *rdk_vap_info = &mgr->radio_config[itr].vaps.rdk_vap_array[itrj];
+
+            if (rdk_vap_info->associated_devices_lock == NULL) {
+                continue;
+            }
+            pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
+            if (rdk_vap_info->associated_devices_map != NULL) {
+                assoc_dev_data = hash_map_get_first(rdk_vap_info->associated_devices_map);
                 while (assoc_dev_data != NULL) {
                     get_sta_stats_info(assoc_dev_data);
-                    assoc_dev_data = hash_map_get_next(
-                        mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map,
+                    assoc_dev_data = hash_map_get_next(rdk_vap_info->associated_devices_map,
                         assoc_dev_data);
                 }
             }
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         }
     }
-    pthread_mutex_unlock(&ctrl->lock);
 
     pdata = (webconfig_subdoc_data_t *)malloc(sizeof(webconfig_subdoc_data_t));
     if (pdata == NULL) {

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -240,6 +240,7 @@ int  webconfig_free_vap_object_diff_assoc_client_entries(webconfig_subdoc_data_t
                 wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: rdk_vap_info is null", __func__, __LINE__);
                 return RETURN_ERR;
             }
+            pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
             if (rdk_vap_info->associated_devices_diff_map != NULL) {
                 assoc_dev_data = hash_map_get_first(rdk_vap_info->associated_devices_diff_map);
                 while(assoc_dev_data != NULL) {
@@ -256,10 +257,12 @@ int  webconfig_free_vap_object_diff_assoc_client_entries(webconfig_subdoc_data_t
             //Clearing the global memory
             tmp_rdk_vap_info = get_wifidb_rdk_vap_info(decoded_params->radios[i].vaps.rdk_vap_array[j].vap_index);
             if (tmp_rdk_vap_info == NULL) {
+                pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
                 wifi_util_error_print(WIFI_CTRL,"%s:%d NULL rdk_vap_info pointer\n", __func__, __LINE__);
                 return RETURN_ERR;
             }
             tmp_rdk_vap_info->associated_devices_diff_map = NULL;
+            pthread_mutex_unlock(tmp_rdk_vap_info->associated_devices_lock);
         }
     }
     return RETURN_OK;

--- a/source/stats/wifi_monitor.h
+++ b/source/stats/wifi_monitor.h
@@ -30,6 +30,8 @@
 
 #define  ANSC_STATUS_SUCCESS                        0
 
+#define MONITOR_QUEUE_SIZE_MAX 500
+
 typedef struct {
     unsigned int        rapid_reconnect_threshold;
     wifi_vapstatus_t    ap_status;

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -569,6 +569,7 @@ webconfig_error_t translate_associated_clients_to_easymesh_sta_info(webconfig_su
                 return webconfig_error_translate_to_easymesh;
             }
 
+            pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
             if (rdk_vap_info->associated_devices_diff_map != NULL) {
                 assoc_dev_data = hash_map_get_first(rdk_vap_info->associated_devices_diff_map);
                 while (assoc_dev_data != NULL) {
@@ -580,6 +581,7 @@ webconfig_error_t translate_associated_clients_to_easymesh_sta_info(webconfig_su
 
                     em_sta_dev_info = (em_sta_info_t *)malloc(sizeof(em_sta_info_t));
                     if (em_sta_dev_info == NULL) {
+                        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
                         wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: sta_info malloc failed\n", __func__, __LINE__);
                         return webconfig_error_translate_to_easymesh;
                     }
@@ -610,6 +612,7 @@ webconfig_error_t translate_associated_clients_to_easymesh_sta_info(webconfig_su
                     em_sta_dev_info->errors_tx=assoc_dev_data->dev_stats.cli_ErrorsSent;
 
                     if (assoc_dev_data->sta_data.msg_data.data == NULL) {
+                        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
                         wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: Association frame data not present\n", __func__, __LINE__);
                         return webconfig_error_translate_to_easymesh;
                     }
@@ -628,6 +631,7 @@ webconfig_error_t translate_associated_clients_to_easymesh_sta_info(webconfig_su
                     assoc_dev_data = hash_map_get_next(rdk_vap_info->associated_devices_diff_map, assoc_dev_data);
                 }
             }
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         }
     }
 

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -1613,6 +1613,10 @@ webconfig_error_t encode_associated_client_object(rdk_wifi_vap_info_t *rdk_vap_i
     cJSON_AddStringToObject(obj_vaps, "VapName", rdk_vap_info->vap_name);
     cJSON_AddItemToObject(obj_vaps, "associatedClients", obj_array);
 
+    if (rdk_vap_info->associated_devices_lock == NULL) {
+        return webconfig_error_none;
+    }
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
     switch (assoclist_type)  {
         case assoclist_type_full:
             devices_map = rdk_vap_info->associated_devices_map;
@@ -1622,6 +1626,7 @@ webconfig_error_t encode_associated_client_object(rdk_wifi_vap_info_t *rdk_vap_i
             devices_map = rdk_vap_info->associated_devices_diff_map;
         break;
         default:
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
             return webconfig_error_encode;
     }
 
@@ -1689,6 +1694,8 @@ webconfig_error_t encode_associated_client_object(rdk_wifi_vap_info_t *rdk_vap_i
             assoc_dev_data = hash_map_get_next(devices_map, assoc_dev_data);
         }
     }
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
+
     return webconfig_error_none;
 }
 


### PR DESCRIPTION
Reason for change: deadlocks due to timers executed with ctrl lock. 
Test Procedure:
 - restart VAP by enabling-disabling multiple times, connect-disconnect multiple clients 
Risks: medium
Priority: P1