### PR TITLE
RDKBWIFI-34: Enable/implement mesh backhaul sta translations

### DIFF
--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -804,7 +804,7 @@ webconfig_error_t translate_sta_info_to_em_common(const wifi_vap_info_t *vap, co
 
     if ((vap_row == NULL) || (vap == NULL)) {
         wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: input argument is NULL\n", __func__, __LINE__);
-        return webconfig_error_translate_from_easymesh;
+        return webconfig_error_translate_to_easymesh;
     }
     default_em_bss_info(vap_row);
 
@@ -825,7 +825,7 @@ webconfig_error_t translate_sta_info_to_em_common(const wifi_vap_info_t *vap, co
                 sizeof(vap_row->fronthaul_akm[1]), ENUM_TO_STRING, &len) != RETURN_OK) {
 
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d failed top convert key mgmt: "
-                "security mode 0x%x\n", __func__, __LINE__, vap->u.bss_info.security.mode);
+                "security mode 0x%x\n", __func__, __LINE__, vap->u.sta_info.security.mode);
     }
     vap_row->num_fronthaul_akms = len;
     // Set backhaul AKMs to empty
@@ -834,10 +834,10 @@ webconfig_error_t translate_sta_info_to_em_common(const wifi_vap_info_t *vap, co
         vap_row->backhaul_akm[i][0] = '\0';
     }
 
-    /*
-    Copy Passphrase
-    strncpy(vap_row->mesh_sta_passphrase, vap->u.bss_info.security.u.key.key, sizeof(vap_row->mesh_sta_passphrase));
-    */
+    
+    //Copy Passphrase
+    strncpy(vap_row->mesh_sta_passphrase, vap->u.sta_info.security.u.key.key, sizeof(vap_row->mesh_sta_passphrase));
+    
     // Find the radio interface map
     for (k = 0; k < (sizeof(wifi_prop->radio_interface_map)/sizeof(radio_interface_mapping_t)); k++) {
         if (wifi_prop->radio_interface_map[k].radio_index == vap->radio_index) {
@@ -1445,14 +1445,14 @@ webconfig_error_t translate_em_common_to_sta_info_common(wifi_vap_info_t *vap, c
                                STRING_TO_ENUM, &len) != RETURN_OK) {
 
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d failed top convert key mgmt: "
-                "security mode 0x%x\n", __func__, __LINE__, vap->u.bss_info.security.mode);
+                "security mode 0x%x\n", __func__, __LINE__, vap->u.sta_info.security.mode);
     }
 
     vap->u.sta_info.security.mode = enum_sec;
-    /*
-    Copy Passphrase
-    strncpy(vap->u.bss_info.security.u.key.key, vap_row->mesh_sta_passphrase, sizeof(vap->u.bss_info.security.u.key.key));
-    */
+    
+    //Copy Passphrase
+    strncpy(vap->u.sta_info.security.u.key.key, vap_row->mesh_sta_passphrase, sizeof(vap->u.sta_info.security.u.key.key));
+    
     return webconfig_error_none;
 }
 // translate_em_bss_to_private_vap_info() em_bss_info_t data elements of wifi_vap_info_t of Onewifi for private vaps

