### PR TITLE
RDKB-57769: wifi tr181 to mlo configuration

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -2093,6 +2093,36 @@ INSTMSMT_PH2 -->
                             <writable>true</writable>
                         </parameter>
                         <parameter>
+                            <name>MLD_Enable</name>
+                            <type>boolean</type>
+                            <syntax>bool</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
+                            <name>MLD_ID</name>
+                            <type>unsignedInt[0:255]</type>
+                            <syntax>uint32</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
+                            <name>MLD_Link_ID</name>
+                            <type>unsignedInt[0:255]</type>
+                            <syntax>uint32</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
+                            <name>MLD_Addr</name>
+                            <type>string(32)</type>
+                            <syntax>string</syntax>
+                            <writable>false</writable>
+                        </parameter>
+                        <parameter>
+                            <name>MLD_Apply</name>
+                            <type>boolean</type>
+                            <syntax>bool</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
                             <name>RetryLimit</name>
                             <type>unsignedInt[0:255]</type>
                             <syntax>uint32</syntax>

--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -1129,6 +1129,51 @@
             "min": 0,
             "max": 1
           }
+        },
+        "mld_enable": {
+          "type": {
+            "key": {
+              "type": "boolean"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mld_id": {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mld_link_id": {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mld_addr": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mld_apply": {
+          "type": {
+            "key": {
+              "type": "boolean"
+            },
+            "min": 0,
+            "max": 1
+          }
         }
       },
     "isRoot": true

--- a/lib/inc/schema_gen.h
+++ b/lib/inc/schema_gen.h
@@ -144,6 +144,11 @@
         PJS_OVS_BOOL(connected_building_enabled) \
         PJS_OVS_BOOL(hostap_mgt_frame_ctrl) \
         PJS_OVS_BOOL(mbo_enabled) \
+        PJS_OVS_BOOL(mld_enable) \
+        PJS_OVS_INT(mld_id) \
+        PJS_OVS_INT(mld_link_id) \
+        PJS_OVS_STRING(mld_addr, 32 + 1) \
+        PJS_OVS_BOOL(mld_apply) \
     )
 
 #define PJS_SCHEMA_Wifi_Interworking_Config \
@@ -2060,8 +2065,12 @@
     COLUMN(repurposed_vap_name)\
     COLUMN(connected_building_enabled)\
     COLUMN(hostap_mgt_frame_ctrl) \
-    COLUMN(mbo_enabled)
-
+    COLUMN(mbo_enabled)\
+    COLUMN(mld_enable)\
+    COLUMN(mld_id)\
+    COLUMN(mld_link_id)\
+    COLUMN(mld_addr)\
+    COLUMN(mld_apply)
 
 #define SCHEMA__Wifi_Interworking_Config "Wifi_Interworking_Config"
 #define SCHEMA_COLUMN__Wifi_Interworking_Config(COLUMN) \
@@ -3406,6 +3415,11 @@
 #define SCHEMA__Wifi_VAP_Config__connected_building_enabled "connected_building_enabled"
 #define SCHEMA__Wifi_VAP_Config__hostap_mgt_frame_ctrl "hostap_mgt_frame_ctrl"
 #define SCHEMA__Wifi_VAP_Config__mbo_enabled "mbo_enabled"
+#define SCHEMA__Wifi_VAP_Config__mld_enable "mld_enable"
+#define SCHEMA__Wifi_VAP_Config__mld_id "mld_id"
+#define SCHEMA__Wifi_VAP_Config__mld_link_id "mld_link_id"
+#define SCHEMA__Wifi_VAP_Config__mld_addr "mld_addr"
+#define SCHEMA__Wifi_VAP_Config__mld_apply "mld_apply"
 
 #define SCHEMA__Wifi_Interworking_Config__enable "enable"
 #define SCHEMA__Wifi_Interworking_Config__vap_name "vap_name"

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -410,6 +410,12 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg.u.bss_info.beaconRate = WIFI_BITRATE_6MBPS;
         strncpy(cfg.u.bss_info.beaconRateCtl,"6Mbps",sizeof(cfg.u.bss_info.beaconRateCtl)-1);
         cfg.vap_mode = wifi_vap_mode_ap;
+        /*TODO: Are values correct?  */
+        cfg.u.bss_info.mld_info.common_info.mld_enable = 1;
+        cfg.u.bss_info.mld_info.common_info.mld_id = 1;
+        cfg.u.bss_info.mld_info.common_info.mld_link_id = 1;
+        cfg.u.bss_info.mld_info.common_info.mld_apply = 1;
+        strcpy(cfg.u.bss_info.mld_info.common_info.mld_addr, "11:11:11:11:11:11");
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.showSsid = true;
             cfg.u.bss_info.wps.methods = WIFI_ONBOARDINGMETHODS_PUSHBUTTON;

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -411,11 +411,11 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         strncpy(cfg.u.bss_info.beaconRateCtl,"6Mbps",sizeof(cfg.u.bss_info.beaconRateCtl)-1);
         cfg.vap_mode = wifi_vap_mode_ap;
         /*TODO: Are values correct?  */
-        cfg.u.bss_info.mld_info.common_info.mld_enable = 1;
-        cfg.u.bss_info.mld_info.common_info.mld_id = 1;
-        cfg.u.bss_info.mld_info.common_info.mld_link_id = 1;
+        cfg.u.bss_info.mld_info.common_info.mld_enable = 0;
+        cfg.u.bss_info.mld_info.common_info.mld_id = 255;
+        cfg.u.bss_info.mld_info.common_info.mld_link_id = 255;
         cfg.u.bss_info.mld_info.common_info.mld_apply = 1;
-        strcpy(cfg.u.bss_info.mld_info.common_info.mld_addr, "11:11:11:11:11:11");
+//        strcpy(cfg.u.bss_info.mld_info.common_info.mld_addr, "11:11:11:11:11:11");
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.showSsid = true;
             cfg.u.bss_info.wps.methods = WIFI_ONBOARDINGMETHODS_PUSHBUTTON;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -981,6 +981,10 @@ void callback_Wifi_VAP_Config(ovsdb_update_monitor_t *mon,
             l_bss_param_cfg->mac_filter_enable = new_rec->mac_filter_enabled;
             l_bss_param_cfg->mac_filter_mode = new_rec->mac_filter_mode;
             l_bss_param_cfg->wmm_enabled = new_rec->wmm_enabled;
+            l_bss_param_cfg->mld_info.common_info.mld_enable = new_rec->mld_enable;
+            l_bss_param_cfg->mld_info.common_info.mld_id = new_rec->mld_id;
+            l_bss_param_cfg->mld_info.common_info.mld_link_id = new_rec->mld_link_id;
+            l_bss_param_cfg->mld_info.common_info.mld_apply = new_rec->mld_apply;
             if (strlen(new_rec->anqp_parameters) != 0) {
                 strncpy((char *)l_bss_param_cfg->interworking.anqp.anqpParameters,new_rec->anqp_parameters,(sizeof(l_bss_param_cfg->interworking.anqp.anqpParameters)-1));
             }
@@ -2568,6 +2572,10 @@ int wifidb_update_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
         strncpy(cfg.mfp_config,"Disabled",sizeof(cfg.mfp_config)-1);
         cfg.hostap_mgt_frame_ctrl = config->u.bss_info.hostap_mgt_frame_ctrl;
         cfg.mbo_enabled = config->u.bss_info.mbo_enabled;
+        cfg.mld_enable = config->u.bss_info.mld_info.common_info.mld_enable;
+        cfg.mld_id = config->u.bss_info.mld_info.common_info.mld_id;
+        cfg.mld_link_id = config->u.bss_info.mld_info.common_info.mld_link_id;
+        cfg.mld_apply = config->u.bss_info.mld_info.common_info.mld_apply;
 
         wifi_util_dbg_print(WIFI_DB,
             "%s:%d: VAP Config update data cfg.radio_name=%s cfg.vap_name=%s cfg.ssid=%s "
@@ -2579,7 +2587,8 @@ int wifidb_update_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
             "uapsd_enabled=%d beacon_rate=%d bridge_name=%s cfg.wmm_noack=%d cfg.wep_key_length=%d "
             "cfg.bss_hotspot=%d cfg.wps_push_button=%d cfg.wps_config_methods=%d "
             "cfg.wps_enabled=%d cfg.beacon_rate_ctl=%s cfg.mfp_config=%s "
-            "network_initiated_greylist=%d exists=%d hostap_mgt_frame_ctrl=%d mbo_enabled=%d\n",
+            "network_initiated_greylist=%d exists=%d hostap_mgt_frame_ctrl=%d mbo_enabled=%d "
+            "mld_enable=%d mld_id=%d mld_link_id=%d mld_apply=%d\n",
             __func__, __LINE__, cfg.radio_name, cfg.vap_name, cfg.ssid, cfg.enabled,
             cfg.ssid_advertisement_enabled, cfg.isolation_enabled, cfg.mgmt_power_control,
             cfg.bss_max_sta, cfg.bss_transition_activated, cfg.nbr_report_activated,
@@ -2588,7 +2597,8 @@ int wifidb_update_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
             cfg.hs2_parameters, cfg.uapsd_enabled, cfg.beacon_rate, cfg.bridge_name, cfg.wmm_noack,
             cfg.wep_key_length, cfg.bss_hotspot, cfg.wps_push_button, cfg.wps_config_methods,
             cfg.wps_enabled, cfg.beacon_rate_ctl, cfg.mfp_config, cfg.network_initiated_greylist,
-            cfg.exists, cfg.hostap_mgt_frame_ctrl, cfg.mbo_enabled);
+            cfg.exists, cfg.hostap_mgt_frame_ctrl, cfg.mbo_enabled,
+            cfg.mld_enable, cfg.mld_id, cfg.mld_link_id, cfg.mld_apply);
     }
     if(onewifi_ovsdb_table_upsert_with_parent(g_wifidb->wifidb_sock_path,&table_Wifi_VAP_Config,&cfg,false,filter_vap,SCHEMA_TABLE(Wifi_Radio_Config),(onewifi_ovsdb_where_simple(SCHEMA_COLUMN(Wifi_Radio_Config,radio_name),radio_name)),SCHEMA_COLUMN(Wifi_Radio_Config,vap_configs)) == false)
     {
@@ -5746,6 +5756,10 @@ int wifidb_get_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
             }
             config->u.bss_info.hostap_mgt_frame_ctrl = pcfg->hostap_mgt_frame_ctrl;
             config->u.bss_info.mbo_enabled = pcfg->mbo_enabled;
+            config->u.bss_info.mld_info.common_info.mld_enable = pcfg->mld_enable;
+            config->u.bss_info.mld_info.common_info.mld_id = pcfg->mld_id;
+            config->u.bss_info.mld_info.common_info.mld_link_id = pcfg->mld_link_id;
+            config->u.bss_info.mld_info.common_info.mld_apply = pcfg->mld_apply;
         }
     }
     free(pcfg);
