### PR TITLE
RDKB-59512: Revert macfilter mode change for easymesh

### DIFF
--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -348,9 +348,7 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg.u.bss_info.rapidReconnThreshold = 180;
         if (isVapMeshBackhaul(vap_index)) {
             cfg.u.bss_info.mac_filter_enable = true;
-            //TBD: Changing to blacklist is a temporary change. This needs to
-            //be updated appropriately to configure connecting sta as part of whitelist.
-            cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
+            cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_white_list;
         } else if (isVapHotspot(vap_index)) {
             cfg.u.bss_info.mac_filter_enable = true;
             cfg.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;


### PR DESCRIPTION
Reason for change: Added change to modify mac filter mode for mesh backhaul in hal layer.
Test Procedure: Ensure with mesh_backhaul, client device can be connected.
Risks: Medium
Priority: P1