### PR TITLE
LTE-2598: protection from tx power 0 value

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -388,7 +388,9 @@ void callback_Wifi_Radio_Config(ovsdb_update_monitor_t *mon,
         l_radio_cfg->operationalDataTransmitRates = new_rec->operational_data_transmit_rate;
         l_radio_cfg->fragmentationThreshold = new_rec->fragmentation_threshold;
         l_radio_cfg->guardInterval = new_rec->guard_interval;
-        l_radio_cfg->transmitPower = new_rec->transmit_power;
+        if (new_rec->transmit_power != 0) {
+            l_radio_cfg->transmitPower = new_rec->transmit_power;
+        }
         l_radio_cfg->rtsThreshold = new_rec->rts_threshold;
         l_radio_cfg->factoryResetSsid = new_rec->factory_reset_ssid;
         l_radio_cfg->radioStatsMeasuringRate = new_rec->radio_stats_measuring_rate;
@@ -1958,7 +1960,7 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
     config->operationalDataTransmitRates = cfg->operational_data_transmit_rate;
     config->fragmentationThreshold = cfg->fragmentation_threshold;
     config->guardInterval = cfg->guard_interval;
-    config->transmitPower = cfg->transmit_power;
+    config->transmitPower = cfg->transmit_power != 0 ? cfg->transmit_power : 100;
     config->rtsThreshold = cfg->rts_threshold;
     config->factoryResetSsid = cfg->factory_reset_ssid;
     config->radioStatsMeasuringRate = cfg->radio_stats_measuring_rate;

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -2879,6 +2879,10 @@ webconfig_error_t decode_radio_object(const cJSON *obj_radio, rdk_wifi_radio_t *
     // TransmitPower
     decode_param_integer(obj_radio, "TransmitPower", param);
     radio_info->transmitPower = param->valuedouble;
+    if (radio_info->transmitPower == 0) {
+        wifi_util_error_print(WIFI_WEBCONFIG, "Invalid TransmitPower value 0, set to 100\n");
+        radio_info->transmitPower = 100;
+    }
 
     // RtsThreshold
     decode_param_integer(obj_radio, "RtsThreshold", param);

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -263,8 +263,9 @@ webconfig_error_t encode_radio_object(const rdk_wifi_radio_t *radio, cJSON *radi
     // GuardInterval
     cJSON_AddNumberToObject(radio_object, "GuardInterval", radio_info->guardInterval);
 
-    // TransmitPower
-    cJSON_AddNumberToObject(radio_object, "TransmitPower", radio_info->transmitPower);
+    // TransmitPower, 0 not allowed
+    cJSON_AddNumberToObject(radio_object, "TransmitPower",
+        radio_info->transmitPower != 0 ? radio_info->transmitPower : 100);
 
     // BeaconInterval
     cJSON_AddNumberToObject(radio_object, "BeaconInterval", radio_info->beaconInterval);


### PR DESCRIPTION
Reason for change:
  0 tx power value is invalid and leads to webconfig failure
  root cause of 0 value unknown
Test Procedure:
Risks: Low
Priority: P1