@@ -6707,6 +6721,12 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg.u.bss_info.beaconRate = WIFI_BITRATE_6MBPS;
         strncpy(cfg.u.bss_info.beaconRateCtl,"6Mbps",sizeof(cfg.u.bss_info.beaconRateCtl)-1);
         cfg.vap_mode = wifi_vap_mode_ap;
+        /*TODO: Are values correct? */
+        cfg.u.bss_info.mld_info.common_info.mld_enable = 1;
+        cfg.u.bss_info.mld_info.common_info.mld_id = 1;
+        cfg.u.bss_info.mld_info.common_info.mld_link_id = 1;
+        cfg.u.bss_info.mld_info.common_info.mld_apply = 1;
+        memset(&cfg.u.bss_info.mld_info.common_info.mld_addr, 0, sizeof(cfg.u.bss_info.mld_info.common_info.mld_addr));
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.showSsid = true;
 #ifdef FEATURE_SUPPORT_WPS

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6722,9 +6722,9 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         strncpy(cfg.u.bss_info.beaconRateCtl,"6Mbps",sizeof(cfg.u.bss_info.beaconRateCtl)-1);
         cfg.vap_mode = wifi_vap_mode_ap;
         /*TODO: Are values correct? */
-        cfg.u.bss_info.mld_info.common_info.mld_enable = 1;
-        cfg.u.bss_info.mld_info.common_info.mld_id = 1;
-        cfg.u.bss_info.mld_info.common_info.mld_link_id = 1;
+        cfg.u.bss_info.mld_info.common_info.mld_enable = 0;
+        cfg.u.bss_info.mld_info.common_info.mld_id = 255;
+        cfg.u.bss_info.mld_info.common_info.mld_link_id = 255;
         cfg.u.bss_info.mld_info.common_info.mld_apply = 1;
         memset(&cfg.u.bss_info.mld_info.common_info.mld_addr, 0, sizeof(cfg.u.bss_info.mld_info.common_info.mld_addr));
         if (isVapPrivate(vap_index)) {

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -6407,6 +6407,20 @@ AccessPoint_GetParamBoolValue
         return TRUE;
     }
 
