### PR TITLE
RDKB-12345678 : DHCP IP check remove for em node

### DIFF
--- a/source/core/services/vap_svc_mesh_ext.c
+++ b/source/core/services/vap_svc_mesh_ext.c
@@ -1565,9 +1565,11 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
                 ext->ext_trigger_disconnection_timeout_handler_id = 0;
             }
 
-            scheduler_add_timer_task(ctrl->sched, FALSE, &ext->ext_udhcp_ip_check_id,
-                process_udhcp_ip_check, svc, EXT_UDHCP_IP_CHECK_INTERVAL,
-                EXT_UDHCP_IP_CHECK_NUM + 1, FALSE);
+            if (ctrl->network_mode != rdk_dev_mode_type_em_node) {
+                scheduler_add_timer_task(ctrl->sched, FALSE, &ext->ext_udhcp_ip_check_id,
+                    process_udhcp_ip_check, svc, EXT_UDHCP_IP_CHECK_INTERVAL,
+                    EXT_UDHCP_IP_CHECK_NUM + 1, FALSE);
+            }
 
             /* Make Self Heal Timeout to flase once connected */
             ext->selfheal_status = false;


### PR DESCRIPTION
Reason for change: DHCP IP check remove for em node Test Procedure: 1) Load OneWifi Image.
                2) Start connection with AP.
                3) Check Client successfuly connected with AP.

Risks: Low
Priority: P1

Signed-off-by: apatel599@cable.comcast.com