### PR TITLE
RDKB-59288 Overall Memory usage is increasing continuously

### DIFF
--- a/source/apps/levl/wifi_levl.c
+++ b/source/apps/levl/wifi_levl.c
@@ -810,6 +810,7 @@ void push_radio_temperature_request_to_monitor_queue(wifi_mon_stats_request_stat
     data->u.mon_stats_config.data_type = mon_stats_type_radio_temperature;
     data->u.mon_stats_config.args.radio_index = radio_index;
     push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
+    free(data);
 }
 
 int webconfig_event_levl(wifi_app_t *apps, wifi_event_subtype_t sub_type, void *data)

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -2109,6 +2109,7 @@ static void config_associated_device_stats(wifi_monitor_data_t *data)
         //for each vap push the event to monitor queue
         for (vapArrayIndex = 0; vapArrayIndex < getNumberVAPsPerRadio(radio_index); vapArrayIndex++) {
             data->u.mon_stats_config.args.vap_index = wifi_mgr->radio_config[radio_index].vaps.rdk_vap_array[vapArrayIndex].vap_index;
+            data->u.mon_stats_config.args.radio_index = radio_index;
             if (!isVapSTAMesh(data->u.mon_stats_config.args.vap_index)) {
                 push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
             }


### PR DESCRIPTION
Reason for change: To free the allocated memory after its usage

Test Procedure:

1.Flash the build in the issue device
2.Make sure Levl is enabled
3.Check for Memory Leak

Priority: P0

Risks: Low

Signed-off-by: Samyuktha Karthikeyan samyuktha_karthikeyan@comcast.com