### PR TITLE
XER5-1686: Removing 11b support for 2G

### DIFF
--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -4214,10 +4214,12 @@ Radio_SetParamStringValue
         }
 
         // TODO: for debug purpouses only
-        static const char * const wifi_mode_strings[] =
+	static const char * const wifi_mode_strings[] =
         {
             "WIFI_80211_VARIANT_A",
+#ifndef _XER5_PRODUCT_REQ_
             "WIFI_80211_VARIANT_B",
+#endif
             "WIFI_80211_VARIANT_G",
             "WIFI_80211_VARIANT_N",
             "WIFI_80211_VARIANT_H",

--- a/source/dml/tr_181/sbapi/cosa_wifi_apis.c
+++ b/source/dml/tr_181/sbapi/cosa_wifi_apis.c
@@ -220,7 +220,9 @@ struct wifiGuardIntervalMap wifiGuardIntervalMap[] ={
 struct  wifiStdCosaHalMap wifiStdDmlMap[] =
 {
     {WIFI_80211_VARIANT_A,  COSA_DML_WIFI_STD_a,  "a"},
+#ifndef _XER5_PRODUCT_REQ_
     {WIFI_80211_VARIANT_B,  COSA_DML_WIFI_STD_b,  "b"},
+#endif
     {WIFI_80211_VARIANT_G,  COSA_DML_WIFI_STD_g,  "g"},
     {WIFI_80211_VARIANT_N,  COSA_DML_WIFI_STD_n,  "n"},
     {WIFI_80211_VARIANT_H,  COSA_DML_WIFI_STD_h,  "h"},


### PR DESCRIPTION
Reason for change: Removed 11b support for 2G as it was not required
Test Procedure: Build image and test sanity
Risks: Low
Priority: P0