+    if( AnscEqualString(ParamName, "MLD_Enable", TRUE))
+    {
+        /* collect value */
+        *pBool = pcfg->u.bss_info.mld_info.common_info.mld_enable;
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "MLD_Apply", TRUE))
+    {
+        /* collect value */
+        *pBool = pcfg->u.bss_info.mld_info.common_info.mld_apply;
+        return TRUE;
+    }
+
     if( AnscEqualString(ParamName, "WMMCapability", TRUE))
     {
         /* collect value */
@@ -6626,6 +6640,16 @@ AccessPoint_GetParamIntValue
     if( AnscEqualString(ParamName, "X_CISCO_COM_BssMaxNumSta", TRUE))
     {
         *pInt = pcfg->u.bss_info.bssMaxSta;
+        return TRUE;
+    }
+    if( AnscEqualString(ParamName, "MLD_ID", TRUE))
+    {
+        *pInt = pcfg->u.bss_info.mld_info.common_info.mld_id;
+        return TRUE;
+    }
+    if( AnscEqualString(ParamName, "MLD_Link_ID", TRUE))
+    {
+        *pInt = pcfg->u.bss_info.mld_info.common_info.mld_link_id;
         return TRUE;
     }
     if( AnscEqualString(ParamName, "X_CISCO_COM_BssUserStatus", TRUE))
@@ -6899,6 +6923,38 @@ AccessPoint_GetParamStringValue
         return 0;
 
     }
