### PR TITLE
RDKB-59277 : Push Station Manager code to WiFiStaManager repo.

### DIFF
--- a/build/linux/makefile
+++ b/build/linux/makefile
@@ -483,6 +483,9 @@ run:
 setup:
 	./build/linux/setup.sh
 
+stamgrsetup:
+	./build/linux/setup.sh stamgr
+
 vapsetup:
 	cp ./build/linux/MultiVap_InterfaceMap.json /nvram/InterfaceMap.json
 	cp ./build/linux/EasymeshCfg.json /nvram/EasymeshCfg.json

--- a/build/linux/setup.sh
+++ b/build/linux/setup.sh
@@ -10,7 +10,10 @@ STA_MGR_DIR="$(pwd)/../WiFiStaManager"
 cd ..
 git clone https://github.com/rdkcentral/rdk-wifi-hal.git rdk-wifi-hal
 git clone https://github.com/rdkcentral/rdkb-halif-wifi.git halinterface
-git clone -b 25Q2_sprint https://gerrit.teamccp.com/rdk/rdkb/components/opensource/ccsp/WiFiStaManager/generic WiFiStaManager
+
+if [ "$1" == "stamgr" ]; then
+		git clone -b 25Q2_sprint https://gerrit.teamccp.com/rdk/rdkb/components/opensource/ccsp/WiFiStaManager/generic WiFiStaManager
+fi
 
 cd $ONEWIFI_DIR
 mkdir -p install/bin


### PR DESCRIPTION
Reason for change: makefile change to make pulling staMgr code optional.
Test Procedure: Station manger code should checkout and build properly.
Risks: Low