### PR TITLE
XER10-1020 : WIFI_GOODBADRSSI marker incorrect

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -2988,6 +2988,8 @@ int init_wifi_monitor()
     unsigned int uptimeval = 0;
     int rssi;
     UINT vap_index, radio;
+    wifi_global_param_t *global_param;
+
     //Initialize MQTTCM
     wifi_util_info_print(WIFI_MON,"%s:%d Monitor init\n", __func__, __LINE__);
 #ifdef MQTTCM
@@ -3009,11 +3011,10 @@ int init_wifi_monitor()
     chan_util_upload_period = get_chan_util_upload_period();
     wifi_util_dbg_print(WIFI_MON, "%s:%d system uptime val is %ld and upload period is %d in secs\n",
              __FUNCTION__,__LINE__,uptimeval,(g_monitor_module.upload_period*60));
-    if (get_vap_dml_parameters(RSSI_THRESHOLD, &rssi) != ANSC_STATUS_SUCCESS) {
-        g_monitor_module.sta_health_rssi_threshold = -65;
-    } else {
-        g_monitor_module.sta_health_rssi_threshold = rssi;
-    }
+    
+    global_param = get_wifidb_wifi_global_param();
+    g_monitor_module.sta_health_rssi_threshold = global_param->good_rssi_threshold;
+    
     for (i = 0; i < getTotalNumberVAPs(); i++) {
         UINT vap_index = VAP_INDEX(mgr->hal_cap, i);
         radio = RADIO_INDEX(mgr->hal_cap, i);

--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -348,10 +348,11 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
                     &t_diff);
             }
             // update thresholds if changed
-            if (get_vap_dml_parameters(RSSI_THRESHOLD, &rssi) == 0) {
-                mon_data->sta_health_rssi_threshold = rssi;
-                wifi_util_dbg_print(WIFI_MON, "%s:%d RSSI threshold updated to %d\n",
-                   __func__,  __LINE__, mon_data->sta_health_rssi_threshold);
+            wifi_global_param_t *global_param = get_wifidb_wifi_global_param();
+            if (mon_data->sta_health_rssi_threshold != global_param->good_rssi_threshold) {
+                wifi_util_dbg_print(WIFI_MON, "%s:%d RSSI threshold updated to %d from %d\n", __func__,
+                    __LINE__, global_param->good_rssi_threshold, mon_data->sta_health_rssi_threshold);
+                mon_data->sta_health_rssi_threshold = global_param->good_rssi_threshold;
             }
 
             if (sta->dev_stats.cli_SignalStrength >= mon_data->sta_health_rssi_threshold) {


### PR DESCRIPTION
Impacted Platforms:
All RDKB OneWiFi Platforms

Reason for change: WIFI_GOODBADRSSI marker values are incorrect. Good rssi time is swapped with Bad rssi time

Test Procedure: WIFI_GOODBADRSSI marker should work fine.

Risks: Low

Priority: P1

Signed-off-by: Karthikeyan Nanjundan Karthikeyan_Nanjundan@comcast.com