### PR TITLE
RDKB-58759:Passpoint dmcli parameters don't report values

### DIFF
--- a/source/core/wifi_passpoint.c
+++ b/source/core/wifi_passpoint.c
@@ -1245,12 +1245,12 @@ INT WiFi_GetWANMetrics(uint8_t vapIndex, char *WANMetrics, UINT WANMetrics_lengt
 
     mainEntry = cJSON_AddObjectToObject(passPointCfg,"WANMetrics");
 
-    cJSON_AddNumberToObject(mainEntry,"WANInfo",g_interworking_data[apIns].passpoint.wanMetricsInfo.wanInfo); 
-    cJSON_AddNumberToObject(mainEntry,"DownlinkSpeed",g_interworking_data[apIns].passpoint.wanMetricsInfo.downLinkSpeed); 
-    cJSON_AddNumberToObject(mainEntry,"UplinkSpeed",g_interworking_data[apIns].passpoint.wanMetricsInfo.upLinkSpeed);
-    cJSON_AddNumberToObject(mainEntry,"DownlinkLoad",g_interworking_data[apIns].passpoint.wanMetricsInfo.downLinkLoad); 
-    cJSON_AddNumberToObject(mainEntry,"UplinkLoad",g_interworking_data[apIns].passpoint.wanMetricsInfo.upLinkLoad); 
-    cJSON_AddNumberToObject(mainEntry,"LMD",g_interworking_data[apIns].passpoint.wanMetricsInfo.lmd); 
+    cJSON_AddNumberToObject(mainEntry,"WANInfo",pCfg->passpoint.wanMetricsInfo.wanInfo); 
+    cJSON_AddNumberToObject(mainEntry,"DownlinkSpeed",pCfg->passpoint.wanMetricsInfo.downLinkSpeed); 
+    cJSON_AddNumberToObject(mainEntry,"UplinkSpeed",pCfg->passpoint.wanMetricsInfo.upLinkSpeed);
+    cJSON_AddNumberToObject(mainEntry,"DownlinkLoad",pCfg->passpoint.wanMetricsInfo.downLinkLoad); 
+    cJSON_AddNumberToObject(mainEntry,"UplinkLoad",pCfg->passpoint.wanMetricsInfo.upLinkLoad);
+    cJSON_AddNumberToObject(mainEntry,"LMD",pCfg->passpoint.wanMetricsInfo.lmd); 
 
 #if 0
     //cJSON_PrintPreallocated(passPointCfg, (char *)&pCfg->IEEE80211uCfg.PasspointCfg.WANMetrics, sizeof(pCfg->IEEE80211uCfg.PasspointCfg.WANMetrics),false); //ONE_WIFI TBD -N
@@ -1281,9 +1281,7 @@ void WiFi_GetHS2Stats(uint8_t vapIndex)
 	return;
     }
 
