### PR TITLE
RDKB-59404: OpenWRT related OneWifi additional change

### DIFF
--- a/build/openwrt/makefile
+++ b/build/openwrt/makefile
@@ -393,7 +393,8 @@ ifdef EM_APP
 	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/em/*.c)
 	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_easymesh_config.c    \
                 $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_beacon_report.c  \
-                $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_em_channel_stats.c
+                $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_em_channel_stats.c \
+                $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_em_sta_link_metrics.c
 endif
 
 COBJECTS = $(CSOURCES:.c=.o)  # expands to list of object files


### PR DESCRIPTION
Reason for change: Adding in the openwrt makefile new file related to link metrics change.
Risks: Low
Test Procedure: Tested on BPI openWRT with 4Address usecase