### PR TITLE
RDKB-59580 Observed unexpected bytes and packets measurements in RDK logs (#303)

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -825,7 +825,6 @@ typedef struct {
     unsigned int    rapid_reconnects;
     bool            updated;
     wifi_associated_dev3_t dev_stats;
-    wifi_associated_dev3_t dev_stats_last;
     unsigned int    reconnect_count;
     long            assoc_monitor_start_time;
     long            gate_time;

--- a/source/apps/whix/wifi_whix.h
+++ b/source/apps/whix/wifi_whix.h
@@ -36,6 +36,7 @@ typedef struct {
     BOOL cli_stat_list[MAX_VAP];
     rejected_client_stat_t rejected_client_stats[MAX_VAP];
     int vap_max_client_id;
+    hash_map_t *last_stats_map; //wifi_associated_dev3_t
 } whix_data_t;
 
 #endif //_WIFI_WHIX_H_

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -653,7 +653,6 @@ static void reset_client_stats_info(unsigned int apIndex)
 
     sta = hash_map_get_first(sta_map);
     while (sta != NULL) {
-        memset((unsigned char *)&sta->dev_stats_last, 0, sizeof(wifi_associated_dev3_t));
         memset((unsigned char *)&sta->dev_stats, 0, sizeof(wifi_associated_dev3_t));
         sta = hash_map_get_next(sta_map, sta);
     }
@@ -1256,7 +1255,6 @@ void process_connect(unsigned int ap_index, auth_deauth_dev_t *dev)
             (sta->total_disconnected_time.tv_nsec / 1000000)));
 
     /* reset stats of client */
-    memset((unsigned char *)&sta->dev_stats_last, 0, sizeof(wifi_associated_dev3_t));
     memset((unsigned char *)&sta->dev_stats, 0, sizeof(wifi_associated_dev3_t));
     memcpy(&sta->dev_stats, &dev->dev_stats, sizeof(wifi_associated_dev3_t));
     sta->dev_stats.cli_Active = true;

--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -330,8 +330,6 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
                     memcpy(hal_sta->cli_MACAddress, hal_sta->cli_MLDAddr, sizeof(mac_address_t));
                 }
             }
-            memcpy((unsigned char *)&sta->dev_stats_last, (unsigned char *)&sta->dev_stats,
-                sizeof(wifi_associated_dev3_t));
             memcpy((unsigned char *)&sta->dev_stats, (unsigned char *)hal_sta,
                 sizeof(wifi_associated_dev3_t));
             sta->updated = true;


### PR DESCRIPTION
Impacted Platforms:
All RDKB Platforms

Reason for change: Counting the bytes between two consecutive whix marker 

Test Procedure: Download some data and check if the same effected in 
                          WIFI_BYTESSENTCLIENTS_<vap_index> marker

Risks: None

Priority: P1

Signed-off-by:Pavithra_Sundaravadivel@comcast.com