-    memset(&pCfg->anqp.passpointStats, 0, sizeof(pCfg->anqp.passpointStats));//ONE_WIFI
-
-    cJSON *passPointStats = cJSON_Parse((char*)g_interworking_data[apIns].anqp.passpointStats);
+    cJSON *passPointStats = cJSON_Parse((const char *) pCfg->anqp.passpointStats);
     if (NULL == passPointStats) {
         wifi_util_dbg_print(WIFI_PASSPOINT,"Failed to parse JSON\n");
         return;

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -19928,15 +19928,15 @@ Passpoint_GetParamStringValue
 
     if( AnscEqualString(ParamName, "WANMetrics", TRUE))
     {
-        WiFi_GetWANMetrics((vap_pcfg->vap_index + 1), (char *)&pcfg->passpoint.wanMetricsInfo,
-                sizeof(pcfg->passpoint.wanMetricsInfo));
+        char WANMetricsInfo[256] = {0};
+        WiFi_GetWANMetrics((vap_pcfg->vap_index + 1), WANMetricsInfo, sizeof(WANMetricsInfo));
         /* collect value */
-        if( AnscSizeOfString((char *)&pcfg->passpoint.wanMetricsInfo) < *pUlSize)
+	if( AnscSizeOfString(WANMetricsInfo) < *pUlSize)
         {
-            AnscCopyString(pValue, (char *)&pcfg->passpoint.wanMetricsInfo);
+	    AnscCopyString(pValue, WANMetricsInfo);
             return 0;
         }else{
-            *pUlSize = AnscSizeOfString((char *)&pcfg->passpoint.wanMetricsInfo)+1;
+	    *pUlSize = AnscSizeOfString(WANMetricsInfo)+1;
             return 1;
         }
         return 0;

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -200,8 +200,12 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
     cJSON *subParam = NULL;
     UCHAR *next_pos = NULL;
 
+    cJSON *passPointStats = cJSON_CreateObject(); 
+    cJSON *statsMainEntry = cJSON_AddObjectToObject(passPointStats, "PassPointStats");
+    cJSON *statsList = cJSON_AddArrayToObject(statsMainEntry, "ANQPResponse");
     if(!anqp || !interworking_info){
         wifi_util_dbg_print(WIFI_WEBCONFIG,"Anqp entry is NULL\n");
+	cJSON_Delete(passPointStats);
         return webconfig_error_decode;
     }
 
@@ -212,6 +216,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
     decode_param_array(anqpElement, "VenueInfo", anqpList);
     if(cJSON_GetArraySize(anqpList) > 16){
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Venue entries cannot be more than 16. Discarding Configuration\n", __func__, __LINE__);
+	cJSON_Delete(passPointStats);
         return webconfig_error_venue_entries;
     } else if (cJSON_GetArraySize(anqpList)) {
         //Venue List is non-empty. Update capability List
@@ -234,8 +239,16 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         anqpParam = cJSON_GetObjectItem(anqpEntry,"Name");
         if(strlen(anqpParam->valuestring) > 255){
             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Venue name cannot be more than 255. Discarding Configuration\n", __func__, __LINE__);
+	    cJSON_Delete(passPointStats);
             return webconfig_error_venue_name_size;
         }
+        cJSON *realmStats = cJSON_CreateObject();
+    	cJSON_AddStringToObject(realmStats, "Name", anqpParam->valuestring);
+	cJSON_AddNumberToObject(realmStats, "EntryType", 1); // 1-Venue
+    	cJSON_AddNumberToObject(realmStats, "Sent", 0);
+    	cJSON_AddNumberToObject(realmStats, "Failed", 0);
+    	cJSON_AddNumberToObject(realmStats, "Timeout", 0);
+    	cJSON_AddItemToArray(statsList, realmStats);
         strcpy((char*)next_pos, anqpParam->valuestring);
         next_pos += strlen(anqpParam->valuestring);
         venueBuf->length = next_pos - &venueBuf->language[0];
@@ -249,6 +262,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
     decode_param_array(anqpElement,"OI",anqpList);
     if(cJSON_GetArraySize(anqpList) > 32){
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Only 32 OUI supported in RoamingConsortiumANQPElement Data. Discarding Configuration\n", __func__, __LINE__);
+	cJSON_Delete(passPointStats);
         return webconfig_error_oui_entries;
     }
     int ouiCount = 0;
@@ -262,6 +276,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
             ouiStrLen = strlen(anqpParam->valuestring);
             if((ouiStrLen < 6) || (ouiStrLen > 30) || (ouiStrLen % 2)){
                 wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid OUI Length in RoamingConsortiumANQPElement Data. Discarding Configuration\n", __func__, __LINE__);
+		cJSON_Delete(passPointStats);
                 return webconfig_error_oui_length;
             }
             strcpy((char*)ouiStr, anqpParam->valuestring);
@@ -276,6 +291,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
                 ouiStr[i] -= ('A' - 10);//A=10
             }else{
                 wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid OUI in RoamingConsortiumANQPElement Data. Discarding Configuration\n", __func__, __LINE__);
+		cJSON_Delete(passPointStats);
                 return webconfig_error_oui_char;
             }
             if(i%2){
@@ -306,6 +322,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
     decode_param_integer(anqpElement,"IPv6AddressType",anqpParam);
     if((0 > anqpParam->valuedouble) || (2 < anqpParam->valuedouble)){
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid IPAddressTypeAvailabilityANQPElement. Discarding Configuration\n", __func__, __LINE__);
+	cJSON_Delete(passPointStats);
         return webconfig_error_ipaddress;
     }
     interworking_info->anqp.ipAddressInfo.field_format = (UCHAR)anqpParam->valuedouble;
@@ -313,6 +330,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
     decode_param_integer(anqpElement,"IPv4AddressType",anqpParam);
     if((0 > anqpParam->valuedouble) || (7 < anqpParam->valuedouble)){
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid IPAddressTypeAvailabilityANQPElement. Discarding Configuration\n", __func__, __LINE__);
+	cJSON_Delete(passPointStats);
         return webconfig_error_ipaddress;
     }
     interworking_info->anqp.ipAddressInfo.field_format |= ((UCHAR)anqpParam->valuedouble << 2);
@@ -327,6 +345,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
     naiElem->nai_realm_count = cJSON_GetArraySize(anqpList);
     if(naiElem->nai_realm_count > 20) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Only 20 Realm Entries are supported. Discarding Configuration\n", __func__, __LINE__);
+	cJSON_Delete(passPointStats);
         return webconfig_error_realm_entries;
     }
     next_pos = (UCHAR *)naiElem;
@@ -347,6 +366,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         decode_param_string(anqpEntry,"Realms",anqpParam);
         if(strlen(anqpParam->valuestring) > 255){
             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Realm Length cannot be more than 255. Discarding Configuration\n", __func__, __LINE__);
+	    cJSON_Delete(passPointStats);
             return webconfig_error_realm_length;
         }
         realmInfoBuf->realm_length = strlen(anqpParam->valuestring);
@@ -354,17 +374,20 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         strcpy((char*)next_pos, anqpParam->valuestring);
         next_pos += realmInfoBuf->realm_length;
 
-/**        cJSON *realmStats = cJSON_CreateObject();//Create a stats Entry here for each Realm
+      	cJSON *realmStats = cJSON_CreateObject();
+        decode_param_string(anqpEntry,"Realms",anqpParam);
         cJSON_AddStringToObject(realmStats, "Name", anqpParam->valuestring);
-        cJSON_AddNumberToObject(realmStats, "EntryType", 1);//1-NAI Realm
+        cJSON_AddNumberToObject(realmStats, "EntryType", 1); // 1-NAI Realm
         cJSON_AddNumberToObject(realmStats, "Sent", 0);
         cJSON_AddNumberToObject(realmStats, "Failed", 0);
-        cJSON_AddNumberToObject(realmStats, "Timeout", 0);**/
+        cJSON_AddNumberToObject(realmStats, "Timeout", 0);
+        cJSON_AddItemToArray(statsList, realmStats);
 
         decode_param_array(anqpEntry,"EAP",subList);
         realmInfoBuf->eap_method_count = cJSON_GetArraySize(subList);
         if(realmInfoBuf->eap_method_count > 16){
             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: EAP entries cannot be more than 16. Discarding Configuration\n", __func__, __LINE__);
+	    cJSON_Delete(passPointStats);
             return webconfig_error_eap_entries;
         }
         next_pos += sizeof(realmInfoBuf->eap_method_count);
@@ -382,6 +405,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
             eapBuf->auth_param_count = cJSON_GetArraySize(subList_1);
             if(eapBuf->auth_param_count > 16){
                 wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Auth entries cannot be more than 16. Discarding Configuration\n", __func__, __LINE__);
+		cJSON_Delete(passPointStats);
                 return webconfig_error_auth_entries;
             }
             next_pos += sizeof(eapBuf->auth_param_count);
@@ -397,6 +421,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
                 subParam_1 = cJSON_GetObjectItem(subEntry_1,"Value");
                 if(!subParam_1){
                     wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Auth Parameter Value not prensent in NAIRealmANQPElement EAP Data. Discarding Configuration\n", __func__, __LINE__);
+		    cJSON_Delete(passPointStats);
                     return webconfig_error_auth_param;
                 } else if (subParam_1->valuedouble) {
                     authBuf->length = 1;
@@ -405,6 +430,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
                     authStrLen = strlen(subParam_1->valuestring);
                     if((authStrLen != 2) && (authStrLen != 14)){
                         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid EAP Value Length in NAIRealmANQPElement Data. Has to be 1 to 7 bytes Long. Discarding Configuration\n", __func__, __LINE__);
+			cJSON_Delete(passPointStats);
                         return webconfig_error_eap_length;
                     }
                     strcpy((char*)authStr,subParam_1->valuestring);
@@ -419,6 +445,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
                             authStr[i] -= ('A' - 10);//A=10
                         }else{
                             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid EAP val in NAIRealmANQPElement Data. Discarding Configuration\n", __func__, __LINE__);
+			    cJSON_Delete(passPointStats);
                             return webconfig_error_eap_value;
                         }
                         if(i%2){
@@ -460,6 +487,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
     if(plmnInfoBuf->number_of_plmns > 16){
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: 3GPP entries cannot be more than 16. Discarding Configuration\n", __func__, __LINE__);
         //strncpy(execRetVal->ErrorMsg, "Exceeded max number of 3GPP entries",sizeof(execRetVal->ErrorMsg)-1);
+	cJSON_Delete(passPointStats);
         return webconfig_error_decode;
      }
 
@@ -478,6 +506,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         }else{
             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid MCC in 3GPPCellularANQPElement Data. Discarding Configuration\n", __func__, __LINE__);
             //strncpy(execRetVal->ErrorMsg, "Invalid MCC in 3GPP Element",sizeof(execRetVal->ErrorMsg)-1);
+	    cJSON_Delete(passPointStats);
             return webconfig_error_decode;
         }
 
@@ -490,6 +519,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         }else{
             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid MNC in 3GPPCellularANQPElement Data. Discarding Configuration\n", __func__, __LINE__);
             //strncpy(execRetVal->ErrorMsg, "Invalid MNC in 3GPP Element",sizeof(execRetVal->ErrorMsg)-1);
+	    cJSON_Delete(passPointStats);
             return webconfig_error_decode;
         }
         wifi_plmn_t *plmnBuf = (wifi_plmn_t *)next_pos;
@@ -498,14 +528,15 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         plmnBuf->PLMN[2] = (UCHAR)((mncStr[0] - '0') | ((mncStr[1] - '0') << 4));
         next_pos += sizeof(wifi_plmn_t);
 
-        /*char  nameStr[8];
-        snprintf(nameStr, sizeof(nameStr), "%s:%s", mccStr, mncStr);
-        cJSON *realmStats = cJSON_CreateObject();//Create a stats Entry here for each Realm
+	char  nameStr[8];
+    	snprintf(nameStr, sizeof(nameStr), "%s:%s", mccStr, mncStr);
+        cJSON *realmStats = cJSON_CreateObject();
         cJSON_AddStringToObject(realmStats, "Name", nameStr);
-        cJSON_AddNumberToObject(realmStats, "EntryType", 3);//3-3GPP
+        cJSON_AddNumberToObject(realmStats, "EntryType", 3); // 3-3GPP
         cJSON_AddNumberToObject(realmStats, "Sent", 0);
         cJSON_AddNumberToObject(realmStats, "Failed", 0);
-        cJSON_AddNumberToObject(realmStats, "Timeout", 0);*/
+        cJSON_AddNumberToObject(realmStats, "Timeout", 0);
+        cJSON_AddItemToArray(statsList, realmStats);
     }
     gppBuf->uhdLength = next_pos - uhd_pos;
     plmnInfoBuf->plmn_length = next_pos - plmn_pos;
