### PR TITLE
RDKB-57830: [OneWifi] HE bus command error code handling

### DIFF
--- a/source/platform/linux/he_bus/inc/he_bus_common.h
+++ b/source/platform/linux/he_bus/inc/he_bus_common.h
@@ -211,6 +211,7 @@ typedef struct he_bus_data_object {
     he_bus_name_string_t name;
     he_bus_msg_sub_type_t msg_sub_type;
     bool is_data_set;
+    he_bus_error_t status;
     he_bus_raw_data_t data;
     struct he_bus_data_object *next_data;
 } he_bus_data_object_t;

--- a/source/platform/linux/he_bus/inc/he_bus_data_conversion.h
+++ b/source/platform/linux/he_bus/inc/he_bus_data_conversion.h
@@ -42,7 +42,7 @@ he_bus_error_t handle_bus_msg_data(he_bus_handle_t handle, int fd,
     he_bus_raw_data_msg_t *p_msg_data, he_bus_raw_data_msg_t *p_res_data);
 
 uint32_t set_bus_object_data(char *event_name, he_bus_data_object_t *p_obj_data,
-    he_bus_msg_sub_type_t msg_sub_type, he_bus_raw_data_t *cfg_data);
+    he_bus_msg_sub_type_t msg_sub_type, he_bus_raw_data_t *cfg_data, he_bus_error_t ret_status);
 
 he_bus_error_t validate_sub_response(he_bus_event_sub_t *sub_data_map,
     he_bus_raw_data_msg_t *recv_data);
@@ -50,7 +50,7 @@ he_bus_error_t prepare_initial_bus_header(he_bus_raw_data_msg_t *p_data, char *c
     he_bus_msg_type_t msg_type);
 he_bus_error_t prepare_rem_payload_bus_msg_data(char *event_name,
     he_bus_raw_data_msg_t *p_base_hdr_data, he_bus_msg_sub_type_t msg_sub_type,
-    he_bus_raw_data_t *payload_data);
+    he_bus_raw_data_t *payload_data, he_bus_error_t ret_status);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Reason for change: HE bus command error code handle properly. Test Procedure: 1) Load OneWifi code on RPI.
                2) Start easy mesh agent code.
                3) Check HE bus get/set/sub/publish
                   is working properly.

Risks: Low
Priority: P1

Change-Id: Ib2866ecf273d97274ebe5ef08a4f83c6eddf6b0f Signed-off-by: apatel599@cable.comcast.com
(cherry picked from commit fa8619e6c810dfb652a452fc759500e8392e608c)