### PR TITLE
RDKBACCL-716 : onewifi is not up and running if extra_oemake=--enable-em-app enabled

### DIFF
--- a/source/webconfig/Makefile.am
+++ b/source/webconfig/Makefile.am
@@ -72,6 +72,7 @@ libwifi_webconfig_la_SOURCES = wifi_webconfig.c wifi_encoder.c wifi_decoder.c wi
 
 if EM_APP_SUPPORT
 libwifi_webconfig_la_SOURCES += wifi_webconfig_em_channel_stats.c wifi_webconfig_em_sta_link_metrics.c
+libwifi_webconfig_la_CFLAGS += $(EM_APP_FLAG)
 endif
 
 if WITH_EASYMESH


### PR DESCRIPTION
Reason for change: This varaiable "EM_APP_FLAG" needs to be added in cflag if we enabled EM_APP_SUPPORT in libwebconfig Makefiles. 
Test Procedure: No core is forming
Risks: Low
Signed-off-by: keerthana.p <keerthana_pandurangan@comcast.com>