@@ -519,6 +550,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
     if(cJSON_GetArraySize(anqpList) > 4){
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Only 4 Entries supported in DomainNameANQPElement Data. Discarding Configuration\n", __func__, __LINE__);
         //strncpy(execRetVal->ErrorMsg, "Exceeded max no of entries in DomainNameANQPElement Data",sizeof(execRetVal->ErrorMsg)-1);
+	cJSON_Delete(passPointStats);
         return webconfig_error_decode;
     }
     next_pos = (UCHAR *)&interworking_info->anqp.domainNameInfo;
@@ -529,6 +561,7 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         if(strlen(anqpParam->valuestring) > 255){
             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Domain name length cannot be more than 255. Discarding Configuration\n", __func__, __LINE__);
             //strncpy(execRetVal->ErrorMsg, "Invalid Domain name length",sizeof(execRetVal->ErrorMsg)-1);
+	    cJSON_Delete(passPointStats);
             return webconfig_error_decode;
         }
         nameBuf->length = strlen(anqpParam->valuestring);
@@ -536,12 +569,14 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         strcpy((char*)next_pos, anqpParam->valuestring);
         next_pos += nameBuf->length;
 
-        /*cJSON *realmStats = cJSON_CreateObject();//Create a stats Entry here for each Realm
+        cJSON *realmStats = cJSON_CreateObject();//Create a stats Entry here for each Realm
+        decode_param_string(anqpEntry,"Name",anqpParam);
         cJSON_AddStringToObject(realmStats, "Name", anqpParam->valuestring);
-        cJSON_AddNumberToObject(realmStats, "EntryType", 2);//2-Domain
+        cJSON_AddNumberToObject(realmStats, "EntryType", 2); // 2-Domain
         cJSON_AddNumberToObject(realmStats, "Sent", 0);
         cJSON_AddNumberToObject(realmStats, "Failed", 0);
-        cJSON_AddNumberToObject(realmStats, "Timeout", 0);*/
+        cJSON_AddNumberToObject(realmStats, "Timeout", 0);
+        cJSON_AddItemToArray(statsList, realmStats);
     }
 
     interworking_info->anqp.domainInfoLength = next_pos - (UCHAR *)&interworking_info->anqp.domainNameInfo;
@@ -549,6 +584,8 @@ webconfig_error_t decode_anqp_object(const cJSON *anqp, wifi_interworking_t *int
         interworking_info->anqp.capabilityInfo.capabilityList[interworking_info->anqp.capabilityInfoLength++] = wifi_anqp_element_name_domain_name;
     }
 
+    cJSON_PrintPreallocated(passPointStats, (char *)&interworking_info->anqp.passpointStats,sizeof(interworking_info->anqp.passpointStats), false);
+    cJSON_Delete(passPointStats);
     return webconfig_error_none;
 }
 


### PR DESCRIPTION
Reason for change:
1.Logic to fetch and return Passpoint parameter values was missing in the implementation. 2.Added the missing logic to retrieve and return Passpoint parameter values when queried via dmcli.

Test Procedure:
1.Configure Passpoint settings.
2.Execute relevant dmcli commands.
3.Verify that the Passpoint parameters return expected values.

Risks: None

Priority: P1

Signed-off-by: akumar052@cable.comcast.com