### PR TITLE
RDKBACCL-736: Mesh_backhaul disconnects due to station ip check

### DIFF
--- a/source/core/services/vap_svc_mesh_ext.c
+++ b/source/core/services/vap_svc_mesh_ext.c
@@ -1565,9 +1565,11 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
                 ext->ext_trigger_disconnection_timeout_handler_id = 0;
             }
 
-            scheduler_add_timer_task(ctrl->sched, FALSE, &ext->ext_udhcp_ip_check_id,
-                process_udhcp_ip_check, svc, EXT_UDHCP_IP_CHECK_INTERVAL,
-                EXT_UDHCP_IP_CHECK_NUM + 1, FALSE);
+            if (ctrl->network_mode != rdk_dev_mode_type_em_node) {
+                scheduler_add_timer_task(ctrl->sched, FALSE, &ext->ext_udhcp_ip_check_id,
+                    process_udhcp_ip_check, svc, EXT_UDHCP_IP_CHECK_INTERVAL,
+                    EXT_UDHCP_IP_CHECK_NUM + 1, FALSE);
+            }
 
             /* Make Self Heal Timeout to flase once connected */
             ext->selfheal_status = false;

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1420,7 +1420,7 @@ static void wps_test_event_receive_handler(char *event_name, raw_data_t *p_data,
     }
 }
 
-#if defined EASY_MESH_NODE || defined EASY_MESH_COLOCATED_NODE
+#if defined(EASY_MESH_NODE) || defined(EASY_MESH_COLOCATED_NODE)
 static void wifi_sta_2g_status_handler(char *event_name, raw_data_t *p_data, void *userData)
 {
     (void)userData;
@@ -1790,7 +1790,7 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
     }
 #endif
 
-#if defined EASY_MESH_NODE || defined EASY_MESH_COLOCATED_NODE 
+#if defined(EASY_MESH_NODE) || defined(EASY_MESH_COLOCATED_NODE)
     if (ctrl->wifi_sta_2g_status_subscribed == false) {
         if (bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_STA_2G_VAP_CONNECT_STATUS, wifi_sta_2g_status_handler, NULL,
                 0) != bus_error_success) {


### PR DESCRIPTION
Reason for change: IP check is not needed for EasyMesh usecase
Test procedure: Did not observe MeshBackhaul disconnection
Risks: Low