### PR TITLE
RDKB-59476 WPA3-Compatibility is not Persisting on reboot (#275)

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2195,7 +2195,7 @@ int wifidb_get_wifi_security_config(char *vap_name, wifi_vap_security_t *sec)
         sec->encr = wifi_encryption_aes;
         wifi_util_error_print(WIFI_DB, "%s:%d Invalid Security mode for 6G %d\n", __func__, __LINE__, pcfg->security_mode);
     } else {
-        sec->mode = pcfg->security_mode;
+        sec->mode = (pcfg->security_mode_new == WPA3_COMPATIBILITY) ? pcfg->security_mode_new : pcfg->security_mode;
         sec->encr = pcfg->encryption_method;
     }
 


### PR DESCRIPTION
Update new security mode after reboot

Impacted Platforms:
XB7, XB8, XB10

Reason for change: WPA3-Personal-Compatibility is not persisting reboot

Test Procedure: Set security mode to WPA3-Personal-Compatibility. Reboot the device and check if the configurations persists.

Risks: Low
Priority:P1
Signed-off-by:Amalesh_Nandh@comcast.com