### PR TITLE
RDKB-59244: WPS Enhancement task

### DIFF
--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -2304,11 +2304,12 @@ void reconfigure_whix_interval(wifi_app_t *app, wifi_event_t *event)
 
 static void wps_enable_telemetry(wifi_app_t *app, wifi_event_t *event)
 {
-    bool enable = 0;
+#ifdef FEATURE_SUPPORT_WPS
     unsigned int radio_index = 0;
     unsigned int vap_index = 0;
     int vap_array_index = 0;
     int band = 0;
+    bool enable = 0;
     char tmp[128];
     FILE *wifihealth_fp = NULL;
     webconfig_subdoc_data_t *webconfig_data = NULL;
@@ -2360,9 +2361,11 @@ static void wps_enable_telemetry(wifi_app_t *app, wifi_event_t *event)
                  fprintf(wifihealth_fp, "%s RDKB_WPS_ENABLED_%d %s\n", tmp, radio_index+1, enable ? "TRUE":"FALSE");
                  app->data.u.whix.wps_enabled[radio_index] = enable;
              }
+
         }
     }
     fclose(wifihealth_fp);
+#endif
 }
 
 void handle_whix_command_event(wifi_app_t *app, wifi_event_t *event)
@@ -2558,7 +2561,9 @@ int whix_init(wifi_app_t *app, unsigned int create_flag)
                  wifi_util_error_print(WIFI_APPS,"%s:%d: Failed to get vap_array_index for vap index %u\n", __func__, __LINE__, vap_index);
                  continue;
              }
+#ifdef FEATURE_SUPPORT_WPS
              app->data.u.whix.wps_enabled[radio_index] = wifi_mgr->radio_config[radio_index].vaps.vap_map.vap_array[vap_array_index].u.bss_info.wps.enable;
