### PR TITLE
RDKB-58000 : Adding debugs for sample interval reconfiguration

### DIFF
--- a/source/apps/sm/sm_utils.c
+++ b/source/apps/sm/sm_utils.c
@@ -45,6 +45,16 @@ static const survey_type_to_dpp_scan_type_t scan_type_mapping[] = {
     {survey_type_off_channel, WIFI_RADIO_SCAN_MODE_OFFCHAN, RADIO_SCAN_TYPE_OFFCHAN, "off_channel"},
 };
 
+typedef struct {
+    stats_type_t stats_type;
+    char *description;
+} stats_type_to_str_t;
+
+static const stats_type_to_str_t stats_type_mapping[] = {
+    { stats_type_neighbor, "neighbor" },
+    { stats_type_survey,   "survey"   },
+    { stats_type_client,   "client"   },
+};
 
 #define NOISE_FLOOR (-95)
 
@@ -145,6 +155,16 @@ radio_scan_type_t neighbor_scan_mode_to_dpp_scan_type(wifi_neighborScanMode_t sc
     return RADIO_SCAN_TYPE_NONE;
 }
 
+char* stats_type_to_str(stats_type_t stats_type)
+{
+    for (size_t i = 0; i < ARRAY_SIZE(stats_type_mapping); i++) {
+        if (stats_type == stats_type_mapping[i].stats_type) {
+            return stats_type_mapping[i].description;
+        }
+    }
+    wifi_util_error_print(WIFI_SM, "%s:%d failed to convert stats_type=%d\n",__func__, __LINE__, stats_type);
+    return "unknown";
+}
 
 char* survey_type_to_str(survey_type_t survey_type)
 {

--- a/source/apps/sm/sm_utils.h
+++ b/source/apps/sm/sm_utils.h
@@ -64,6 +64,7 @@ extern "C" {
 radio_type_t freq_band_to_dpp_radio_type(wifi_freq_bands_t freq_band);
 report_type_t reporting_type_to_dpp_report_type(reporting_type_t report_type);
 radio_scan_type_t survey_type_to_dpp_scan_type(survey_type_t survey_type);
+char* stats_type_to_str(stats_type_t stats_type);
 char* survey_type_to_str(survey_type_t survey_type);
 char* neighbor_scan_mode_to_str(wifi_neighborScanMode_t scan_mode);
 radio_chanwidth_t str_to_dpp_chan_width(char *str);

--- a/source/apps/sm/wifi_sm.c
+++ b/source/apps/sm/wifi_sm.c
@@ -614,13 +614,13 @@ int handle_sm_webconfig_event(wifi_app_t *app, wifi_event_t *event)
     bool off_scan_rfc = g_wifi_mgr->rfc_dml_parameters.wifi_offchannelscan_sm_rfc;
     webconfig_subdoc_data_t *webconfig_data = NULL;
     if (event == NULL) {
-        wifi_util_dbg_print(WIFI_SM,"%s %d input arguements are NULL\n", __func__, __LINE__);
+        wifi_util_dbg_print(WIFI_SM, "%s %d input arguements are NULL\n", __func__, __LINE__);
         return RETURN_ERR;
     }
 
     webconfig_data = event->u.webconfig_data;
     if (webconfig_data == NULL) {
-        wifi_util_dbg_print(WIFI_SM,"%s %d webconfig_data is NULL\n", __func__, __LINE__);
+        wifi_util_dbg_print(WIFI_SM, "%s %d webconfig_data is NULL\n", __func__, __LINE__);
         return RETURN_ERR;
     }
 
@@ -628,31 +628,37 @@ int handle_sm_webconfig_event(wifi_app_t *app, wifi_event_t *event)
         return RETURN_ERR;
     }
 
-
     hash_map_t *new_ctrl_stats_cfg_map = webconfig_data->u.decoded.stats_config_map;
     hash_map_t *cur_app_stats_cfg_map = app->data.u.sm_data.sm_stats_config_map;
     stats_config_t *cur_stats_cfg, *new_stats_cfg, *tmp_stats_cfg;
     stats_config_t *temp_stats_config;
-    char key[64] = {0};
+    char key[64] = { 0 };
 
     if (new_ctrl_stats_cfg_map == NULL) {
-        wifi_util_dbg_print(WIFI_SM,"%s %d input ctrl stats map is null, Nothing to update\n", __func__, __LINE__);
+        wifi_util_dbg_print(WIFI_SM, "%s %d input ctrl stats map is null, Nothing to update\n",
+            __func__, __LINE__);
         return RETURN_ERR;
     }
 
-    //update neigbour sampling_interval to survey interval if value is 0
+    // update neigbour sampling_interval to survey interval if value is 0
     new_stats_cfg = hash_map_get_first(new_ctrl_stats_cfg_map);
     while (new_stats_cfg != NULL) {
-        if (new_stats_cfg->stats_type == stats_type_neighbor && new_stats_cfg->sampling_interval == 0 ) {
-            //search survey configuration.
+        if (new_stats_cfg->stats_type == stats_type_neighbor &&
+            new_stats_cfg->sampling_interval == 0) {
+            // search survey configuration.
             tmp_stats_cfg = hash_map_get_first(new_ctrl_stats_cfg_map);
             while (tmp_stats_cfg != NULL) {
-                if (tmp_stats_cfg->stats_type == stats_type_survey && tmp_stats_cfg->radio_type == new_stats_cfg->radio_type
-                    && tmp_stats_cfg->survey_type == new_stats_cfg->survey_type && tmp_stats_cfg->sampling_interval != 0) {
-                        new_stats_cfg->sampling_interval = tmp_stats_cfg->sampling_interval;
-                        wifi_util_dbg_print(WIFI_SM,"%s %d update sampling_interval for neighbor stats_type_neighbor(radio_type %d, survey_type %d) to %u\n", __func__, __LINE__,
-                                        new_stats_cfg->radio_type, new_stats_cfg->survey_type, new_stats_cfg->sampling_interval);
-                        break;
+                if (tmp_stats_cfg->stats_type == stats_type_survey &&
+                    tmp_stats_cfg->radio_type == new_stats_cfg->radio_type &&
+                    tmp_stats_cfg->survey_type == new_stats_cfg->survey_type &&
+                    tmp_stats_cfg->sampling_interval != 0) {
+                    new_stats_cfg->sampling_interval = tmp_stats_cfg->sampling_interval;
+                    wifi_util_dbg_print(WIFI_SM,
+                        "%s %d update sampling_interval for neighbor "
+                        "stats_type_neighbor(radio_type %d, survey_type %d) to %u\n",
+                        __func__, __LINE__, new_stats_cfg->radio_type, new_stats_cfg->survey_type,
+                        new_stats_cfg->sampling_interval);
+                    break;
                 }
                 tmp_stats_cfg = hash_map_get_next(new_ctrl_stats_cfg_map, tmp_stats_cfg);
             }
@@ -660,25 +666,25 @@ int handle_sm_webconfig_event(wifi_app_t *app, wifi_event_t *event)
         new_stats_cfg = hash_map_get_next(new_ctrl_stats_cfg_map, new_stats_cfg);
     }
 
-    //search for the deleted elements if any in new_ctrl_stats_cfg
+    // search for the deleted elements if any in new_ctrl_stats_cfg
     if (cur_app_stats_cfg_map != NULL) {
         cur_stats_cfg = hash_map_get_first(cur_app_stats_cfg_map);
         while (cur_stats_cfg != NULL) {
             if (hash_map_get(new_ctrl_stats_cfg_map, cur_stats_cfg->stats_cfg_id) == NULL) {
-                //send the delete and remove elem from cur_stats_cfg
+                // send the delete and remove elem from cur_stats_cfg
                 memset(key, 0, sizeof(key));
                 snprintf(key, sizeof(key), "%s", cur_stats_cfg->stats_cfg_id);
-                push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_stop, cur_stats_cfg);
+                push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_stop,
+                    cur_stats_cfg);
                 cur_stats_cfg = hash_map_get_next(cur_app_stats_cfg_map, cur_stats_cfg);
 
-                //Temporary removal, need to uncomment it
+                // Temporary removal, need to uncomment it
                 temp_stats_config = hash_map_remove(cur_app_stats_cfg_map, key);
                 if (temp_stats_config != NULL) {
                     free(temp_stats_config);
                 }
             } else {
                 cur_stats_cfg = hash_map_get_next(cur_app_stats_cfg_map, cur_stats_cfg);
-
             }
         }
     }
@@ -691,27 +697,46 @@ int handle_sm_webconfig_event(wifi_app_t *app, wifi_event_t *event)
             if (cur_stats_cfg == NULL) {
                 cur_stats_cfg = (stats_config_t *)malloc(sizeof(stats_config_t));
                 if (cur_stats_cfg == NULL) {
-                    wifi_util_error_print(WIFI_SM,"%s %d NULL pointer \n", __func__, __LINE__);
+                    wifi_util_error_print(WIFI_SM, "%s %d NULL pointer \n", __func__, __LINE__);
                     return RETURN_ERR;
                 }
                 memset(cur_stats_cfg, 0, sizeof(stats_config_t));
                 memcpy(cur_stats_cfg, new_stats_cfg, sizeof(stats_config_t));
-                hash_map_put(cur_app_stats_cfg_map, strdup(cur_stats_cfg->stats_cfg_id), cur_stats_cfg);
-                //Notification for new entry.
-                if(!(!off_scan_rfc && cur_stats_cfg->survey_type == survey_type_off_channel && ( cur_stats_cfg->radio_type == WIFI_FREQUENCY_5_BAND || cur_stats_cfg->radio_type == WIFI_FREQUENCY_5L_BAND || cur_stats_cfg->radio_type == WIFI_FREQUENCY_5H_BAND ))) {
-                     push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_start, cur_stats_cfg);
+                hash_map_put(cur_app_stats_cfg_map, strdup(cur_stats_cfg->stats_cfg_id),
+                    cur_stats_cfg);
+                // Notification for new entry.
+                if (!(!off_scan_rfc && cur_stats_cfg->survey_type == survey_type_off_channel &&
+                        (cur_stats_cfg->radio_type == WIFI_FREQUENCY_5_BAND ||
+                            cur_stats_cfg->radio_type == WIFI_FREQUENCY_5L_BAND ||
+                            cur_stats_cfg->radio_type == WIFI_FREQUENCY_5H_BAND))) {
+                    push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_start,
+                        cur_stats_cfg);
                 }
             } else {
                 if (memcmp(cur_stats_cfg, new_stats_cfg, sizeof(stats_config_t)) != 0) {
+                    if (new_stats_cfg->sampling_interval != cur_stats_cfg->sampling_interval) {
+                        radio_type_t radio_type = freq_band_to_dpp_radio_type(
+                            new_stats_cfg->radio_type);
+                        wifi_util_error_print(WIFI_SM,
+                            "%s %d Reconfigured sampling interval as %u secs for %s stats type of "
+                            "%s radio\n",
+                            __func__, __LINE__, new_stats_cfg->sampling_interval,
+                            stats_type_to_str(new_stats_cfg->stats_type),
+                            radio_get_name_from_type(radio_type));
+                    }
                     memcpy(cur_stats_cfg, new_stats_cfg, sizeof(stats_config_t));
-                    if(!off_scan_rfc && cur_stats_cfg->survey_type == survey_type_off_channel && ( cur_stats_cfg->radio_type == WIFI_FREQUENCY_5_BAND || cur_stats_cfg->radio_type == WIFI_FREQUENCY_5L_BAND || cur_stats_cfg->radio_type == WIFI_FREQUENCY_5H_BAND )) {
-                        if (is_scan_scheduled(app,cur_stats_cfg))
-                        {
-                            push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_stop, cur_stats_cfg);
+                    if (!off_scan_rfc && cur_stats_cfg->survey_type == survey_type_off_channel &&
+                        (cur_stats_cfg->radio_type == WIFI_FREQUENCY_5_BAND ||
+                            cur_stats_cfg->radio_type == WIFI_FREQUENCY_5L_BAND ||
+                            cur_stats_cfg->radio_type == WIFI_FREQUENCY_5H_BAND)) {
+                        if (is_scan_scheduled(app, cur_stats_cfg)) {
+                            push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_stop,
+                                cur_stats_cfg);
                         }
                     } else {
-                        //Notification for update entry.
-                        push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_start, cur_stats_cfg);
+                        // Notification for update entry.
+                        push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_start,
+                            cur_stats_cfg);
                     }
                 }
             }


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms

Reason for change: No existing prints for sample interval reconfiguration.

Test Procedure:

Load the device with the above mentioned build.
Enable the SM App.
Verify the NOC push table with ovsh s Wifi_Stats_Config. Change the sampling interval of any stats type and check the logs in /tmp/wifiSM.
Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com