### PR TITLE
Update wifi_db.c

### DIFF
--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -426,11 +426,18 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         } else {
             cfg.u.bss_info.showSsid = false;
         }
-        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index) ||
+/*For XER5/XB10/XER10 2.4G XHS is disable by default*/
+#if defined(_XER5_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+        if ((isVapLnf(vap_index) || isVapPrivate(vap_index) ||
             isVapMeshBackhaul(vap_index) || isVapXhs(vap_index)) {
             cfg.u.bss_info.enabled = true;
         }
-
+#else
+        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index) || 
+            isVapMeshBackhaul(vap_index) || isVapXhs(vap_index)) {
+            cfg.u.bss_info.enabled = true;
+        }
+#endif 
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
         } else {


### PR DESCRIPTION
RDKB-58922: [XHS] - After FR - 2.4Ghz XHS SSID is enabled by default

Reason for change:Change wifi db to default values set disable Test Procedure: upon FR xhs should be disabled
Risks: Low
Priority: P1
Signed-off-by:rishi_sharma2@comcast.com