+#endif
         }
     }
     app->data.u.whix.sched_handler_id = 0;

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -2177,12 +2177,15 @@ void process_tcm_rfc(bool type)
 
 void process_wps_command_event(unsigned int vap_index)
 {
+#ifdef FEATURE_SUPPORT_WPS
     wifi_util_info_print(WIFI_CTRL,"%s:%d wifi wps test vap index = %d\n",__func__, __LINE__, vap_index);
     wifi_hal_setApWpsButtonPush(vap_index);
+#endif
 }
 
 void process_wps_pin_command_event(void *data)
 {
+#ifdef FEATURE_SUPPORT_WPS
     wps_pin_config_t  *wps_config = (wps_pin_config_t *)data;
     if (wps_config == NULL) {
         wifi_util_error_print(WIFI_CTRL,"%s:%d wps pin config data is NULL\n",__func__, __LINE__);
@@ -2192,10 +2195,12 @@ void process_wps_pin_command_event(void *data)
     wifi_util_info_print(WIFI_CTRL,"%s:%d wifi wps pin vap index = %d, wps_pin:%s\n",__func__, __LINE__,
                                         wps_config->vap_index, wps_config->wps_pin);
     wifi_hal_setApWpsPin(wps_config->vap_index, wps_config->wps_pin);
+#endif
 }
 
 static void process_wps_cancel_event(void *data)
 {
+#ifdef FEATURE_SUPPORT_WPS
     if (data == NULL) {
         wifi_util_error_print(WIFI_CTRL,"%s:%d data is NULL\n",__func__, __LINE__);
         return;
@@ -2206,6 +2211,7 @@ static void process_wps_cancel_event(void *data)
     wifi_util_info_print(WIFI_CTRL,"%s:%d wps pbc cancel vap index = %d\n",
         __func__, __LINE__, vap_index);
     wifi_hal_setApWpsCancel(vap_index);
+#endif
 }
 
 void marker_list_config_event(char *data, marker_list_t list_type)

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -111,7 +111,9 @@ void print_wifi_hal_vap_security_param(wifi_dbg_type_t log_file_type, char *pref
 
 void print_wifi_hal_vap_wps_data(wifi_dbg_type_t log_file_type, char *prefix, unsigned int vap_index, wifi_wps_t *l_wifi_wps)
 {
+#ifdef FEATURE_SUPPORT_WPS
     wifi_util_info_print(log_file_type,"%s:%d: [%s] Wifi_wps_Config vap_index=%d\n enable:%d\n methods:%d\r\n", __func__, __LINE__, prefix, vap_index, l_wifi_wps->enable, l_wifi_wps->methods);
+#endif
 }
 
 #define WEBCONFIG_DML_SUBDOC_STATES                         \
@@ -740,11 +742,13 @@ int webconfig_hal_vap_apply_by_name(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_
                     print_wifi_hal_vap_security_param(WIFI_WEBCONFIG, "Old", tgt_vap_index, &mgr_vap_info->u.bss_info.security);
                     print_wifi_hal_vap_security_param(WIFI_WEBCONFIG, "New", tgt_vap_index, &vap_info->u.bss_info.security);
                 }
+#ifdef FEATURE_SUPPORT_WPS
                 if (memcmp(&mgr_vap_info->u.bss_info.wps, &vap_info->u.bss_info.wps, sizeof(wifi_wps_t))) {
                     print_wifi_hal_vap_wps_data(WIFI_WEBCONFIG, "Old", tgt_vap_index, &mgr_vap_info->u.bss_info.wps);
                     print_wifi_hal_vap_wps_data(WIFI_WEBCONFIG, "New", tgt_vap_index, &vap_info->u.bss_info.wps);
                 }
-            }
+#endif
+            } 
 
             p_tgt_vap_map = (wifi_vap_info_map_t *) malloc(sizeof(wifi_vap_info_map_t));
             if(p_tgt_vap_map == NULL ) {

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -123,7 +123,9 @@ static char *ApIsolationEnable    = "eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiF
 static char *BeaconRateCtl   = "eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.Radio.AccessPoint.%d.BeaconRateCtl";
 static char *BSSTransitionActivated    = "eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.AccessPoint.%d.BSSTransitionActivated";
 static char *BssHotSpot        = "eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.AccessPoint.%d.HotSpot";
+#ifdef FEATURE_SUPPORT_WPS
 static char *WpsPushButton = "eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.AccessPoint.%d.WpsPushButton";
+#endif
 static char *RapidReconnThreshold        = "eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.AccessPoint.%d.RapidReconnThreshold";
 static char *RapidReconnCountEnable      = "eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.AccessPoint.%d.RapidReconnCountEnable";
 static char *vAPStatsEnable = "eRT.com.cisco.spvtg.ccsp.tr181pa.Device.WiFi.AccessPoint.%d.vAPStatsEnable";
@@ -995,9 +997,11 @@ void callback_Wifi_VAP_Config(ovsdb_update_monitor_t *mon,
             l_bss_param_cfg->wmmNoAck = new_rec->wmm_noack;
             l_bss_param_cfg->wepKeyLength = new_rec->wep_key_length;
             l_bss_param_cfg->bssHotspot = new_rec->bss_hotspot;
+#if defined(FEATURE_SUPPORT_WPS)
             l_bss_param_cfg->wpsPushButton = new_rec->wps_push_button;
             l_bss_param_cfg->wps.methods = new_rec->wps_config_methods;
             l_bss_param_cfg->wps.enable = new_rec->wps_enabled;
+#endif
             if (strlen(new_rec->beacon_rate_ctl) != 0) {
                 strncpy(l_bss_param_cfg->beaconRateCtl, new_rec->beacon_rate_ctl,(sizeof(l_bss_param_cfg->beaconRateCtl)-1));
             }
@@ -1141,11 +1145,13 @@ void callback_Wifi_Global_Config(ovsdb_update_monitor_t *mon,
         g_wifidb->global_config.global_parameters.wifi_active_msmt_num_samples = new_rec->wifi_active_msmt_num_samples;
         g_wifidb->global_config.global_parameters.wifi_active_msmt_sample_duration = new_rec->wifi_active_msmt_sample_duration;
         g_wifidb->global_config.global_parameters.vlan_cfg_version = new_rec->vlan_cfg_version;
+#ifdef FEATURE_SUPPORT_WPS
         if (strlen(new_rec->wps_pin) != 0) {
             strncpy(g_wifidb->global_config.global_parameters.wps_pin,new_rec->wps_pin,sizeof(g_wifidb->global_config.global_parameters.wps_pin)-1);
         } else {
             strcpy(g_wifidb->global_config.global_parameters.wps_pin, DEFAULT_WPS_PIN);
         }
+#endif
         g_wifidb->global_config.global_parameters.bandsteering_enable = new_rec->bandsteering_enable;
         g_wifidb->global_config.global_parameters.good_rssi_threshold = new_rec->good_rssi_threshold;
         g_wifidb->global_config.global_parameters.assoc_count_threshold = new_rec->assoc_count_threshold;
@@ -2553,15 +2559,11 @@ int wifidb_update_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
         cfg.wmm_noack = config->u.bss_info.wmmNoAck;
         cfg.wep_key_length = config->u.bss_info.wepKeyLength;
         cfg.bss_hotspot = config->u.bss_info.bssHotspot;
+#ifdef FEATURE_SUPPORT_WPS
         cfg.wps_push_button = config->u.bss_info.wpsPushButton;
         cfg.wps_config_methods = config->u.bss_info.wps.methods;
-#if defined(_CBR2_PRODUCT_REQ_)
-        if(config->u.bss_info.wps.enable != false) {
-            cfg.wps_enabled = false;
-        }
-#else
         cfg.wps_enabled = config->u.bss_info.wps.enable;
-#endif /* _CBR2_PRODUCT_REQ_ */
+#endif
         strncpy(cfg.beacon_rate_ctl,config->u.bss_info.beaconRateCtl,sizeof(cfg.beacon_rate_ctl)-1);
         strncpy(cfg.mfp_config,"Disabled",sizeof(cfg.mfp_config)-1);
         cfg.hostap_mgt_frame_ctrl = config->u.bss_info.hostap_mgt_frame_ctrl;
@@ -3021,11 +3023,13 @@ int wifidb_get_wifi_global_config(wifi_global_param_t *config)
         config->wifi_active_msmt_num_samples = pcfg->wifi_active_msmt_num_samples;
         config->wifi_active_msmt_sample_duration = pcfg->wifi_active_msmt_sample_duration;
         config->vlan_cfg_version = pcfg->vlan_cfg_version;
+#ifdef FEATURE_SUPPORT_WPS
         if (strlen(pcfg->wps_pin) != 0) {
             strncpy(config->wps_pin,pcfg->wps_pin,sizeof(config->wps_pin)-1);
         } else {
             strcpy(config->wps_pin, DEFAULT_WPS_PIN);
         }
+#endif
         config->bandsteering_enable = pcfg->bandsteering_enable;
         config->good_rssi_threshold = pcfg->good_rssi_threshold;
         config->assoc_count_threshold = pcfg->assoc_count_threshold;
@@ -4495,36 +4499,41 @@ void wifidb_vap_config_correction(wifi_vap_info_map_t *l_vap_map_param)
     for (index = 0; index < l_vap_map_param->num_vaps; index++) {
         vap_config = &l_vap_map_param->vap_array[index];
 
-        if ((isVapPrivate(vap_config->vap_index)) && (access(ONEWIFI_BSS_MAXASSOC_FLAG, F_OK) != 0) &&
+        if ((isVapPrivate(vap_config->vap_index)) &&
+            (access(ONEWIFI_BSS_MAXASSOC_FLAG, F_OK) != 0) &&
             (vap_config->u.bss_info.bssMaxSta != wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow)) {
-                wifi_util_info_print(WIFI_DB, "%s:%d: Update bssMaxSta for private_vap:%d from %d to %d\r\n",
-                    __func__, __LINE__, vap_config->vap_index, vap_config->u.bss_info.bssMaxSta, wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow);
-                vap_config->u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
+            wifi_util_info_print(WIFI_DB,
+                "%s:%d: Update bssMaxSta for private_vap:%d from %d to %d\r\n", __func__, __LINE__,
+                vap_config->vap_index, vap_config->u.bss_info.bssMaxSta,
+                wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow);
+            vap_config->u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
 
-                rdk_vap_config = get_wifidb_rdk_vaps(vap_config->radio_index);
-                if (rdk_vap_config == NULL) {
-                    wifi_util_error_print(WIFI_DB, "%s:%d: failed to get rdk vaps for radio index %d\n", __func__, __LINE__, vap_config->radio_index);
-                } else {
-                    update_wifi_vap_info(vap_config->vap_name, vap_config, rdk_vap_config);
-                }
+            rdk_vap_config = get_wifidb_rdk_vaps(vap_config->radio_index);
+            if (rdk_vap_config == NULL) {
+                wifi_util_error_print(WIFI_DB, "%s:%d: failed to get rdk vaps for radio index %d\n",
+                    __func__, __LINE__, vap_config->radio_index);
+            } else {
+                update_wifi_vap_info(vap_config->vap_name, vap_config, rdk_vap_config);
+            }
         }
 
         if (isVapPrivate(vap_config->vap_index) &&
             is_sec_mode_personal(vap_config->u.bss_info.security.mode)) {
+#ifdef FEATURE_SUPPORT_WPS
             if (vap_config->u.bss_info.wps.enable == false) {
-#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_) && !defined(_CBR2_PRODUCT_REQ_)
                 vap_config->u.bss_info.wps.enable = true;
-
-                wifi_util_info_print(WIFI_DB, "%s:%d: force wps enabled for private_vap:%d\r\n",__func__, __LINE__, vap_config->vap_index);
-#endif
+                wifi_util_info_print(WIFI_DB, "%s:%d: force wps enabled for private_vap:%d\r\n",
+                    __func__, __LINE__, vap_config->vap_index);
             }
             continue;
+#endif
         }
         if (isVapLnfSecure(vap_config->vap_index) &&
             is_sec_mode_enterprise(vap_config->u.bss_info.security.mode)) {
             set_lnf_radius_server_ip(&vap_config->u.bss_info.security);
-            wifi_util_info_print(WIFI_DB,"%s:%d: Primary Ip and Secondry Ip: %s , %s\n", __func__, __LINE__, (char *)vap_config->u.bss_info.security.u.radius.ip,
-                                            (char *)vap_config->u.bss_info.security.u.radius.s_ip);
+            wifi_util_info_print(WIFI_DB, "%s:%d: Primary Ip and Secondry Ip: %s , %s\n", __func__,
+                __LINE__, (char *)vap_config->u.bss_info.security.u.radius.ip,
+                (char *)vap_config->u.bss_info.security.u.radius.s_ip);
             continue;
         }
     }
@@ -5731,9 +5740,11 @@ int wifidb_get_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
             config->u.bss_info.wmmNoAck = pcfg->wmm_noack;
             config->u.bss_info.wepKeyLength = pcfg->wep_key_length;
             config->u.bss_info.bssHotspot = pcfg->bss_hotspot;
+#if defined(FEATURE_SUPPORT_WPS)
             config->u.bss_info.wpsPushButton = pcfg->wps_push_button;
             config->u.bss_info.wps.methods = pcfg->wps_config_methods;
             config->u.bss_info.wps.enable = pcfg->wps_enabled;
+#endif
             if (strlen(pcfg->beacon_rate_ctl) != 0) {
                 strncpy(config->u.bss_info.beaconRateCtl, pcfg->beacon_rate_ctl,(sizeof(config->u.bss_info.beaconRateCtl)-1));
             }
@@ -6476,12 +6487,14 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
 {
     wifi_mgr_t *g_wifidb;
     g_wifidb = get_wifimgr_obj();
-    wifi_hal_capability_t *wifi_hal_cap_obj = rdk_wifi_get_hal_capability_map();
+    wifi_hal_capability_t *wifi_hal_cap_obj = &g_wifidb->hal_cap;
     unsigned int vap_array_index;
     unsigned int found = 0;
     wifi_vap_info_t cfg;
     char vap_name[BUFFER_LENGTH_WIFIDB] = {0};
+#ifdef FEATURE_SUPPORT_WPS
     char wps_pin[128] = {0};
+#endif
     char password[128] = {0};
     char radius_key[128] = {0};
     char ssid[128] = {0};
@@ -6597,10 +6610,10 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.vapStatsEnable = true;
             cfg.u.bss_info.wpsPushButton = 0;
-#if defined(NEWPLATFORM_PORT) || defined(_CBR2_PRODUCT_REQ_)
-            cfg.u.bss_info.wps.enable = false;
-#else
+#ifdef FEATURE_SUPPORT_WPS
             cfg.u.bss_info.wps.enable = true;
+#else
+            cfg.u.bss_info.wps.enable = false;
 #endif
             cfg.u.bss_info.rapidReconnectEnable = true;
         } else {
@@ -6684,18 +6697,18 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg.vap_mode = wifi_vap_mode_ap;
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.showSsid = true;
+#ifdef FEATURE_SUPPORT_WPS
             cfg.u.bss_info.wps.methods = WIFI_ONBOARDINGMETHODS_PUSHBUTTON;
             memset(wps_pin, 0, sizeof(wps_pin));
             if ((wifi_hal_get_default_wps_pin(wps_pin) == RETURN_OK) && ((strlen(wps_pin) != 0))) {
                 strcpy(cfg.u.bss_info.wps.pin, wps_pin);
             } else {
-#ifndef NEWPLATFORM_PORT
-                wifi_util_error_print(WIFI_DB, "%s:%d: Incorrect wps pin for vap '%s'\n", __func__, __LINE__, vap_name);
-#endif
+                wifi_util_error_print(WIFI_DB, "%s:%d: Incorrect wps pin for vap '%s'\n", __func__,
+                    __LINE__, vap_name);
                 strcpy(cfg.u.bss_info.wps.pin, "12345678");
             }
-        }
-        else if (isVapHotspot(vap_index)) {
+#endif
+        } else if (isVapHotspot(vap_index)) {
             cfg.u.bss_info.showSsid = true;
         } else {
             cfg.u.bss_info.showSsid = false;
@@ -7577,11 +7590,14 @@ int wifi_db_update_global_config(wifi_global_param_t *global_cfg)
     memset(strValue, 0, sizeof(strValue));
     str = p_ccsp_desc->psm_get_value_fn(WpsPin, strValue);
     if (str != NULL) {
-        //global_cfg->wps_pin = atoi(str);
-        strcpy(global_cfg->wps_pin, str);
-        wifi_util_dbg_print(WIFI_MGR,"global_cfg->wps_pin is %s and str is %s and atoi(str) is %d\n", global_cfg->wps_pin, str, atoi(str));
+        // global_cfg->wps_pin = atoi(str);
+	strcpy(global_cfg->wps_pin, str);
+        wifi_util_dbg_print(WIFI_MGR,
+	"global_cfg->wps_pin is %s and str is %s and atoi(str) is %d\n", global_cfg->wps_pin,
+         str, atoi(str));
     } else {
-        wifi_util_dbg_print(WIFI_MGR,":%s:%d str value for wps_pin:%s \r\n", __func__, __LINE__, str);
+        wifi_util_dbg_print(WIFI_MGR, ":%s:%d str value for wps_pin:%s \r\n", __func__, __LINE__,
+            str);
     }
 
     memset(strValue, 0, sizeof(strValue));
@@ -8192,14 +8208,16 @@ int get_vap_params_from_psm(unsigned int vap_index, wifi_vap_info_t *vap_config,
 
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));
+#ifdef FEATURE_SUPPORT_WPS
     snprintf(recName, sizeof(recName), WpsPushButton, instance_number);
     str = p_ccsp_desc->psm_get_value_fn(recName, strValue);
     if (str != NULL) {
         bss_cfg->wpsPushButton = atoi(str);
         wifi_util_dbg_print(WIFI_MGR,"bss_cfg->wpsPushButton is %d and str is %s and atoi(str) is %d\n", bss_cfg->wpsPushButton, str, atoi(str));
     } else {
-        wifi_util_dbg_print(WIFI_MGR,"%s:%d str value for wpsPushButton:%s \r\n", __func__, __LINE__, str);
+        wifi_util_dbg_print(WIFI_MGR, "%s:%d str value for wpsPushButton:%s \r\n", __func__,__LINE__, str);
     }
+#endif
 
     memset(recName, 0, sizeof(recName));
     memset(strValue, 0, sizeof(strValue));

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -11718,6 +11718,7 @@ WPS_SetParamBoolValue
         BOOL                        bValue
     )
 {
+#ifdef FEATURE_SUPPORT_WPS
     wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
     if (pcfg == NULL)
     {
@@ -11736,34 +11737,21 @@ WPS_SetParamBoolValue
         wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
         return TRUE;
     }
- 
     /* check the parameter name and set the corresponding value */
     if (AnscEqualString(ParamName, "Enable", TRUE)) {
-#if defined(_CBR2_PRODUCT_REQ_)
-        wifi_util_info_print(WIFI_DMCLI, "%s:%d:WPS option is not supported for CBRV2\n", __func__,
-            __LINE__);
-        return FALSE;
-#else
         if (vapInfo->u.bss_info.wps.enable != bValue) {
-            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d:key=%d bValue=%d  \n", __func__, __LINE__,
-                vapInfo->u.bss_info.wps.enable, bValue);
             vapInfo->u.bss_info.wps.enable = bValue;
             set_dml_cache_vap_config_changed(instance_number - 1);
         }
         return TRUE;
-#endif
     }
-    if( AnscEqualString(ParamName, "X_CISCO_COM_ActivatePushButton", TRUE))
-    {
-        if (vapInfo->u.bss_info.wpsPushButton == bValue)
-        {
-            return TRUE;
+    if (AnscEqualString(ParamName, "X_CISCO_COM_ActivatePushButton", TRUE)) {
+        if (vapInfo->u.bss_info.wpsPushButton != bValue) {
+            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d:key=%d bValue=%d\n", __func__, __LINE__,
+                vapInfo->u.bss_info.wpsPushButton, bValue);
+            vapInfo->u.bss_info.wpsPushButton = bValue;
+            set_dml_cache_vap_config_changed(instance_number - 1);
         }
-
-        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d:key=%d bValue=%d  \n",__func__, __LINE__,vapInfo->u.bss_info.wpsPushButton,bValue);
-        vapInfo->u.bss_info.wpsPushButton = bValue;
-        set_dml_cache_vap_config_changed(instance_number - 1);
-
         return TRUE;
     }
     if( AnscEqualString(ParamName, "X_CISCO_COM_CancelSession", TRUE))
@@ -11773,8 +11761,9 @@ WPS_SetParamBoolValue
         push_event_to_ctrl_queue(&instance_number, sizeof(instance_number), wifi_event_type_command, wifi_event_type_command_wps_cancel, NULL);
         return TRUE;
     }
-
-    /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
+#else
+    wifi_util_info_print(WIFI_DMCLI, "%s:%d: WPS not supported\n", __func__, __LINE__);
+#endif
     return FALSE;
 }
 
@@ -11818,348 +11807,332 @@ WPS_SetParamIntValue
 {
  
     /* check the parameter name and set the corresponding value */
-
-    if (AnscEqualString(ParamName, "X_CISCO_COM_WpsPushButton", TRUE))
-    {
+#ifdef FEATURE_SUPPORT_WPS
+    if (AnscEqualString(ParamName, "X_CISCO_COM_WpsPushButton", TRUE)) {
         return TRUE;
     }
-
-    /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
+#else
+    wifi_util_info_print(WIFI_DMCLI, "%s:%d: WPS not supported\n", __func__, __LINE__);
+#endif
     return FALSE;
 }
 
-/**********************************************************************  
 
-    caller:     owner of this object 
+    /**********************************************************************
 
-    prototype: 
+        caller:     owner of this object
 
-        BOOL
-        WPS_SetParamUlongValue
-            (
-                ANSC_HANDLE                 hInsContext,
-                char*                       ParamName,
-                ULONG                       uValue
-            );
+        prototype:
 
-    description:
+            BOOL
+            WPS_SetParamUlongValue
+                (
+                    ANSC_HANDLE                 hInsContext,
+                    char*                       ParamName,
+                    ULONG                       uValue
+                );
 
-        This function is called to set ULONG parameter value; 
+        description:
 
-    argument:   ANSC_HANDLE                 hInsContext,
-                The instance handle;
+            This function is called to set ULONG parameter value;
 
-                char*                       ParamName,
-                The parameter name;
+        argument:   ANSC_HANDLE                 hInsContext,
+                    The instance handle;
 
-                ULONG                       uValue
-                The updated ULONG value;
+                    char*                       ParamName,
+                    The parameter name;
 
-    return:     TRUE if succeeded.
+                    ULONG                       uValue
+                    The updated ULONG value;
 
-**********************************************************************/
-BOOL
-WPS_SetParamUlongValue
-    (
-        ANSC_HANDLE                 hInsContext,
-        char*                       ParamName,
-        ULONG                       uValue
-    )
-{
-    UNREFERENCED_PARAMETER(hInsContext);
-    UNREFERENCED_PARAMETER(ParamName);
-    UNREFERENCED_PARAMETER(uValue);
-    /* check the parameter name and set the corresponding value */
+        return:     TRUE if succeeded.
 
-    /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
-    return FALSE;
-}
-
-/**********************************************************************  
-
-    caller:     owner of this object 
-
-    prototype: 
-
-        BOOL
-        WPS_SetParamStringValue
-            (
-                ANSC_HANDLE                 hInsContext,
-                char*                       ParamName,
-                char*                       pString
-            );
-
-    description:
-
-        This function is called to set string parameter value; 
-
-    argument:   ANSC_HANDLE                 hInsContext,
-                The instance handle;
-
-                char*                       ParamName,
-                The parameter name;
-
-                char*                       pString
-                The updated string value;
-
-    return:     TRUE if succeeded.
-
-**********************************************************************/
-BOOL
-WPS_SetParamStringValue
-    (
-        ANSC_HANDLE                 hInsContext,
-        char*                       ParamName,
-        char*                       pString
-    )
-{
-    wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
-    if (pcfg == NULL)
+    **********************************************************************/
+    BOOL WPS_SetParamUlongValue(ANSC_HANDLE hInsContext, char *ParamName, ULONG uValue)
     {
-        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Null pointer get fail\n", __FUNCTION__,__LINE__);
-        return FALSE;
-    }
-    uint8_t instance_number = convert_vap_name_to_index(&((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop, pcfg->vap_name)+1;
-    wifi_vap_info_t *vapInfo = (wifi_vap_info_t *) get_dml_cache_vap_info(instance_number-1);
+        UNREFERENCED_PARAMETER(hInsContext);
+        UNREFERENCED_PARAMETER(ParamName);
+        UNREFERENCED_PARAMETER(uValue);
+        /* check the parameter name and set the corresponding value */
 
-    if (vapInfo == NULL)
-    {
-        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Unable to get VAP info for instance_number:%d\n", __FUNCTION__,__LINE__,instance_number);
+        /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
         return FALSE;
     }
 
-    /* check the parameter name and set the corresponding value */
-    if( AnscEqualString(ParamName, "ConfigMethodsEnabled", TRUE))
-    {
-        int match = 0;
+    /**********************************************************************
 
-        if (isVapSTAMesh(pcfg->vap_index)) {
-            wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
+        caller:     owner of this object
+
+        prototype:
+
+            BOOL
+            WPS_SetParamStringValue
+                (
+                    ANSC_HANDLE                 hInsContext,
+                    char*                       ParamName,
+                    char*                       pString
+                );
+
+        description:
+
+            This function is called to set string parameter value;
+
+        argument:   ANSC_HANDLE                 hInsContext,
+                    The instance handle;
+
+                    char*                       ParamName,
+                    The parameter name;
+
+                    char*                       pString
+                    The updated string value;
+
+        return:     TRUE if succeeded.
+
+    **********************************************************************/
+    BOOL WPS_SetParamStringValue(ANSC_HANDLE hInsContext, char *ParamName, char *pString)
+    {
+#ifdef FEATURE_SUPPORT_WPS
+        wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
+        if (pcfg == NULL) {
+            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Null pointer get fail\n", __FUNCTION__,
+                __LINE__);
+            return FALSE;
+        }
+        uint8_t instance_number = convert_vap_name_to_index(
+                                      &((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop,
+                                      pcfg->vap_name) +
+            1;
+        wifi_vap_info_t *vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(instance_number - 1);
+
+        if (vapInfo == NULL) {
+            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Unable to get VAP info for instance_number:%d\n",
+                __FUNCTION__, __LINE__, instance_number);
+            return FALSE;
+        }
+        /* check the parameter name and set the corresponding value */
+        if (AnscEqualString(ParamName, "ConfigMethodsEnabled", TRUE)) {
+            int match = 0;
+
+            if (isVapSTAMesh(pcfg->vap_index)) {
+                wifi_util_dbg_print(WIFI_DMCLI, "%s:%d %s does not support configuration\n",
+                    __FUNCTION__, __LINE__, pcfg->vap_name);
+                return TRUE;
+            }
+            // Needs to initialize by 0 before setting
+            vapInfo->u.bss_info.wps.methods = 0;
+            /* save update to backup */
+            if (_ansc_strstr(pString, "USBFlashDrive")) {
+                match++;
+                vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods |
+                    WIFI_ONBOARDINGMETHODS_USBFLASHDRIVE);
+            }
+            if (_ansc_strstr(pString, "Ethernet")) {
+                match++;
+                vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods |
+                    WIFI_ONBOARDINGMETHODS_ETHERNET);
+            }
+            if (_ansc_strstr(pString, "ExternalNFCToken")) {
+                match++;
+                vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods |
+                    WIFI_ONBOARDINGMETHODS_EXTERNALNFCTOKEN);
+            }
+            if (_ansc_strstr(pString, "IntegratedNFCToken")) {
+                match++;
+                vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods |
+                    WIFI_ONBOARDINGMETHODS_INTEGRATEDNFCTOKEN);
+            }
+            if (_ansc_strstr(pString, "NFCInterface")) {
+                match++;
+                vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods |
+                    WIFI_ONBOARDINGMETHODS_NFCINTERFACE);
+            }
+            if (_ansc_strstr(pString, "PushButton")) {
+                match++;
+                vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods |
+                    WIFI_ONBOARDINGMETHODS_PUSHBUTTON);
+            }
+            if (_ansc_strstr(pString, "PIN")) {
+                match++;
+                vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods |
+                    WIFI_ONBOARDINGMETHODS_PIN);
+            }
+            if (_ansc_strstr(pString, "NONE")) {
+                match++;
+                vapInfo->u.bss_info.wps.methods = 0;
+                set_dml_cache_vap_config_changed(instance_number - 1);
+            }
+
+            // If match is not there then return error
+            if (match == 0) { // Might have passed value that is invalid
+                return FALSE;
+            }
+            if (vapInfo->u.bss_info.wps.methods != 0) {
+                set_dml_cache_vap_config_changed(instance_number - 1);
+            }
             return TRUE;
         }
-        //Needs to initialize by 0 before setting
-        vapInfo->u.bss_info.wps.methods = 0;
-        /* save update to backup */
-        if (_ansc_strstr(pString, "USBFlashDrive"))
-        {
-            match++;
-            vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods  | WIFI_ONBOARDINGMETHODS_USBFLASHDRIVE);
+
+        if (AnscEqualString(ParamName, "X_CISCO_COM_ClientPin", TRUE)) {
+            if ((strlen(pString) >= 4) && (strlen(pString) <= 8)) {
+                push_wps_pin_dml_to_ctrl_queue((instance_number - 1), pString);
+            } else {
+                return FALSE;
+            }
+            return TRUE;
         }
-        if (_ansc_strstr(pString, "Ethernet"))
-        {
-            match++;
-            vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods  | WIFI_ONBOARDINGMETHODS_ETHERNET);
-        }
-        if (_ansc_strstr(pString, "ExternalNFCToken"))
-        {
-            match++;
-            vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods  | WIFI_ONBOARDINGMETHODS_EXTERNALNFCTOKEN);
-        }
-        if (_ansc_strstr(pString, "IntegratedNFCToken"))
-        {
-            match++;
-            vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods  | WIFI_ONBOARDINGMETHODS_INTEGRATEDNFCTOKEN);
-        }
-        if (_ansc_strstr(pString, "NFCInterface"))
-        {
-            match++;
-            vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods  | WIFI_ONBOARDINGMETHODS_NFCINTERFACE);
-        }
-        if (_ansc_strstr(pString, "PushButton"))
-        {
-            match++;
-            vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods  | WIFI_ONBOARDINGMETHODS_PUSHBUTTON);
-        }
-        if (_ansc_strstr(pString, "PIN"))
-        {
-            match++;
-            vapInfo->u.bss_info.wps.methods = (vapInfo->u.bss_info.wps.methods  | WIFI_ONBOARDINGMETHODS_PIN);
-        }
-        if (_ansc_strstr(pString, "NONE"))
-        {
-            match++;
-            vapInfo->u.bss_info.wps.methods = 0;
-            set_dml_cache_vap_config_changed(instance_number - 1);
-        }
-
-        //If match is not there then return error
-        if (match == 0)
-        {   // Might have passed value that is invalid
-            return FALSE;
-        }
-        if (vapInfo->u.bss_info.wps.methods != 0)
-        {
-            set_dml_cache_vap_config_changed(instance_number - 1);
-        }
-        return TRUE;
-    }
-
-    if (AnscEqualString(ParamName, "X_CISCO_COM_ClientPin", TRUE))
-    {
-        if ((strlen(pString) >= 4) && (strlen(pString) <= 8)) {
-            push_wps_pin_dml_to_ctrl_queue((instance_number - 1), pString);
-        } else {
-            return FALSE;
-        }
-        return TRUE;
-    }
-
-
-    /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
-    return FALSE;
-}
-
-/**********************************************************************  
-
-    caller:     owner of this object 
-
-    prototype: 
-
-        BOOL
-        WPS_Validate
-            (
-                ANSC_HANDLE                 hInsContext,
-                char*                       pReturnParamName,
-                ULONG*                      puLength
-            );
-
-    description:
-
-        This function is called to finally commit all the update.
-
-    argument:   ANSC_HANDLE                 hInsContext,
-                The instance handle;
-
-                char*                       pReturnParamName,
-                The buffer (128 bytes) of parameter name if there's a validation. 
-
-                ULONG*                      puLength
-                The output length of the param name. 
-
-    return:     TRUE if there's no validation.
-
-**********************************************************************/
-BOOL
-WPS_Validate
-    (
-        ANSC_HANDLE                 hInsContext,
-        char*                       pReturnParamName,
-        ULONG*                      puLength
-    )
-{
-    wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
-    if (pcfg == NULL)
-    {
-        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Null pointer get fail\n", __FUNCTION__,__LINE__);
-        return FALSE;
-    }
-    uint8_t instance_number = convert_vap_name_to_index(&((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop, pcfg->vap_name)+1;
-    INT wlanIndex =  -1;
-    wlanIndex = instance_number -1;
-    dml_vap_default *cfg = (dml_vap_default *) get_vap_default(wlanIndex);
-    wifi_vap_info_t *vapInfo = (wifi_vap_info_t *) get_dml_cache_vap_info(instance_number-1);
-
-    if (wifiApIsSecmodeOpenForPrivateAP(wlanIndex) != ANSC_STATUS_SUCCESS)
-    {
+#else
+        wifi_util_info_print(WIFI_DMCLI, "%s:%d WPS is not supported\n", __FUNCTION__, __LINE__);
+#endif
         return FALSE;
     }
 
-    if (vapInfo->u.bss_info.wpsPushButton == true)
-    {
-        if (vapInfo->u.bss_info.wps.enable == false)
-        {
-            CcspWifiTrace(("RDK_LOG_ERROR,(%s) WPS is not enabled for vap %d\n", __func__, wlanIndex));
+    /**********************************************************************
 
-            vapInfo->u.bss_info.wpsPushButton = false;
+        caller:     owner of this object
+
+        prototype:
+
+            BOOL
+            WPS_Validate
+                (
+                    ANSC_HANDLE                 hInsContext,
+                    char*                       pReturnParamName,
+                    ULONG*                      puLength
+                );
+
+        description:
+
+            This function is called to finally commit all the update.
+
+        argument:   ANSC_HANDLE                 hInsContext,
+                    The instance handle;
+
+                    char*                       pReturnParamName,
+                    The buffer (128 bytes) of parameter name if there's a validation.
+
+                    ULONG*                      puLength
+                    The output length of the param name.
+
+        return:     TRUE if there's no validation.
+
+    **********************************************************************/
+    BOOL WPS_Validate(ANSC_HANDLE hInsContext, char *pReturnParamName, ULONG *puLength)
+    {
+#ifdef FEATURE_SUPPORT_WPS
+        wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
+        if (pcfg == NULL) {
+            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Null pointer get fail\n", __FUNCTION__,
+                __LINE__);
             return FALSE;
         }
+        uint8_t instance_number = convert_vap_name_to_index(
+                                      &((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop,
+                                      pcfg->vap_name) +
+            1;
+        INT wlanIndex = -1;
+        wlanIndex = instance_number - 1;
+        dml_vap_default *cfg = (dml_vap_default *)get_vap_default(wlanIndex);
+        wifi_vap_info_t *vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(instance_number - 1);
 
-        if ((cfg->wps_methods & WIFI_ONBOARDINGMETHODS_PUSHBUTTON) == 0)
-        {
-            CcspWifiTrace(("RDK_LOG_ERROR,(%s) WPS PBC is not configured for vap %d\n", __func__, wlanIndex));
-
-            vapInfo->u.bss_info.wpsPushButton = false;
+        if (wifiApIsSecmodeOpenForPrivateAP(wlanIndex) != ANSC_STATUS_SUCCESS) {
             return FALSE;
         }
+        if (vapInfo->u.bss_info.wpsPushButton == true) {
+            if (vapInfo->u.bss_info.wps.enable == false) {
+                CcspWifiTrace(
+                    ("RDK_LOG_ERROR,(%s) WPS is not enabled for vap %d\n", __func__, wlanIndex));
+
+                vapInfo->u.bss_info.wpsPushButton = false;
+                return FALSE;
+            }
+
+            if ((cfg->wps_methods & WIFI_ONBOARDINGMETHODS_PUSHBUTTON) == 0) {
+                CcspWifiTrace(("RDK_LOG_ERROR,(%s) WPS PBC is not configured for vap %d\n",
+                    __func__, wlanIndex));
+
+                vapInfo->u.bss_info.wpsPushButton = false;
+                return FALSE;
+            }
+        }
+        return TRUE;
+#endif
+        return FALSE;
     }
-    return TRUE;
-}
 
-/**********************************************************************  
+    /**********************************************************************
 
-    caller:     owner of this object 
+        caller:     owner of this object
 
-    prototype: 
+        prototype:
 
-        ULONG
-        WPS_Commit
-            (
-                ANSC_HANDLE                 hInsContext
-            );
+            ULONG
+            WPS_Commit
+                (
+                    ANSC_HANDLE                 hInsContext
+                );
 
-    description:
+        description:
 
-        This function is called to finally commit all the update.
+            This function is called to finally commit all the update.
 
-    argument:   ANSC_HANDLE                 hInsContext,
-                The instance handle;
+        argument:   ANSC_HANDLE                 hInsContext,
+                    The instance handle;
 
-    return:     The status of the operation.
+        return:     The status of the operation.
 
-**********************************************************************/
-ULONG
-WPS_Commit
-    (
-        ANSC_HANDLE                 hInsContext
-    )
-{
-    wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
-    uint8_t instance_number = convert_vap_name_to_index(&((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop, pcfg->vap_name)+1;
-    INT wlanIndex = instance_number -1;
-    wifi_vap_info_t *vapInfo = (wifi_vap_info_t *) get_dml_cache_vap_info(instance_number-1);
-
-    if (vapInfo->u.bss_info.wpsPushButton == true)
+    **********************************************************************/
+    ULONG
+    WPS_Commit(ANSC_HANDLE hInsContext)
     {
-        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d:Activate push button for vap %d\n",__func__, __LINE__, wlanIndex);
-        push_event_to_ctrl_queue(&wlanIndex, sizeof(wlanIndex), wifi_event_type_command, wifi_event_type_command_wps, NULL);
-        vapInfo->u.bss_info.wpsPushButton = false;
+#ifdef FEATURE_SUPPORT_WPS
+        wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
+        uint8_t instance_number = convert_vap_name_to_index(
+                                      &((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop,
+                                      pcfg->vap_name) +
+            1;
+        INT wlanIndex = instance_number - 1;
+        wifi_vap_info_t *vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(instance_number - 1);
+        if (vapInfo->u.bss_info.wpsPushButton == true) {
+            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d:Activate push button for vap %d\n", __func__,
+                __LINE__, wlanIndex);
+            push_event_to_ctrl_queue(&wlanIndex, sizeof(wlanIndex), wifi_event_type_command,
+                wifi_event_type_command_wps, NULL);
+            vapInfo->u.bss_info.wpsPushButton = false;
+        }
+        return TRUE;
+#endif
+        return FALSE;
     }
 
-    return TRUE;
-}
+    /**********************************************************************
 
-/**********************************************************************  
+        caller:     owner of this object
 
-    caller:     owner of this object 
+        prototype:
 
-    prototype: 
+            ULONG
+            WPS_Rollback
+                (
+                    ANSC_HANDLE                 hInsContext
+                );
 
-        ULONG
-        WPS_Rollback
-            (
-                ANSC_HANDLE                 hInsContext
-            );
+        description:
 
-    description:
+            This function is called to roll back the update whenever there's a
+            validation found.
 
-        This function is called to roll back the update whenever there's a 
-        validation found.
+        argument:   ANSC_HANDLE                 hInsContext,
+                    The instance handle;
 
-    argument:   ANSC_HANDLE                 hInsContext,
-                The instance handle;
+        return:     The status of the operation.
 
-    return:     The status of the operation.
-
-**********************************************************************/
-ULONG
-WPS_Rollback
-    (
-        ANSC_HANDLE                 hInsContext
-    )
-{
-    UNREFERENCED_PARAMETER(hInsContext);
-    return ANSC_STATUS_SUCCESS;
-}
+    **********************************************************************/
+    ULONG
+    WPS_Rollback(ANSC_HANDLE hInsContext)
+    {
+        UNREFERENCED_PARAMETER(hInsContext);
+        return ANSC_STATUS_SUCCESS;
+    }
 
 /**********************************************************************
 
@@ -12189,7 +12162,6 @@ BOOL
 IsValidMacAddress(char *mac)
 {
     int iter = 0, len = 0;
-
     len = strlen(mac);
     if(len != MAC_ADDR_LEN) {
 	CcspWifiTrace(("RDK_LOG_ERROR, (%s) MACAddress is not valid!!!\n", __func__));

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -1623,7 +1623,6 @@ webconfig_error_t decode_vap_common_object(const cJSON *vap, wifi_vap_info_t *va
         decode_param_allow_empty_string(vap, "WpsConfigPin", param);
         strcpy(vap_info->u.bss_info.wps.pin, param->valuestring);
     }
-
     // BeaconRateCtl
     decode_param_string(vap, "BeaconRateCtl", param);
     strcpy(vap_info->u.bss_info.beaconRateCtl, param->valuestring);
@@ -2183,9 +2182,11 @@ webconfig_error_t decode_wifi_global_config(const cJSON *global_cfg, wifi_global
     decode_param_integer(global_cfg, "VlanCfgVersion", param);
     global_info->vlan_cfg_version = param->valuedouble;
 
-    //WpsPin
+ #ifndef EASY_MESH_NODE
+    // WpsPin
     decode_param_string(global_cfg, "WpsPin", param);
     strcpy(global_info->wps_pin, param->valuestring);
+#endif
 
     // BandsteeringEnable
     decode_param_bool(global_cfg, "BandsteeringEnable", param);

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -428,7 +428,6 @@ webconfig_error_t encode_vap_common_object(const wifi_vap_info_t *vap_info,
 
     // BssHotspot
     cJSON_AddBoolToObject(vap_object, "BssHotspot", vap_info->u.bss_info.bssHotspot);
-
     // wpsPushButton
     cJSON_AddNumberToObject(vap_object, "WpsPushButton", vap_info->u.bss_info.wpsPushButton);
 
@@ -441,7 +440,6 @@ webconfig_error_t encode_vap_common_object(const wifi_vap_info_t *vap_info,
         //WpsConfigPin
         cJSON_AddStringToObject(vap_object, "WpsConfigPin", vap_info->u.bss_info.wps.pin);
     }
-
     // BeaconRateCtl
     cJSON_AddStringToObject(vap_object, "BeaconRateCtl", vap_info->u.bss_info.beaconRateCtl);
 
@@ -676,7 +674,7 @@ webconfig_error_t encode_wifi_global_config(const wifi_global_param_t *global_in
 
     //WpsPin
     cJSON_AddStringToObject(global_obj, "WpsPin", global_info->wps_pin);
-
+    
     // BandsteeringEnable
     cJSON_AddBoolToObject(global_obj, "BandsteeringEnable", (const cJSON_bool)global_info->bandsteering_enable);
 

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -2704,6 +2704,7 @@ webconfig_error_t translate_vap_info_to_vif_state_common(const wifi_vap_info_t *
         vap_row->wps = vap->u.bss_info.wps.enable;
         vap_row->wps_exists = true;
     } else {
+        wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: WPS is disabled for vap\n", __func__, __LINE__);
         vap_row->wps_exists=false;
     }
 
@@ -2713,6 +2714,7 @@ webconfig_error_t translate_vap_info_to_vif_state_common(const wifi_vap_info_t *
     } else {
         vap_row->wps_pbc_key_id_exists = false;
     }
+
     vap_row->vlan_id = iface_map->vlan_id;
     memset(vap_row->parent, 0, sizeof(vap_row->parent));
 
@@ -3872,8 +3874,10 @@ webconfig_error_t translate_ovsdb_to_vap_info_common(const struct schema_Wifi_VI
     vap->u.bss_info.bssTransitionActivated = vap_row->btm;
     vap->u.bss_info.nbrReportActivated = vap_row->rrm;
     vap->u.bss_info.wps.enable = vap_row->wps;
-    snprintf(vap->u.bss_info.wps.pin, sizeof(vap->u.bss_info.wps.pin),"%s",vap_row->wps_pbc_key_id);
-    wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: vapIndex : %d min_hw_mode %s\n", __func__, __LINE__, vap->vap_index, vap_row->min_hw_mode);
+    snprintf(vap->u.bss_info.wps.pin, sizeof(vap->u.bss_info.wps.pin), "%s",
+        vap_row->wps_pbc_key_id);
+    wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d: vapIndex : %d min_hw_mode %s\n", __func__, __LINE__,
+        vap->vap_index, vap_row->min_hw_mode);
     min_hw_mode_conversion(vap->vap_index, (char *)vap_row->min_hw_mode, "", "CONFIG");
     vif_radio_idx_conversion(vap->vap_index, (int *)&vap_row->vif_radio_idx, NULL, "CONFIG");
 


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: Moved WPS code under separate CFLAGS to enable for appropriate platforms.

Test Procedure:

1. Load the above mentioned build
2. If the loaded device supports WPS , then trigger the WPS push button led turns blue and client would connect via WPS.
3. If the loaded device doesn't support WPS, then trigger the WPS push button and verify the WPS didn't get triggered, if triggered then issue reproduced.

Risks: Medium

Priority: P1

Signed-off-by:sanjayvenkatesan1902@gmail.com