### PR TITLE
RDKB-58755:[OneWifi]4way_handshake timeout increase for Apple Clients…

### DIFF
--- a/source/apps/analytics/wifi_analytics.c
+++ b/source/apps/analytics/wifi_analytics.c
@@ -322,6 +322,7 @@ int analytics_event_webconfig_get_data(wifi_app_t *apps, void *arg)
 
 int analytics_event_webconfig_set_data_tunnel(wifi_app_t *apps, void *arg)
 {
+    wifi_util_info_print(WIFI_ANALYTICS, analytics_format_webconfig_core, "set", "webconfig tunnel data");
     return RETURN_OK;
 }
 

--- a/source/core/services/vap_svc_private.c
+++ b/source/core/services/vap_svc_private.c
@@ -58,6 +58,7 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
     bool enabled;
     unsigned int i;
     wifi_vap_info_map_t *p_tgt_vap_map = NULL;
+    int ret;
 
     p_tgt_vap_map = (wifi_vap_info_map_t *) malloc( sizeof(wifi_vap_info_map_t) );
     if (p_tgt_vap_map == NULL) {
@@ -89,10 +90,12 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
 #endif /* !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_PP203X_PRODUCT_REQ_) && !defined(_GREXT02ACTS_PRODUCT_REQ_) */
         p_tgt_vap_map->vap_array[0].u.bss_info.enabled &= rdk_vap_info[i].exists;
 
-        if (wifi_hal_createVAP(radio_index, p_tgt_vap_map) != RETURN_OK) {
+        ret = wifi_hal_createVAP(radio_index, p_tgt_vap_map);
+        if (ret != RETURN_OK) {
             wifi_util_error_print(WIFI_CTRL,"%s: wifi vap create failure: radio_index:%d vap_index:%d\n",__FUNCTION__,
                                                 radio_index, map->vap_array[i].vap_index);
-            continue;
+            free(p_tgt_vap_map);
+            return ret;
         }
 
         p_tgt_vap_map->vap_array[0].u.bss_info.enabled = enabled;

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -91,6 +91,11 @@ extern "C" {
 #define HOTSPOT_VAP_MAC_FILTER_ENTRY_SYNC  (15 * 60)
 
 #define MAX_WIFI_SCHED_TIMEOUT         (4 * 1000)
+#define MAX_WIFI_SCHED_CSA_TIMEOUT     (8 * 1000)
+
+#define MAX_HOTSPOT_BLOB_SET_TIMEOUT             100
+#define MAX_WEBCONFIG_HOTSPOT_BLOB_SET_TIMEOUT   120
+#define MAX_VAP_RE_CFG_APPLY_RETRY     2
 
 //This is a dummy string if the value is not passed.
 #define INVALID_KEY                      "12345678"
@@ -207,6 +212,13 @@ typedef struct {
     pthread_mutex_t      events_bus_lock;
 } events_bus_data_t;
 
+typedef struct hotspot_cfg_sem_param {
+    bool is_init;
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    bool cfg_status;
+} hotspot_cfg_sem_param_t;
+
 typedef struct wifi_ctrl {
     bool                exit_ctrl;
     queue_t             *queue;
@@ -253,6 +265,7 @@ typedef struct wifi_ctrl {
     int                 speed_test_timeout;
     int                 speed_test_running;
     events_bus_data_t   events_bus_data;
+    hotspot_cfg_sem_param_t hotspot_sem_param;
 } wifi_ctrl_t;
 
 
@@ -385,6 +398,9 @@ char *get_assoc_devices_blob();
 void get_subdoc_name_from_vap_index(uint8_t vap_index, int* subdoc);
 int dfs_nop_start_timer(void *args);
 int webconfig_send_full_associate_status(wifi_ctrl_t *ctrl);
+
+bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec);
+void hotspot_cfg_sem_signal(bool status);
 
 #ifdef __cplusplus
 }

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3541,7 +3541,9 @@ void handle_webconfig_event(wifi_ctrl_t *ctrl, const char *raw, unsigned int len
     case wifi_event_webconfig_set_data_tunnel:
         memcpy((unsigned char *)&data.u.decoded.hal_cap, (unsigned char *)&mgr->hal_cap,
             sizeof(wifi_hal_capability_t));
+        apps_mgr_analytics_event(&ctrl->apps_mgr, wifi_event_type_webconfig, subtype, NULL);
         webconfig_decode(config, &data, raw);
+        apps_mgr_analytics_event(&ctrl->apps_mgr, wifi_event_type_webconfig, subtype, NULL);
         webconfig_data_free(&data);
         break;
 


### PR DESCRIPTION
…-RC fix

Reason for change: Changed radio channel CSA timer value from 4 seconds to 8 seconds.
                   When Assoc request stuck detected then OneWifi is restart only
                   once on device boot-up.

Test Procedure: 1. Load OneWifi Image.
                2. Connect client with all vaps.
                3. Check client connectivity with Client.

Risks: Low
Priority: P0

Change-Id: Ie6a29753b01a28ce679a9b359b478ee715a450fd
Signed-off-by: aniketnarsinhbhai_Patel@comcast.com

RDKB-58829:[OneWifi] CcspHotspot process is not found

Reason for change: Increasing hotspot vap cfg timeout from
                   4 seconds to 30 seconds.

Test Procedure: 1. Load OneWifi Image.
                2. Config hotspot VAPs.
                3. Check Hotspot VAPs client connectivity.
                4. Check CcspHotspot process ID.
                   CcspHotspot process ID-> ps | grep -i "CcspHotspot"

Risks: Low
Priority: P0

Change-Id: I4023ecc04a8ee11889cc0e017e021254c69177d9
Signed-off-by: aniketnarsinhbhai_Patel@comcast.com

RDKB-58829:[OneWifi] CcspHotspot process is not found

Reason for change: Increasing hotspot vap cfg timeout from
                   30 seconds to 100 seconds on OneWifi hal apply
                   and Webconfig component timeout 120 seconds.

Test Procedure: 1. Load OneWifi Image.
                2. Config hotspot VAPs.
                3. Check Hotspot VAPs client connectivity.
                4. Check CcspHotspot process ID.
                   CcspHotspot process ID-> ps | grep -i "CcspHotspot"

Risks: Low
Priority: P0

Change-Id: Iee41787dd7e2198a938d8e380e0c66aaa144ebc8
Signed-off-by: aniketnarsinhbhai_Patel@comcast.com