### PR TITLE
RDKB-59556: 6 GHz radio configurations not working in EasyMesh

### DIFF
--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -410,7 +410,7 @@ webconfig_error_t translate_radio_object_to_easymesh_for_dml(webconfig_subdoc_da
             em_radio_info->band = 0;
         } else if (oper_param->band == WIFI_FREQUENCY_5_BAND) {
             em_radio_info->band = 1;
-        } else if (oper_param->band == WIFI_FREQUENCY_60_BAND) {
+        } else if (oper_param->band == WIFI_FREQUENCY_6_BAND) {
             em_radio_info->band = 2;
         }
         radio_iface_map = NULL;


### PR DESCRIPTION
RDKB-59556: 6 GHz radio configurations not working in EasyMesh

Reason for change: Fix the translation code for 6GHz band by changing WIFI_FREQUENCY_60_BAND to WIFI_FREQUENCY_6_BAND
Test Procedure: Ensure 6 GHz radio is configured as expected.
Risks: Medium
Priority: P1