+
+    if( AnscEqualString(ParamName, "MLD_Addr", TRUE))
+    {
+        char buff[24] = {0};
+        if (isVapSTAMesh(pcfg->vap_index)) {
+            _ansc_sprintf
+            (
+                buff,
+                "%02X:%02X:%02X:%02X:%02X:%02X",
+                0x0,
+                0x0,
+                0x0,
+                0x0,
+                0x0,
+                0x0
+            );
+        } else {
+            _ansc_sprintf
+            (
+                buff,
+                "%02X:%02X:%02X:%02X:%02X:%02X",
+                pcfg->u.bss_info.mld_info.common_info.mld_addr[0],
+                pcfg->u.bss_info.mld_info.common_info.mld_addr[1],
+                pcfg->u.bss_info.mld_info.common_info.mld_addr[2],
+                pcfg->u.bss_info.mld_info.common_info.mld_addr[3],
+                pcfg->u.bss_info.mld_info.common_info.mld_addr[4],
+                pcfg->u.bss_info.mld_info.common_info.mld_addr[5]
+            );
+        }
+        memcpy(pValue, buff, strlen(buff)+1);
+        return 0;
+     }
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
     return -1;
 }
@@ -7021,6 +7077,32 @@ AccessPoint_SetParamBoolValue
         
         /* save update to backup */
         vapInfo->u.bss_info.showSsid = bValue;
+        set_dml_cache_vap_config_changed(instance_number - 1);
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "MLD_Enable", TRUE))
+    {
+        if ( vapInfo->u.bss_info.mld_info.common_info.mld_enable == bValue )
+        {
+            return TRUE;
+        }
+
+        /* save update to backup */
+        vapInfo->u.bss_info.mld_info.common_info.mld_enable = bValue;
+        set_dml_cache_vap_config_changed(instance_number - 1);
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "MLD_Apply", TRUE))
+    {
+        if ( vapInfo->u.bss_info.mld_info.common_info.mld_apply == bValue )
+        {
+            return TRUE;
+        }
+
+        /* save update to backup */
+        vapInfo->u.bss_info.mld_info.common_info.mld_apply = bValue;
         set_dml_cache_vap_config_changed(instance_number - 1);
         return TRUE;
     }
