### PR TITLE
Revert "RDKB-59859: Add TestSuite compilation (#344)"

### DIFF
--- a/build/openwrt/Makefile_package
+++ b/build/openwrt/Makefile_package
@@ -10,7 +10,7 @@ define Package/easymesh
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=EasyMesh
-  DEPENDS:=+avro-c +libopenssl +cJSON +libev +libnl +libnl-genl +libnl-route +libuuid +libstdcpp +libmariadb +libpcap +libcurl 
+  DEPENDS:=+avro-c +libopenssl +cJSON +libev +libnl +libnl-genl +libnl-route +libuuid +libstdcpp +libmariadb
 endef
 
 define Package/easymesh/description
@@ -28,23 +28,14 @@ define Build/Prepare
 	$(CP) -r ./halinterface $(PKG_BUILD_DIR)/
 	$(CP) -r ./rdk-wifi-hal $(PKG_BUILD_DIR)/
 	$(CP) -r ./rdk-wifi-libhostap $(PKG_BUILD_DIR)/
-	$(CP) -r ./TestSuite $(PKG_BUILD_DIR)/
 	$(CP) -r ./OneWifi/install $(PKG_BUILD_DIR)/
 	$(CP) -r ./OneWifi/install/bin $(PKG_BUILD_DIR)/
-	$(CP) -r ./TestSuite/install $(PKG_BUILD_DIR)/
-	$(CP) -r ./TestSuite/install/bin $(PKG_BUILD_DIR)/
 endef
 
 define Build/Compile
 	echo "Compiling OneWifi..."
 	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS) $(TARGET_LDFLAGS)" \
 	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/OneWifi/build/openwrt/  \
-		$(TARGET_CONFIGURE_OPTS)
-
-	echo "Compiling TestSuite..."
-	rm -rf $(PKG_BUILD_DIR)/rdk-wifi-hal/src/*.o
-	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS) $(TARGET_LDFLAGS)" \
-	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/TestSuite/build/openwrt/  \
 		$(TARGET_CONFIGURE_OPTS)
 
 	echo "Compiling Easymesh AGENT..."
@@ -64,7 +55,6 @@ define Package/easymesh/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/bin/onewifi_em_agent $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/bin/onewifi_em_ctrl $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/OneWifi/install/bin/OneWifi $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/TestSuite/install/bin/cci $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,easymesh))


### PR DESCRIPTION
This reverts commit 1fcf030eb94f34e1ea066ef49c3d57f07f7d4e5b as it is causing compilation issue in OpenWRT build.