### PR TITLE
Removing 11b support for 2.4GHz

### DIFF
--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -4214,7 +4214,22 @@ Radio_SetParamStringValue
         }
 
         // TODO: for debug purpouses only
+#ifdef _XER5_PRODUCT_REQ_
         static const char * const wifi_mode_strings[] =
+        {
+            "WIFI_80211_VARIANT_A",
+            "WIFI_80211_VARIANT_G",
+            "WIFI_80211_VARIANT_N",
+            "WIFI_80211_VARIANT_H",
+            "WIFI_80211_VARIANT_AC",
+            "WIFI_80211_VARIANT_AD",
+            "WIFI_80211_VARIANT_AX",
+#ifdef CONFIG_IEEE80211BE
+            "WIFI_80211_VARIANT_BE",
+#endif
+        };
+#else
+	static const char * const wifi_mode_strings[] =
         {
             "WIFI_80211_VARIANT_A",
             "WIFI_80211_VARIANT_B",
@@ -4228,6 +4243,7 @@ Radio_SetParamStringValue
             "WIFI_80211_VARIANT_BE",
 #endif /* CONFIG_IEEE80211BE */
         };
+#endif
 
         for (size_t i = 0; i < (sizeof(wifi_mode_strings) / sizeof(wifi_mode_strings[0])); i++) {
             if (wifi_variant & (1ul << i))

--- a/source/dml/tr_181/sbapi/cosa_wifi_apis.c
+++ b/source/dml/tr_181/sbapi/cosa_wifi_apis.c
@@ -220,7 +220,9 @@ struct wifiGuardIntervalMap wifiGuardIntervalMap[] ={
 struct  wifiStdCosaHalMap wifiStdDmlMap[] =
 {
     {WIFI_80211_VARIANT_A,  COSA_DML_WIFI_STD_a,  "a"},
+#ifndef _XER5_PRODUCT_REQ_
     {WIFI_80211_VARIANT_B,  COSA_DML_WIFI_STD_b,  "b"},
+#endif
     {WIFI_80211_VARIANT_G,  COSA_DML_WIFI_STD_g,  "g"},
     {WIFI_80211_VARIANT_N,  COSA_DML_WIFI_STD_n,  "n"},
     {WIFI_80211_VARIANT_H,  COSA_DML_WIFI_STD_h,  "h"},


### PR DESCRIPTION
XER5-1686: Removing 11b support for 2.4GHz

Reason for change: Removed 11b support for 2G as it was not required
Test Procedure: Build image and test sanity
Risks: Low
Priority: P0