@@ -7315,6 +7397,29 @@ AccessPoint_SetParamIntValue
         return TRUE;
     }
 
+    if( AnscEqualString(ParamName, "MLD_ID", TRUE))
+    {
+        if ( vapInfo->u.bss_info.mld_info.common_info.mld_id == (unsigned int)iValue )
+        {
+            return  TRUE;
+        }
+        /* save update to backup */
+        vapInfo->u.bss_info.mld_info.common_info.mld_id = iValue;
+        set_dml_cache_vap_config_changed(instance_number - 1);
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "MLD_Link_ID", TRUE))
+    {
+        if ( vapInfo->u.bss_info.mld_info.common_info.mld_link_id == (unsigned int)iValue )
+        {
+            return  TRUE;
+        }
+        /* save update to backup */
+        vapInfo->u.bss_info.mld_info.common_info.mld_link_id = iValue;
+        set_dml_cache_vap_config_changed(instance_number - 1);
+        return TRUE;
+    }
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
     return FALSE;
 }

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -3783,6 +3783,14 @@ bool is_vap_param_config_changed(wifi_vap_info_t *vap_info_old, wifi_vap_info_t 
             IS_STR_CHANGED(vap_info_old->u.bss_info.preassoc.sixGOpInfoMinRate,
                 vap_info_new->u.bss_info.preassoc.sixGOpInfoMinRate,
                 sizeof(vap_info_old->u.bss_info.preassoc.sixGOpInfoMinRate)) ||
+            IS_CHANGED(vap_info_old->u.bss_info.mld_info.common_info.mld_enable,
+                vap_info_new->u.bss_info.mld_info.common_info.mld_enable) ||
+            IS_CHANGED(vap_info_old->u.bss_info.mld_info.common_info.mld_id,
+                vap_info_new->u.bss_info.mld_info.common_info.mld_id) ||
+            IS_CHANGED(vap_info_old->u.bss_info.mld_info.common_info.mld_link_id,
+                vap_info_new->u.bss_info.mld_info.common_info.mld_link_id) ||
+            IS_CHANGED(vap_info_old->u.bss_info.mld_info.common_info.mld_apply,
+                vap_info_new->u.bss_info.mld_info.common_info.mld_apply) ||
             IS_CHANGED(vap_info_old->u.bss_info.hostap_mgt_frame_ctrl,
                 vap_info_new->u.bss_info.hostap_mgt_frame_ctrl) ||
             IS_CHANGED(vap_info_old->u.bss_info.vendor_elements_len,

--- a/source/utils/wifi_validator.c
+++ b/source/utils/wifi_validator.c
@@ -1511,6 +1511,26 @@ int validate_vap(const cJSON *vap, wifi_vap_info_t *vap_info, wifi_platform_prop
 	validate_param_bool(vap, "SSIDAdvertisementEnabled", param);
 	vap_info->u.bss_info.showSsid = (param->type & cJSON_True) ? true:false;
 
+    // MLD Enable
+    validate_param_bool(vap, "MLD_Enable", param);
+	vap_info->u.bss_info.mld_info.common_info.mld_enable = (param->type & cJSON_True) ? true:false;
+
+    // MLD Apply
+	validate_param_bool(vap, "MLD_Apply", param);
+	vap_info->u.bss_info.mld_info.common_info.mld_apply = (param->type & cJSON_True) ? true:false;
+
+    // MLD ID
+	validate_param_integer(vap, "MLD_ID", param);
+	vap_info->u.bss_info.mld_info.common_info.mld_id = param->valuedouble;
+
+    // MLD Link ID
+	validate_param_integer(vap, "MLD_Link_ID", param);
+	vap_info->u.bss_info.mld_info.common_info.mld_link_id = param->valuedouble;
+
+    // MLD_Addr
+    validate_param_string(vap, "MLD_Addr", param);
+    string_mac_to_uint8_mac((uint8_t *)&vap_info->u.bss_info.mld_info.common_info.mld_addr, param->valuestring);
+
 	// Isolation
 	validate_param_bool(vap, "IsolationEnable", param);
 	vap_info->u.bss_info.isolation = (param->type & cJSON_True) ? true:false;

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -1525,6 +1525,26 @@ webconfig_error_t decode_vap_common_object(const cJSON *vap, wifi_vap_info_t *va
     decode_param_bool(vap, "SSIDAdvertisementEnabled", param);
     vap_info->u.bss_info.showSsid = (param->type & cJSON_True) ? true : false;
 
+    // MLD Enable
+    decode_param_bool(vap, "MLD_Enable", param);
+    vap_info->u.bss_info.mld_info.common_info.mld_enable = (param->type & cJSON_True) ? true:false;
+
+    // MLD Apply
+    decode_param_bool(vap, "MLD_Apply", param);
+    vap_info->u.bss_info.mld_info.common_info.mld_apply = (param->type & cJSON_True) ? true:false;
+
+    // MLD_ID
+    decode_param_integer(vap, "MLD_ID", param);
+    vap_info->u.bss_info.mld_info.common_info.mld_id = param->valuedouble;
+
+    // MLD_Link_ID
+    decode_param_integer(vap, "MLD_Link_ID", param);
+    vap_info->u.bss_info.mld_info.common_info.mld_link_id = param->valuedouble;
+
+    // MLD_Addr
+    decode_param_string(vap, "MLD_Addr", param);
+    string_mac_to_uint8_mac(vap_info->u.bss_info.mld_info.common_info.mld_addr, param->valuestring);
+
     // Isolation
     decode_param_bool(vap, "IsolationEnable", param);
     vap_info->u.bss_info.isolation = (param->type & cJSON_True) ? true : false;

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -344,6 +344,7 @@ webconfig_error_t encode_vap_common_object(const wifi_vap_info_t *vap_info,
     const rdk_wifi_vap_info_t *rdk_vap_info, cJSON *vap_object)
 {
     char mac_str[32];
+    char mld_mac_str[32];
     char extra_vendor_ies_hex_str[(vap_info->u.bss_info.vendor_elements_len * 2) + 1];
 
     //VAP Name
@@ -376,6 +377,22 @@ webconfig_error_t encode_vap_common_object(const wifi_vap_info_t *vap_info,
 
     // Broadcast SSID
     cJSON_AddBoolToObject(vap_object, "SSIDAdvertisementEnabled", vap_info->u.bss_info.showSsid);
+
+    // MLD Enable
+    cJSON_AddBoolToObject(vap_object, "MLD_Enable", vap_info->u.bss_info.mld_info.common_info.mld_enable);
+
+    // MLD Apply
+    cJSON_AddBoolToObject(vap_object, "MLD_Apply", vap_info->u.bss_info.mld_info.common_info.mld_apply);
+
+    // MLD_ID
+    cJSON_AddNumberToObject(vap_object, "MLD_ID", vap_info->u.bss_info.mld_info.common_info.mld_id);
+
+    // MLD_Link_ID
+    cJSON_AddNumberToObject(vap_object, "MLD_Link_ID", vap_info->u.bss_info.mld_info.common_info.mld_link_id);
+
+    // MLD_Addr
+    uint8_mac_to_string_mac((uint8_t *)vap_info->u.bss_info.mld_info.common_info.mld_addr, mld_mac_str);
+    cJSON_AddStringToObject(vap_object, "MLD_Addr", mld_mac_str);
 
     // Isolation
     cJSON_AddBoolToObject(vap_object, "IsolationEnable", vap_info->u.bss_info.isolation);


### PR DESCRIPTION
Reason for change: Implement the following tr181's to support configuration of mlo params, these need to be added under Device.WiFi.AccessPoint:
	mld_enable
	mld_id
	mld_link_id
	mld_addr
	mld_apply
corresponding to:
	RDK_VENDOR_ATTR_MLD_ENABLE
	RDK_VENDOR_ATTR_MLD_ID
	RKD_VENDOR_ATTR_MLD_LINK_ID
	RDK_VENDOR_ATTR_MLD_MAC
	RDK_VENDOR_ATTR_MLD_CONFIG_APPLY
Test Procedure: mld_enable - true for mlo, false for slo mld_id - should be from 0 to 7 from private through mesh mld_link_id - link id of vap
mld_addr - should be bssid of vap for slo, should be bssid of first vap of the group in an mlo. mld_apply - should be 1 for the last vap in a group Priority: P1
Risks: high