### PR TITLE
RDKB-55444: Majority of the WIFI Telemetry markers are not populating…

### DIFF
--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -2109,6 +2109,7 @@ static void config_associated_device_stats(wifi_monitor_data_t *data)
         //for each vap push the event to monitor queue
         for (vapArrayIndex = 0; vapArrayIndex < getNumberVAPsPerRadio(radio_index); vapArrayIndex++) {
             data->u.mon_stats_config.args.vap_index = wifi_mgr->radio_config[radio_index].vaps.rdk_vap_array[vapArrayIndex].vap_index;
+            data->u.mon_stats_config.args.radio_index = radio_index;
             if (!isVapSTAMesh(data->u.mon_stats_config.args.vap_index)) {
                 push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
             }


### PR DESCRIPTION
… in Eco mode

Reason for change: To populate the Telemetry markers that are missing in the Eco Mode.

Test Procedure:
1.Enable ECO mode using below commands
    dmcli eRT setv Device.WiFi.Radio.1.X_RDK_EcoPowerDown bool true
    dmcli eRT setv Device.WiFi.ApplyRadioSettings bool true
2.Connect WIFI clients in 5ghz
3.Check for WIFI Markers in /rdklogs/logs/wifihealth.txt

Priority: P2

Risks: Low