### PR TITLE
wifi_easyconnect.c: add new path for BSS info publishing

### DIFF
--- a/source/apps/easyconnect/wifi_easyconnect.h
+++ b/source/apps/easyconnect/wifi_easyconnect.h
@@ -26,6 +26,7 @@ extern "C" {
 
 #define WIFI_EASYCONNECT_RADIO_TABLE        "Device.WiFi.Radio.{i}"
 #define WIFI_EASYCONNECT_RADIO_CCE_IND      "Device.WiFi.Radio.{i}.CCEInd"
+#define WIFI_EASYCONNECT_BSS_INFO           "Device.WiFi.EC.BSSInfo"
 
 typedef struct _easyconnect_data {
     bool subscriptions[MAX_NUM_RADIOS];


### PR DESCRIPTION
EasyConnect implementors (such as unified-wifi-mesh) need to be able to parse beacons and probe responses and search for a given SSID to build their DPP Reconfiguration Announcement channel list

This expands the CCE IE HAL callback and publishes each BSS info heard for consumption / parsing by external apps

The reasoning for this logic can be found in Wi-Fi Alliance EasyConnect standard V3 section 6.5.2:

From the spec, specifically section 2.:
```
Enrollee -> Configurator: SHA-256(C-sign-key), group, A-NONCE, E'-id
Enrollees that send this message first derive a channel list for sending the DPP Reconfiguration Announcement frame
using the following steps:
1. Select preferred channels on which to send a DPP Presence Announcement frame to the broadcast address. For
interoperability purposes, the preferred channel shall be one from each of the following channels:
 2.4 GHz: Channel 6 (2.437 GHz)
 5 GHz: Channel 44 (5.220 GHz) if local regulations permit operation only in the 5.150 – 5.250 GHz band and
Channel 149 (5.745 GHz) otherwise
 60 GHz: Channel 2 (60.48 GHz)
 Sub-1 GHz: Channel 37 (920.5 MHz) if local regulations permit use of global operating class 68 (ITU Region
2, Australia, New Zealand, Singapore) otherwise Channel 1 (863.5 MHz) if local regulations permit use of
global operating class 66 (Europe)
Add the preferred channels to the channel list; then,
2. For each channel on which the Enrollee detects the SSID for which it is currently configured, add to the channel
list; then,
3. Scan all supported bands and add each channel on which an AP is advertising the Configurator Connectivity IE
(section 8.5.2) to the channel list; then,
4. Remove any duplicate channels.
```