### PR TITLE
RDKB-59512: Easymesh - Mesh BackHaul changes for colocated agent

### DIFF
--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -348,7 +348,7 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg.u.bss_info.rapidReconnThreshold = 180;
         if (isVapMeshBackhaul(vap_index)) {
             cfg.u.bss_info.mac_filter_enable = true;
-            cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_white_list;
+            cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
         } else if (isVapHotspot(vap_index)) {
             cfg.u.bss_info.mac_filter_enable = true;
             cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -348,6 +348,8 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg.u.bss_info.rapidReconnThreshold = 180;
         if (isVapMeshBackhaul(vap_index)) {
             cfg.u.bss_info.mac_filter_enable = true;
+            //TBD: Changing to blacklist is a temporary change. This needs to
+            //be updated appropriately to configure connecting sta as part of whitelist.
             cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
         } else if (isVapHotspot(vap_index)) {
             cfg.u.bss_info.mac_filter_enable = true;


### PR DESCRIPTION
RDKB-59512: Easymesh - Mesh BackHaul changes for colocated agent

Reason for change: To allow client connection in mesh_backhaul mac_filter_mode is changed to wifi_mac_filter_mode_black_list
Test Procedure: In colocated mode, if there is single vap at al mac address, ensure it is configured as mesh_backhaul
Risks: Medium
Priority: P1