### PR TITLE
RDKB-59288 Overall Memory usage is increasing continuously

### DIFF
--- a/source/apps/levl/wifi_levl.c
+++ b/source/apps/levl/wifi_levl.c
@@ -810,6 +810,7 @@ void push_radio_temperature_request_to_monitor_queue(wifi_mon_stats_request_stat
     data->u.mon_stats_config.data_type = mon_stats_type_radio_temperature;
     data->u.mon_stats_config.args.radio_index = radio_index;
     push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
+    free(data);
 }
 
 int webconfig_event_levl(wifi_app_t *apps, wifi_event_subtype_t sub_type, void *data)

--- a/source/apps/levl/wifi_levl.c
+++ b/source/apps/levl/wifi_levl.c
@@ -810,10 +810,7 @@ void push_radio_temperature_request_to_monitor_queue(wifi_mon_stats_request_stat
     data->u.mon_stats_config.data_type = mon_stats_type_radio_temperature;
     data->u.mon_stats_config.args.radio_index = radio_index;
     push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
-    if (data != NULL) {
-        free(data);
-        data = NULL;
-    }
+    free(data);
 }
 
 int webconfig_event_levl(wifi_app_t *apps, wifi_event_subtype_t sub_type, void *data)

--- a/source/apps/levl/wifi_levl.c
+++ b/source/apps/levl/wifi_levl.c
@@ -810,9 +810,9 @@ void push_radio_temperature_request_to_monitor_queue(wifi_mon_stats_request_stat
     data->u.mon_stats_config.data_type = mon_stats_type_radio_temperature;
     data->u.mon_stats_config.args.radio_index = radio_index;
     push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
-    if(data != NULL) {
-    free(data);
-    data = NULL;
+    if (data != NULL) {
+        free(data);
+        data = NULL;
     }
 }
 

--- a/source/apps/levl/wifi_levl.c
+++ b/source/apps/levl/wifi_levl.c
@@ -810,7 +810,10 @@ void push_radio_temperature_request_to_monitor_queue(wifi_mon_stats_request_stat
     data->u.mon_stats_config.data_type = mon_stats_type_radio_temperature;
     data->u.mon_stats_config.args.radio_index = radio_index;
     push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
+    if(data != NULL) {
     free(data);
+    data = NULL;
+    }
 }
 
 int webconfig_event_levl(wifi_app_t *apps, wifi_event_subtype_t sub_type, void *data)

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1322,11 +1322,12 @@ void process_disconnect(unsigned int ap_index, auth_deauth_dev_t *dev)
     t_tmp.tv_sec = sta->total_connected_time.tv_sec;
     t_tmp.tv_nsec = sta->total_connected_time.tv_nsec;
     timespecadd(&t_tmp, &t_diff, &(sta->total_connected_time));
-    if (sta->dev_stats.cli_Active = false && (tv_now.tv_sec - sta->assoc_frame_data.frame_timestamp > 5)) {
+    if (sta->dev_stats.cli_Active = false && (sta->total_connected_time.tv_sec == 0)) {
         tmp_sta = hash_map_remove(sta_map, sta_key);
         if (tmp_sta != NULL) {
-                free(tmp_sta);
-                tmp_sta = NULL;
+            free(tmp_sta);
+            tmp_sta = NULL;
+            return;
         }
     }
     sta->dev_stats.cli_Active = false;

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1291,7 +1291,7 @@ void process_connect(unsigned int ap_index, auth_deauth_dev_t *dev)
 void process_disconnect(unsigned int ap_index, auth_deauth_dev_t *dev)
 {
     sta_key_t sta_key;
-    sta_data_t *sta;
+    sta_data_t *sta, *tmp_sta;
     hash_map_t *sta_map;
     struct timespec tv_now, t_diff, t_tmp;
     instant_msmt_t msmt;
@@ -1323,6 +1323,13 @@ void process_disconnect(unsigned int ap_index, auth_deauth_dev_t *dev)
     t_tmp.tv_nsec = sta->total_connected_time.tv_nsec;
     timespecadd(&t_tmp, &t_diff, &(sta->total_connected_time));
     sta->dev_stats.cli_Active = false;
+    if (sta->dev_stats.cli_Active = false && (tv_now.tv_sec - sta->assoc_frame_data.frame_timestamp > 5)) {
+        tmp_sta = hash_map_remove(sta_map, sta_key);
+        if (tmp_sta != NULL) {
+                free(tmp_sta);
+                tmp_sta = NULL;
+        }
+    }
     sta->connection_authorized = false;
     if (!sta->deauth_monitor_start_time)
         sta->deauth_monitor_start_time = tv_now.tv_sec;

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1291,7 +1291,7 @@ void process_connect(unsigned int ap_index, auth_deauth_dev_t *dev)
 void process_disconnect(unsigned int ap_index, auth_deauth_dev_t *dev)
 {
     sta_key_t sta_key;
-    sta_data_t *sta, *tmp_sta;
+    sta_data_t *sta;
     hash_map_t *sta_map;
     struct timespec tv_now, t_diff, t_tmp;
     instant_msmt_t msmt;
@@ -1322,14 +1322,6 @@ void process_disconnect(unsigned int ap_index, auth_deauth_dev_t *dev)
     t_tmp.tv_sec = sta->total_connected_time.tv_sec;
     t_tmp.tv_nsec = sta->total_connected_time.tv_nsec;
     timespecadd(&t_tmp, &t_diff, &(sta->total_connected_time));
-    if (sta->dev_stats.cli_Active = false && (sta->total_connected_time.tv_sec == 0)) {
-        tmp_sta = hash_map_remove(sta_map, sta_key);
-        if (tmp_sta != NULL) {
-            free(tmp_sta);
-            tmp_sta = NULL;
-            return;
-        }
-    }
     sta->dev_stats.cli_Active = false;
     sta->connection_authorized = false;
     if (!sta->deauth_monitor_start_time)

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1322,7 +1322,6 @@ void process_disconnect(unsigned int ap_index, auth_deauth_dev_t *dev)
     t_tmp.tv_sec = sta->total_connected_time.tv_sec;
     t_tmp.tv_nsec = sta->total_connected_time.tv_nsec;
     timespecadd(&t_tmp, &t_diff, &(sta->total_connected_time));
-    sta->dev_stats.cli_Active = false;
     if (sta->dev_stats.cli_Active = false && (tv_now.tv_sec - sta->assoc_frame_data.frame_timestamp > 5)) {
         tmp_sta = hash_map_remove(sta_map, sta_key);
         if (tmp_sta != NULL) {
@@ -1330,6 +1329,7 @@ void process_disconnect(unsigned int ap_index, auth_deauth_dev_t *dev)
                 tmp_sta = NULL;
         }
     }
+    sta->dev_stats.cli_Active = false;
     sta->connection_authorized = false;
     if (!sta->deauth_monitor_start_time)
         sta->deauth_monitor_start_time = tv_now.tv_sec;


### PR DESCRIPTION
Reason for change: To free the allocated memory after its usage

Test Procedure: 
1. Flash the build in the issue device
2. Make sure Levl is enabled
3. Check for Memory Leak

Priority: P0

Risks: Low

Signed-off-by: Samyuktha Karthikeyan <samyuktha_karthikeyan@comcast.com>