### PR TITLE
RDKB-59404: OpenWRT related onewifi configuration

### DIFF
--- a/config/openwrt/banana-pi/InterfaceMap.json
+++ b/config/openwrt/banana-pi/InterfaceMap.json
@@ -1,0 +1,62 @@
+{
+    "PhyList": [
+        {
+            "Index": 0,
+            "RadioList": [
+                 {
+                    "Index": 2,
+                    "RadioName": "wifi2",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi2",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 16,
+                            "vapName": "private_ssid_6g"
+                        }
+                    ]
+                },
+                {
+                    "Index": 1,
+                    "RadioName": "wifi1",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi1",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 1,
+                            "vapName": "private_ssid_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi1.1",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 15,
+                            "vapName": "mesh_sta_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi1.2",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 13,
+                            "vapName": "mesh_backhaul_5g"
+                        }
+                    ]
+                },
+                {
+                    "Index": 0,
+                    "RadioName": "wifi0",
+                    "InterfaceList": [
+                        {
+                            "InterfaceName": "wifi0",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 0,
+                            "vapName": "private_ssid_2g"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/config/openwrt/banana-pi/etc/init.d/onewifi
+++ b/config/openwrt/banana-pi/etc/init.d/onewifi
@@ -1,0 +1,67 @@
+#!/bin/sh /etc/rc.common
+
+START=99  # Service startup order
+STOP=01  # Service stop order
+USE_PROCD=1
+Name=OneWifi
+
+start_service() {
+    echo "Starting onewifi service..." >> /tmp/onewifi_log.txt
+    # Run wifi_interface_up.sh only once after boot
+    if [ ! -f /tmp/onewifi_bootup_completed ]; then
+        echo "Running wifi_interface_up.sh..." >> /tmp/onewifi_log.txt
+        cd /banana-pi
+        ./wifi_interface_up.sh >> /tmp/onewifi_log.txt
+        cd -
+        touch /tmp/onewifi_bootup_completed  # Create flag to ensure it's not run again
+    fi
+
+    # Use procd to manage the OneWifi process
+    procd_open_instance
+    procd_set_param command /usr/bin/OneWifi -c  # Command with arguments
+    procd_set_param respawn 50 10 10  # Automatically restart if down
+    procd_set_param limits core="unlimited"
+    procd_set_param limits stack="unlimited"
+    procd_set_param stdout 1 # forward stdout of the command to logd
+    procd_set_param stderr 1 # same for stderr
+    procd_set_param pidfile /tmp/onewifi.pid
+    procd_close_instance
+
+    # Start the main process for onewifi
+    #/usr/bin/OneWifi -c &   # Replace this with your process path or command
+    #echo $! > /tmp/onewifi.pid   # Save the PID of the process
+}
+
+stop_service() {
+    echo "Stopping onewifi service..." >> /tmp/onewifi_log.txt
+    # Stop the main process if it is running
+    if [ -f /tmp/onewifi.pid ]; then
+        kill -9 "$(cat /tmp/onewifi.pid)"  # Kill the process
+        rm -f /tmp/onewifi.pid         # Remove the PID file
+    fi
+    cd /banana-pi
+    ./wifi_interface_down.sh >> /tmp/onewifi_log.txt
+    cd -
+    if [ -f /tmp/onewifi_bootup_completed ]; then
+       rm -rf /tmp/onewifi_bootup_completed
+    fi
+}
+
+restart_service() {
+    echo "Restart triggered for onewifi service..."
+    stop
+    start
+}
+
+reload_service() {
+    echo "Reload triggered for onewifi service..."
+    stop
+    start
+}
+
+service_triggers() {
+    echo "Setting up respawn trigger for onewifi service..."
+    procd_add_reload_trigger "/nvram/EasymeshCfg.json" "/nvram/InterfaceMap.json"
+}
+
+

--- a/config/openwrt/banana-pi/wifi_interface_down.sh
+++ b/config/openwrt/banana-pi/wifi_interface_down.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+echo "Bringing down all wifi interfaces and deleting it"
+ifconfig wifi0 down
+ifconfig wifi1 down
+ifconfig wifi1.1 down
+ifconfig wifi1.2 down
+ifconfig wifi2 down
+
+#delete the interfaces
+iw dev wifi0 del
+iw dev wifi1 del
+iw dev wifi1.1 del
+iw dev wifi1.2 del
+iw dev wifi2 del

--- a/config/openwrt/banana-pi/wifi_interface_up.sh
+++ b/config/openwrt/banana-pi/wifi_interface_up.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+/etc/init.d/wpad stop
+
+iw phy phy0 interface add wifi0 type __ap
+iw phy phy0 interface add wifi1 type __ap
+iw phy phy0 interface add wifi1.1 type __ap
+iw phy phy0 interface add wifi1.2 type __ap
+iw phy phy0 interface add wifi2 type __ap
+
+#Derive the initial wifi mac address from eth0 or erouter0 address
+#as they are unique for each Banana PI
+if [ -e "/sys/class/net/erouter0/address" ]; then
+	primary_addr="$(cat /sys/class/net/erouter0/address)"
+	echo "Reading mac:$primary_addr from erouter0"
+	#Convert the mac address into hex and increment by 1
+	primary_wifi_mac=$(echo $primary_addr | tr -d ':')
+	primary_wifi_mac=$((0x$primary_wifi_mac + 1))
+elif [ -e "/sys/class/net/eth0/address" ]; then
+        primary_addr="$(cat /sys/class/net/eth0/address)"
+        echo "Reading mac:$primary_addr from eth0"
+	primary_wifi_mac=$(echo $primary_addr | tr -d ':')
+	primary_wifi_mac=$((0x$primary_wifi_mac + 1))
+else
+	primary_addr="$(cat /sys/class/ieee80211/phy0/macaddress)"
+	primary_wifi_mac=$(echo $primary_addr | tr -d ':')
+	primary_wifi_mac=$((0x$primary_wifi_mac + 0))
+fi
+
+#Obtain the wifi0 mac address from primary_wifi_mac by converting to str format
+wifi0_mac=$(printf "%012x" $primary_wifi_mac | sed 's/../&:/g;s/:$//')
+#Increment primary_wifi_mac by 1 to get wifi1_mac
+mac_incr=$(($primary_wifi_mac + 1))
+wifi1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi1.1 address
+mac_incr=$(($mac_incr + 1))
+wifi1_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi1.2 address
+mac_incr=$(($mac_incr + 1))
+wifi1_2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi2 address
+mac_incr=$(($mac_incr + 1))
+wifi2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#print the mac address
+echo $wifi0_mac
+echo $wifi1_mac
+echo $wifi1_1_mac
+echo $wifi1_2_mac
+echo $wifi2_mac
+
+#Update the mac address using ip link command
+ifconfig wifi0 down
+ifconfig wifi1 down
+ifconfig wifi1.1 down
+ifconfig wifi1.2 down
+ifconfig wifi2 down
+ip link set dev wifi0 address $wifi0_mac
+ip link set dev wifi1 address $wifi1_mac
+ip link set dev wifi1.1 address $wifi1_1_mac
+ip link set dev wifi1.2 address $wifi1_2_mac
+ip link set dev wifi2 address $wifi2_mac
+ifconfig wifi0 up
+ifconfig wifi1 up
+ifconfig wifi1.1 up
+ifconfig wifi1.2 up
+ifconfig wifi2 up
+
+# Create the EasyMeshCfg.json which will have the al_mac_address
+# same as that of wifi_1_1_mac
+al_mac_addr=$wifi1_1_mac
+colocated_mode=0
+backhaul_ssid="mesh_backhaul"
+backhaul_keypassphrase="test-backhaul"
+sta_4addr_mode_enabled=true
+
+# Construct the JSON string
+json_data=$(cat <<EOF
+{
+  "AL_MAC_ADDR": "${al_mac_addr}",
+  "Colocated_mode": ${colocated_mode},
+  "Backhaul_SSID": "${backhaul_ssid}",
+  "Backhaul_KeyPassphrase": "${backhaul_keypassphrase}",
+  "sta_4addr_mode_enabled": ${sta_4addr_mode_enabled}
+}
+EOF
+)
+
+# Write the JSON data to the file
+output_file="EasymeshCfg.json"
+echo "$json_data" > "$output_file"
+
+# Print a confirmation message
+echo "Successfully created ${output_file} with the following content:"
+cat "$output_file"
+
+#Copy configuration file to nvram
+mkdir -p /nvram
+cp InterfaceMap.json /nvram/.
+cp EasymeshCfg.json /nvram/.


### PR DESCRIPTION
Few files which are required for onewifi execution on OpenWRT 1)InterfaceMap.json to depict the initial interfaces and mapping. 2)/etc/init.d/onewifi systemd related file
3)log_enablement.sh to enable certain important logging 4)wifi_interface_up.sh to bring up wifi interface with associated EasymeshCfg.json changes.
5)wifi_interface_down.sh to bring down wifi interfaces and cleanup.