### PR TITLE
RDKB-59209: EM App - Fix typo in EM_MAX_NEIGHBORS

### DIFF
--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -1704,7 +1704,7 @@ webconfig_error_t translate_channel_stats_to_easymesh_channel_info(webconfig_sub
         em_scan_result.aggr_scan_duration = 0;
         em_scan_result.scan_type = 0;
 
-        for (j = 0; j < src->num_neighbors && j < EM_MAX_NEIGHORS; j++) {
+        for (j = 0; j < src->num_neighbors && j < EM_MAX_NEIGHBORS; j++) {
             neighbor_bss_t *src_neighbor = &src->neighbors[j];
             em_neighbor_t *dst_neighbor = &em_scan_result.neighbor[j];
 


### PR DESCRIPTION
RDKB-59209: EM App - Fix typo in EM_MAX_NEIGHBORS

Reason for change: Fix typo in EM_MAX_NEIGHBORS
Test Procedure: Ensure channel scan results are received in agent side and then to controller cli upon request for channel scan.
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>