### PR TITLE
RDKB-59230: WPS enable value is true for CBRV2

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2553,7 +2553,13 @@ int wifidb_update_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
         cfg.bss_hotspot = config->u.bss_info.bssHotspot;
         cfg.wps_push_button = config->u.bss_info.wpsPushButton;
         cfg.wps_config_methods = config->u.bss_info.wps.methods;
+#if defined(_CBR2_PRODUCT_REQ_)
+        if(config->u.bss_info.wps.enable != false) {
+            cfg.wps_enabled = false;
+        }
+#else
         cfg.wps_enabled = config->u.bss_info.wps.enable;
+#endif /* _CBR2_PRODUCT_REQ_ */
         strncpy(cfg.beacon_rate_ctl,config->u.bss_info.beaconRateCtl,sizeof(cfg.beacon_rate_ctl)-1);
         strncpy(cfg.mfp_config,"Disabled",sizeof(cfg.mfp_config)-1);
         cfg.hostap_mgt_frame_ctrl = config->u.bss_info.hostap_mgt_frame_ctrl;
@@ -4487,7 +4493,7 @@ void wifidb_vap_config_correction(wifi_vap_info_map_t *l_vap_map_param)
         if (isVapPrivate(vap_config->vap_index) &&
             is_sec_mode_personal(vap_config->u.bss_info.security.mode)) {
             if (vap_config->u.bss_info.wps.enable == false) {
-#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_)
+#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_) && !defined(_CBR2_PRODUCT_REQ_)
                 vap_config->u.bss_info.wps.enable = true;
 
                 wifi_util_info_print(WIFI_DB, "%s:%d: force wps enabled for private_vap:%d\r\n",__func__, __LINE__, vap_config->vap_index);
@@ -6572,7 +6578,7 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.vapStatsEnable = true;
             cfg.u.bss_info.wpsPushButton = 0;
-#ifdef NEWPLATFORM_PORT
+#if defined(NEWPLATFORM_PORT) || defined(_CBR2_PRODUCT_REQ_)
             cfg.u.bss_info.wps.enable = false;
 #else
             cfg.u.bss_info.wps.enable = true;

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -11718,16 +11718,20 @@ WPS_SetParamBoolValue
     }
  
     /* check the parameter name and set the corresponding value */
-    if( AnscEqualString(ParamName, "Enable", TRUE))
-    {
-        if (vapInfo->u.bss_info.wps.enable == bValue)
-        {
-            return TRUE;
+    if (AnscEqualString(ParamName, "Enable", TRUE)) {
+#if defined(_CBR2_PRODUCT_REQ_)
+        wifi_util_info_print(WIFI_DMCLI, "%s:%d:WPS option is not supported for CBRV2\n", __func__,
+            __LINE__);
+        return FALSE;
+#else
+        if (vapInfo->u.bss_info.wps.enable != bValue) {
+            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d:key=%d bValue=%d  \n", __func__, __LINE__,
+                vapInfo->u.bss_info.wps.enable, bValue);
+            vapInfo->u.bss_info.wps.enable = bValue;
+            set_dml_cache_vap_config_changed(instance_number - 1);
         }
-	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d:key=%d bValue=%d  \n",__func__, __LINE__,vapInfo->u.bss_info.wps.enable,bValue);
-        vapInfo->u.bss_info.wps.enable = bValue;
-       set_dml_cache_vap_config_changed(instance_number - 1);
         return TRUE;
+#endif
     }
     if( AnscEqualString(ParamName, "X_CISCO_COM_ActivatePushButton", TRUE))
     {


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: WPS enable is defaulted to true in CBRv2, so the value being set to true.

Test Procedure:

Load the above mentioned build in CBRv2.
Check the value of the wps by,
dmcli eRT getv Device.WiFi.AccessPoint.1.WPS.Enable If the value is true , issue is repoduced.
Risks: Medium

Priority: P1

Signed-off-by:sanjayvenkatesan1902@gmail.com