### PR TITLE
RDKBWIFI-35: Add steady state to mesh service to disrupt constant disconnected scanning

### DIFF
--- a/include/wifi_events.h
+++ b/include/wifi_events.h
@@ -157,6 +157,7 @@ typedef enum {
     wifi_event_type_tcm_rfc,
     wifi_event_type_send_action_frame,
     wifi_event_type_start_channel_scan,
+    wifi_event_type_toggle_disconn_steady_state,
     wifi_event_type_rsn_override_rfc,
     wifi_event_type_sta_client_info,
     wifi_event_command_max,

--- a/source/apps/em/wifi_em.h
+++ b/source/apps/em/wifi_em.h
@@ -29,6 +29,8 @@ extern "C" {
 #define WIFI_EM_BEACON_REPORT                 "Device.WiFi.EM.BeaconReport"
 #define WIFI_EM_STA_LINK_METRICS_REPORT       "Device.WiFi.EM.STALinkMetricsReport"
 #define WIFI_EM_ASSOCIATION_STATUS            "Device.WiFi.EM.AssociationStatus"
+#define WIFI_SET_DISCONN_STEADY_STATE         "Device.WiFi.EM.SetDisconnSteadyState"
+#define WIFI_SET_DISCONN_SCAN_NONE_STATE      "Device.WiFi.EM.SetDisconnScanNoneState"
 
 typedef struct wifi_app wifi_app_t;
 

--- a/source/core/services/vap_svc.h
+++ b/source/core/services/vap_svc.h
@@ -81,6 +81,7 @@ typedef enum {
     connection_state_disconnected_scan_list_none,
     connection_state_disconnected_scan_list_in_progress,
     connection_state_disconnected_scan_list_all,
+    connection_state_disconnected_steady,
     connection_state_connection_in_progress,
     connection_state_connection_to_lcb_in_progress,
     connection_state_connection_to_nb_in_progress,

--- a/source/core/services/vap_svc_mesh_ext.c
+++ b/source/core/services/vap_svc_mesh_ext.c
@@ -197,6 +197,8 @@ static char *ext_conn_state_to_str(connection_state_t conn_state)
         return "disconnected_scan_list_in_progress";
     case connection_state_disconnected_scan_list_all:
         return "disconnected_scan_list_all";
+    case connection_state_disconnected_steady:
+        return "disconnected_steady";
     case connection_state_connection_in_progress:
         return "connection_in_progress";
     case connection_state_connection_to_lcb_in_progress:
@@ -215,7 +217,7 @@ static char *ext_conn_state_to_str(connection_state_t conn_state)
         break;
     }
 
-    return "udefined state";
+    return "undefined state";
 }
 
 static char *ext_conn_status_to_str(wifi_connection_status_t status)
@@ -821,6 +823,10 @@ int process_ext_connect_algorithm(vap_svc_t *svc)
     ext->ext_connect_algo_processor_id = 0;
 
     switch (ext->conn_state) {
+        case connection_state_disconnected_steady:
+            // Don't scan, don't attempt connection, just do nothing
+            wifi_util_dbg_print(WIFI_CTRL, "%s:%d disconnected steady state\n", __func__, __LINE__);
+            break;
         case connection_state_disconnected_scan_list_none:
             ext_start_scan(svc);
             break;


### PR DESCRIPTION
Adds a new `connection_state_disconnected_steady` state to temporarily disrupt scanning during disconnection. Additionally adds EasyMesh add bus methods to set this state (if disconnected) and to kick back to the base `connection_state_disconnected_scan_list_none` state.

**Reason for change:** The constant scanning can cause action frames to not be sent or received sporadically. This allows the scanning state machine to be disrupted while other things (like the sending of action frames) occur. The disconnected scanning state machine can be initiated again later.

**Test Procedure:** Start OneWifi with no BSS for it to connect to (in the current version `/nvram/EasymeshCfg.json` must include which are empty strings). Then call `"Device.WiFi.EM.SetDisconnSteadyState"` and see in the debug `wifiCtrl` logs that it no longer actively scans. Later call `"Device.WiFi.EM.SetDisconnScanNoneState"` to see scanning resume.

**Risks:** Low

Risks are low because:
1. This steady state must be manually triggered, it cannot occur naturally
2. There are numerous scenarios where state machine can be kicked out of the steady state without user interaction so permanent stalling is not an issue.
3. The only methods to set the steady state are in the EasyMesh app which must be compile separately.

**Priority:** P1
@amarnathhullur @vivianecordeiro-sky @gsathish86 @narendradandu 