### PR TITLE
RDKB-58944: set default mac filter mode configuration

### DIFF
--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -354,6 +354,7 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
             cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
         } else {
             cfg.u.bss_info.mac_filter_enable = false;
+            cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
         }
         cfg.u.bss_info.UAPSDEnabled = true;
         cfg.u.bss_info.wmmNoAck = false;

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -1246,11 +1246,11 @@ int macfilter_conversion(char *mac_list_type, size_t string_len,  wifi_vap_info_
             return RETURN_OK;
         } else if (strncmp(mac_list_type, "none", strlen("none")) == 0) {
             vap_info->u.bss_info.mac_filter_enable = FALSE;
-            vap_info->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_white_list;
+            vap_info->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
             return RETURN_OK;
         } else if (mac_list_type[0] == '\0') {
             vap_info->u.bss_info.mac_filter_enable = FALSE;
-            vap_info->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_white_list;
+            vap_info->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
             return RETURN_OK;
         }
     } else if (conv_type == ENUM_TO_STRING) {

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -872,6 +872,7 @@ webconfig_error_t translator_ovsdb_init(webconfig_subdoc_data_t *data)
         default_vap_info->u.bss_info.nbrReportActivated = false;
         default_vap_info->u.bss_info.rapidReconnThreshold = 180;
         default_vap_info->u.bss_info.mac_filter_enable = false;
+        default_vap_info->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
         default_vap_info->u.bss_info.UAPSDEnabled = true;
         default_vap_info->u.bss_info.wmmNoAck = false;
         default_vap_info->u.bss_info.wepKeyLength = 128;
@@ -939,6 +940,8 @@ webconfig_error_t translator_ovsdb_init(webconfig_subdoc_data_t *data)
                 default_vap_info->u.bss_info.security.encr = wifi_encryption_aes;
                 default_vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_required;
             }
+            default_vap_info->u.bss_info.mac_filter_enable = true;
+            default_vap_info->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_white_list;
         } else if(is_vap_lnf_radius(&hal_cap->wifi_prop, vapIndex) == TRUE) {
             strcpy(default_vap_info->u.bss_info.security.u.radius.identity, "lnf_radius_identity");
             default_vap_info->u.bss_info.security.u.radius.port = 1812;


### PR DESCRIPTION
Reason for change: different mac filter mode triggers vap reconfiguration 
Test Procedure:
  Check SSID is not reset to default after FR and SSID configuration.
Risks: Low
Priority: P1