--- a/source/webconfig/wifi_webconfig_mesh_backhaul_sta.c
+++ b/source/webconfig/wifi_webconfig_mesh_backhaul_sta.c
@@ -49,9 +49,15 @@ webconfig_error_t access_check_mesh_backhaul_sta_subdoc(webconfig_t *config, web
 
 webconfig_error_t translate_from_mesh_backhaul_sta_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data)
 {
-    if ((data->descriptor & webconfig_data_descriptor_translate_to_ovsdb) == webconfig_data_descriptor_translate_to_ovsdb) {
+    if (((data->descriptor & webconfig_data_descriptor_translate_to_ovsdb) == webconfig_data_descriptor_translate_to_ovsdb)
+        ||  ((data->descriptor & webconfig_data_descriptor_translate_to_easymesh) == webconfig_data_descriptor_translate_to_easymesh)) {
+
         if (config->proto_desc.translate_to(webconfig_subdoc_type_mesh_backhaul_sta, data) != webconfig_error_none) {
-            return webconfig_error_translate_to_ovsdb;
+            if ((data->descriptor & webconfig_data_descriptor_translate_to_ovsdb) == webconfig_data_descriptor_translate_to_ovsdb) {
+                return webconfig_error_translate_to_ovsdb;
+            } else {
+                return webconfig_error_translate_to_easymesh;
+            }
         }
     } else if ((data->descriptor & webconfig_data_descriptor_translate_to_tr181) == webconfig_data_descriptor_translate_to_tr181) {
 
@@ -63,13 +69,18 @@ webconfig_error_t translate_from_mesh_backhaul_sta_subdoc(webconfig_t *config, w
 
 webconfig_error_t translate_to_mesh_backhaul_sta_subdoc(webconfig_t *config, webconfig_subdoc_data_t *data)
 {
-    if ((data->descriptor & webconfig_data_descriptor_translate_from_ovsdb) == webconfig_data_descriptor_translate_from_ovsdb) {
+    if (((data->descriptor & webconfig_data_descriptor_translate_from_ovsdb) == webconfig_data_descriptor_translate_from_ovsdb)
+        ||  ((data->descriptor & webconfig_data_descriptor_translate_from_easymesh) == webconfig_data_descriptor_translate_from_easymesh)) {
         if (config->proto_desc.translate_from(webconfig_subdoc_type_mesh_backhaul_sta, data) != webconfig_error_none) {
-            return webconfig_error_translate_from_ovsdb;
+            if ((data->descriptor & webconfig_data_descriptor_translate_from_ovsdb) == webconfig_data_descriptor_translate_from_ovsdb) {
+                return webconfig_error_translate_from_ovsdb;
+            } else {
+                return webconfig_error_translate_from_easymesh;
+            }
         }
     } else if ((data->descriptor & webconfig_data_descriptor_translate_from_tr181) == webconfig_data_descriptor_translate_from_tr181) {
-
     } else {
+
         // no translation required
     }
     return webconfig_error_none;


### PR DESCRIPTION
**Reason for change:** No method currently exists to **programmatically** connect a backhaul STA to a BSS from outside of OneWifi. By translating the mesh_backhaul_sta type (with a different BSSID), the `webconfig_send_sta_bssid_change_event` will be triggered, allowing the `services` state machine to begin associating the backhaul STA to the specified BSS. 
**Test Procedure:** Change the SSID, Password, and (most importantly to trigger the event) the BSSID in the `em_bss_info_t` struct and encode/update/apply it. OneWifi will take it and begin the state machine, associating to the given BSS.
**Risks:** None.
**Priority: P1**

**Depends on [**unified-wifi-mesh PR #329**](https://github.com/rdkcentral/unified-wifi-mesh/pull/329)**

**Packet capture of association with UWM backhaul AP**
![PCAP](https://github.com/user-attachments/assets/bc4e0aaa-e3ee-4672-9857-d07b5e47c2b0)

**Associated to a non-UWM AP with WPA2-PSK encryption.**
```
[~]$ iw dev
phy#1
	Interface wlan1
		ifindex 4
		wdev 0x100000001
		addr 94:18:65:5c:e7:ac
		ssid HomeNetwork
		type managed
		channel 11 (2462 MHz), width: 40 MHz, center1: 2452 MHz
		txpower 3.00 dBm
		multicast TXQ:
			qsz-byt	qsz-pkt	flows	drops	marks	overlmt	hashcol	tx-bytes	tx-packets
			0	0	0	0	0	0	0	0		0
phy#0
	Interface wlan0
		ifindex 3
		wdev 0x1
		addr d8:3a:dd:74:f3:92
		type AP
		channel 34 (5170 MHz), width: 20 MHz, center1: 5170 MHz
		txpower 31.00 dBm
```
@amarnathhullur @vivianecordeiro-sky @gsathish86 @narendradandu 
