### PR TITLE
RDKB-50264,XER10-1146 : ctrl lock refactoring (#229)

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -574,6 +574,7 @@ typedef struct {
     hash_map_t              *acl_map;
     hash_map_t              *associated_devices_map; //Full
     hash_map_t              *associated_devices_diff_map; //Add,Remove
+    pthread_mutex_t         *associated_devices_lock;
     int                     kick_device_task_counter;
     bool                    kick_device_config_change;
     bool                    is_mac_filter_initialized;

--- a/source/apps/blaster/wifi_blaster.c
+++ b/source/apps/blaster/wifi_blaster.c
@@ -160,7 +160,10 @@ bool is_blaster_device_associated(int ap_index, mac_address_t sta_mac)
         wifi_util_error_print(WIFI_BLASTER, "%s: Failed to get rdk_vap_info from vap index %d\n", __func__, ap_index);
         return false;
     }
+
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
     if (rdk_vap_info->associated_devices_map == NULL) {
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         wifi_util_error_print(WIFI_BLASTER,"%s:%d NULL  associated_devices_map  pointer  for  %d\n", __func__, __LINE__, rdk_vap_info->vap_index);
         return false;
     }
@@ -169,6 +172,7 @@ bool is_blaster_device_associated(int ap_index, mac_address_t sta_mac)
 
     to_sta_key(sta_mac, sta_key);
     sta = (assoc_dev_data_t *) hash_map_get(rdk_vap_info->associated_devices_map, sta_key);
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
     if (sta == NULL) {
         wifi_util_error_print(WIFI_BLASTER, "%s: Failed to get sta from vap index %d\n", __func__, ap_index);
         return false;

--- a/source/apps/harvester/wifi_harvester.c
+++ b/source/apps/harvester/wifi_harvester.c
@@ -95,7 +95,10 @@ bool is_harvester_device_associated(int ap_index, mac_address_t sta_mac)
         wifi_util_error_print(WIFI_HARVESTER, "%s: Failed to get rdk_vap_info from vap index %d\n", __func__, ap_index);
         return false;
     }
+
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
     if (rdk_vap_info->associated_devices_map == NULL) {
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         wifi_util_error_print(WIFI_HARVESTER,"%s:%d NULL  associated_devices_map  pointer  for  %d\n", __func__, __LINE__, rdk_vap_info->vap_index);
         return false;
     }
@@ -104,6 +107,7 @@ bool is_harvester_device_associated(int ap_index, mac_address_t sta_mac)
 
     to_sta_key(sta_mac, sta_key);
     sta = (assoc_dev_data_t *) hash_map_get(rdk_vap_info->associated_devices_map, sta_key);
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
     if (sta == NULL) {
         wifi_util_error_print(WIFI_HARVESTER, "%s: Failed to get sta from vap index %d\n", __func__, ap_index);
         return false;

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -116,6 +116,8 @@ extern "C" {
 
 #define BUS_DML_CONFIG_FILE "bus_dml_config.json"
 
+#define CTRL_QUEUE_SIZE_MAX 500
+
 typedef enum {
     ctrl_webconfig_state_none = 0,
     ctrl_webconfig_state_radio_cfg_rsp_pending = 0x0001,
@@ -212,7 +214,7 @@ typedef struct hotspot_cfg_sem_param {
 typedef struct wifi_ctrl {
     bool                exit_ctrl;
     queue_t             *queue;
-    pthread_mutex_t     lock;
+    pthread_mutex_t     queue_lock;
     pthread_cond_t      cond;
     pthread_mutexattr_t attr;
     unsigned int        poll_period;

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -915,16 +915,20 @@ bool  IsClientConnected(rdk_wifi_vap_info_t* rdk_vap_info, char *check_mac)
         return false;
     }
 
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
     if (rdk_vap_info->associated_devices_map) {
         str_tolower(check_mac);
         assoc_dev_data = hash_map_get(rdk_vap_info->associated_devices_map, check_mac);
         if (assoc_dev_data != NULL) {
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
             return true;
         }
     } else {
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         wifi_util_error_print(WIFI_CTRL, "%s:%d associated_devices_map is NULL for vap : %d\n",__func__, __LINE__, rdk_vap_info->vap_index);
         return false;
     }
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
 
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d Client is not connected to vap_index\n", __func__, __LINE__);
@@ -1054,10 +1058,7 @@ void kick_all_macs(int vap_index, int timeout, rdk_wifi_vap_info_t* rdk_vap_info
         wifi_util_dbg_print(WIFI_CTRL, "%s:%d Failed to kick all mac from ap_index %d\n", __func__, __LINE__, vap_index);
         return;
     }
-    if (rdk_vap_info->associated_devices_map ==  NULL) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d Error Associated devices hash map is NULL\n", __func__, __LINE__);
-        return;
-    }
+
     kick_details = (kick_details_t *)malloc(sizeof(kick_details_t));
     if (kick_details == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d NULL data Pointer\n", __func__, __LINE__);
@@ -1072,6 +1073,17 @@ void kick_all_macs(int vap_index, int timeout, rdk_wifi_vap_info_t* rdk_vap_info
     }
 
     memset(assoc_maclist, 0, 2048);
+
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
+    if (rdk_vap_info->associated_devices_map == NULL) {
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Error Associated devices hash map is NULL\n",
+            __func__, __LINE__);
+        free(kick_details);
+        free(assoc_maclist);
+        return;
+    }
+
     assoc_dev_data = hash_map_get_first(rdk_vap_info->associated_devices_map);
     while (assoc_dev_data != NULL) {
         memset(mac_str, 0, sizeof(mac_addr_str_t));
@@ -1110,6 +1122,8 @@ void kick_all_macs(int vap_index, int timeout, rdk_wifi_vap_info_t* rdk_vap_info
         strcat(assoc_maclist, ",");
         assoc_dev_data = hash_map_get_next(rdk_vap_info->associated_devices_map, assoc_dev_data);
     }
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
+
     int len = strlen(assoc_maclist);
     if (len > 0) {
         assoc_maclist[len-1] = '\0';
@@ -1457,6 +1471,7 @@ void process_wifi_host_sync()
                 break;
             }
             count = 0;
+            pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
             if (rdk_vap_info->associated_devices_map != NULL) {
                 assoc_dev_data = hash_map_get_first(rdk_vap_info->associated_devices_map);
                 while (assoc_dev_data != NULL) {
@@ -1483,6 +1498,7 @@ void process_wifi_host_sync()
             } else {
                 wifi_util_error_print(WIFI_CTRL,"%s:%d Error associated_devices_map is NULL for vap %d\n", __func__, __LINE__, rdk_vap_info->vap_index);
             }
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         }
     }
     if (notify_LM_Lite(&p_wifi_mgr->ctrl, &hosts, false) != RETURN_OK) {
@@ -1581,15 +1597,12 @@ void process_disassoc_device_event(void *data)
         return;
     }
 
-    if (rdk_vap_info->associated_devices_map == NULL) {
-        wifi_util_error_print(WIFI_CTRL,"%s:%d NULL Pointer\n", __func__, __LINE__);
-        return;
-    }
     memset(mac_str, 0, sizeof(mac_str));
     to_mac_str(assoc_data->dev_stats.cli_MACAddress, mac_str);
 
     if ((memcmp(assoc_data->dev_stats.cli_MACAddress, disassoc_mac, sizeof(mac_address_t)) == 0) ||
             (memcmp(assoc_data->dev_stats.cli_MACAddress, zero_mac, sizeof(mac_address_t)) == 0)) {
+        pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
         if (rdk_vap_info->associated_devices_map !=  NULL) {
             assoc_dev_data =  hash_map_get_first(rdk_vap_info->associated_devices_map);
             while (assoc_dev_data != NULL) {
@@ -1604,6 +1617,7 @@ void process_disassoc_device_event(void *data)
                     if (add_client_diff_assoclist(&rdk_vap_info->associated_devices_diff_map, mac_str, temp_assoc_dev_data) == RETURN_ERR) {
                         wifi_util_error_print(WIFI_CTRL,"%s:%d Failed to update diff assoclist for vap %d mac_str : %s\n", __func__, __LINE__, rdk_vap_info->vap_index, mac_str);
                         free(temp_assoc_dev_data);
+                        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
                         return;
                     }
                     p_wifi_mgr->ctrl.webconfig_state |= ctrl_webconfig_state_associated_clients_cfg_rsp_pending;
@@ -1613,6 +1627,8 @@ void process_disassoc_device_event(void *data)
                 }
             }
         }
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
+
         new_count  = 0;
         if (((isVapPrivate(rdk_vap_info->vap_index)) || (isVapXhs(rdk_vap_info->vap_index)))){
             if (notify_associated_entries(&p_wifi_mgr->ctrl, rdk_vap_info->vap_index, new_count, old_count) != RETURN_OK) {
@@ -1624,6 +1640,7 @@ void process_disassoc_device_event(void *data)
         return;
     }
 
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
     if (rdk_vap_info->associated_devices_map !=  NULL) {
         old_count = hash_map_count(rdk_vap_info->associated_devices_map);
 
@@ -1633,6 +1650,7 @@ void process_disassoc_device_event(void *data)
             if (add_client_diff_assoclist(&rdk_vap_info->associated_devices_diff_map, mac_str, temp_assoc_dev_data) == RETURN_ERR) {
                 wifi_util_error_print(WIFI_CTRL,"%s:%d Failed to update diff assoclist for vap %d mac_str : %s\n", __func__, __LINE__, rdk_vap_info->vap_index, mac_str);
                 free(temp_assoc_dev_data);
+                pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
                 return;
             }
             p_wifi_mgr->ctrl.webconfig_state |= ctrl_webconfig_state_associated_clients_cfg_rsp_pending;
@@ -1650,7 +1668,7 @@ void process_disassoc_device_event(void *data)
         wifi_util_info_print(WIFI_CTRL,"%s:%d Disassoc event for mac : %s, Removed the entry from hashmap\n", __func__, __LINE__, mac_str);
 
     }
-    return;
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
 }
 
 void process_assoc_device_event(void *data)
@@ -1679,7 +1697,10 @@ void process_assoc_device_event(void *data)
         wifi_util_error_print(WIFI_CTRL,"%s:%d NULL rdk_vap_info pointer\n", __func__, __LINE__);
         return;
     }
+
+    pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
     if (rdk_vap_info->associated_devices_map == NULL) {
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
         wifi_util_error_print(WIFI_CTRL,"%s:%d NULL  associated_devices_map  pointer  for  %d\n", __func__, __LINE__, rdk_vap_info->vap_index);
         return;
     }
@@ -1693,12 +1714,14 @@ void process_assoc_device_event(void *data)
         old_count = hash_map_count(rdk_vap_info->associated_devices_map);
         tmp_assoc_dev_data = (assoc_dev_data_t *)malloc(sizeof(assoc_dev_data_t));
         if (tmp_assoc_dev_data == NULL) {
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
             wifi_util_error_print(WIFI_CTRL,"%s:%d NULL tmp_assoc_dev_data pointer for vap %d\n", __func__, __LINE__, rdk_vap_info->vap_index);
             return;
         }
         memcpy(tmp_assoc_dev_data, assoc_data, sizeof(assoc_dev_data_t));
         tmp_assoc_dev_data->client_state = client_state_connected;
         if (add_client_diff_assoclist(&rdk_vap_info->associated_devices_diff_map, mac_str, tmp_assoc_dev_data) == RETURN_ERR) {
+            pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
             wifi_util_error_print(WIFI_CTRL,"%s:%d Failed to update diff assoclist for vap %d mac_str : %s\n", __func__, __LINE__, rdk_vap_info->vap_index, mac_str);
             free(tmp_assoc_dev_data);
             return;
@@ -1725,6 +1748,8 @@ void process_assoc_device_event(void *data)
 
         }
     }
+    pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
+
     if ((isVapPrivate(rdk_vap_info->vap_index))) {
         if (pcfg != NULL && pcfg->prefer_private) {
             pub_svc = get_svc_by_type(&p_wifi_mgr->ctrl, vap_svc_type_public);
@@ -1743,6 +1768,7 @@ void process_assoc_device_event(void *data)
         memset(&hosts, 0, sizeof(LM_wifi_hosts_t));
         strncpy((char *)hosts.host[0].ssid, ssid, sizeof(hosts.host[0].ssid));
 
+        pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
         if (rdk_vap_info->associated_devices_map != NULL) {
             str_tolower(mac_str);
             itrj = hash_map_count(rdk_vap_info->associated_devices_map);
@@ -1778,6 +1804,7 @@ void process_assoc_device_event(void *data)
                 wifi_util_error_print(WIFI_CTRL,"%s:%d Unable to send notification to LMLite\n", __func__, __LINE__);
             }
         }
+        pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
     }
 }
 

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -243,6 +243,7 @@ int  webconfig_free_vap_object_diff_assoc_client_entries(webconfig_subdoc_data_t
                 wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: rdk_vap_info is null", __func__, __LINE__);
                 return RETURN_ERR;
             }
+            pthread_mutex_lock(rdk_vap_info->associated_devices_lock);
             if (rdk_vap_info->associated_devices_diff_map != NULL) {
                 assoc_dev_data = hash_map_get_first(rdk_vap_info->associated_devices_diff_map);
                 while(assoc_dev_data != NULL) {
@@ -259,10 +260,12 @@ int  webconfig_free_vap_object_diff_assoc_client_entries(webconfig_subdoc_data_t
             //Clearing the global memory
             tmp_rdk_vap_info = get_wifidb_rdk_vap_info(decoded_params->radios[i].vaps.rdk_vap_array[j].vap_index);
             if (tmp_rdk_vap_info == NULL) {
+                pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
                 wifi_util_error_print(WIFI_CTRL,"%s:%d NULL rdk_vap_info pointer\n", __func__, __LINE__);
                 return RETURN_ERR;
             }
             tmp_rdk_vap_info->associated_devices_diff_map = NULL;
+            pthread_mutex_unlock(tmp_rdk_vap_info->associated_devices_lock);
         }
     }
     return RETURN_OK;

--- a/source/core/wifi_events.c
+++ b/source/core/wifi_events.c
@@ -666,6 +666,7 @@ int push_monitor_response_event_to_ctrl_queue(const void *msg, unsigned int len,
 {
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     wifi_event_t *event;
+    bool is_limit_reached;
 
     if (msg == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s %d  msg is null\n", __FUNCTION__, __LINE__);
@@ -696,10 +697,21 @@ int push_monitor_response_event_to_ctrl_queue(const void *msg, unsigned int len,
             return RETURN_ERR;
         }
 
-        pthread_mutex_lock(&ctrl->lock);
-        queue_push(ctrl->queue, event);
-        pthread_cond_signal(&ctrl->cond);
-        pthread_mutex_unlock(&ctrl->lock);
+        pthread_mutex_lock(&ctrl->queue_lock);
+        is_limit_reached = queue_count(ctrl->queue) >= CTRL_QUEUE_SIZE_MAX;
+        if (!is_limit_reached) {
+            queue_push(ctrl->queue, event);
+            pthread_cond_signal(&ctrl->cond);
+        }
+        pthread_mutex_unlock(&ctrl->queue_lock);
+
+        if (is_limit_reached) {
+            wifi_util_error_print(WIFI_CTRL,
+                "%s:%d max queue size reached, drop message type: %s subtype: %s\n", __FUNCTION__,
+                __LINE__, wifi_event_type_to_string(type), wifi_event_subtype_to_string(sub_type));
+            destroy_wifi_event(event);
+            return RETURN_ERR;
+        }
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s %d Invalid type : %s subtype : %s\n", __FUNCTION__,
             __LINE__, wifi_event_type_to_string(type), wifi_event_subtype_to_string(sub_type));
@@ -714,6 +726,7 @@ int push_event_to_ctrl_queue(const void *msg, unsigned int len, wifi_event_type_
 {
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     wifi_event_t *event;
+    bool is_limit_reached;
 
     if (msg == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s %d  msg is null\n", __FUNCTION__, __LINE__);
@@ -740,10 +753,21 @@ int push_event_to_ctrl_queue(const void *msg, unsigned int len, wifi_event_type_
         event->u.core_data.len = 0;
     }
 
-    pthread_mutex_lock(&ctrl->lock);
-    queue_push(ctrl->queue, event);
-    pthread_cond_signal(&ctrl->cond);
-    pthread_mutex_unlock(&ctrl->lock);
+    pthread_mutex_lock(&ctrl->queue_lock);
+    is_limit_reached = queue_count(ctrl->queue) >= CTRL_QUEUE_SIZE_MAX;
+    if (!is_limit_reached) {
+        queue_push(ctrl->queue, event);
+        pthread_cond_signal(&ctrl->cond);
+    }
+    pthread_mutex_unlock(&ctrl->queue_lock);
+
+    if (is_limit_reached) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d max queue size reached, drop message type: %s subtype: %s\n", __FUNCTION__,
+            __LINE__, wifi_event_type_to_string(type), wifi_event_subtype_to_string(sub_type));
+        destroy_wifi_event(event);
+        return RETURN_ERR;
+    }
 
     return RETURN_OK;
 }
@@ -753,6 +777,7 @@ int push_event_to_monitor_queue(wifi_monitor_data_t *mon_data, wifi_event_subtyp
 {
     wifi_monitor_t *monitor_param = (wifi_monitor_t *)get_wifi_monitor();
     wifi_event_t *event;
+    bool is_limit_reached;
 
     /* Check if monitor queue is initialized */
     if (monitor_initialization_done == false) {
@@ -781,9 +806,19 @@ int push_event_to_monitor_queue(wifi_monitor_data_t *mon_data, wifi_event_subtyp
     }
 
     pthread_mutex_lock(&monitor_param->queue_lock);
-    queue_push(monitor_param->queue, event);
-    pthread_cond_signal(&monitor_param->cond);
+    is_limit_reached = queue_count(monitor_param->queue) >= MONITOR_QUEUE_SIZE_MAX;
+    if (!is_limit_reached) {
+        queue_push(monitor_param->queue, event);
+        pthread_cond_signal(&monitor_param->cond);
+    }
     pthread_mutex_unlock(&monitor_param->queue_lock);
+
+    if (is_limit_reached) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d max queue size reached, drop message subtype: %s\n",
+            __FUNCTION__, __LINE__, wifi_event_subtype_to_string(sub_type));
+        destroy_wifi_event(event);
+        return RETURN_ERR;
+    }
 
     return RETURN_OK;
 }

--- a/source/stats/wifi_monitor.h
+++ b/source/stats/wifi_monitor.h
@@ -30,6 +30,8 @@
 
 #define  ANSC_STATUS_SUCCESS                        0
 
+#define MONITOR_QUEUE_SIZE_MAX 500
+
 typedef struct {
     unsigned int        rapid_reconnect_threshold;
     wifi_vapstatus_t    ap_status;


### PR DESCRIPTION
Reason for change: deadlocks due to timers executed with ctrl lock. 
Test Procedure:
 - restart VAP by enabling-disabling multiple times, connect-disconnect multiple clients 
Risks: medium
Priority: P1