### PR TITLE
RDKCOM-5329: RDKBDEV-3189 more robust inclusion of base64.h

### DIFF
--- a/source/apps/cac/wifi_cac.c
+++ b/source/apps/cac/wifi_cac.c
@@ -30,7 +30,7 @@
 #include "wifi_cac.h"
 #include "wifi_hal_rdk_framework.h"
 #include "wifi_monitor.h"
-#include <rbus.h>
+#include <rbus/rbus.h>
 
 void cac_print(char *format, ...)
 {

--- a/source/core/services/vap_svc_mesh_pod.c
+++ b/source/core/services/vap_svc_mesh_pod.c
@@ -10,7 +10,7 @@
 #include "wifi_util.h"
 #include "wifi_monitor.h"
 #include "wifi_hal_generic.h"
-#include <rbus.h>
+#include <rbus/rbus.h>
 #include <errno.h>
 
 #define WIFI_HOME_AP_IF_PREFIX     "home-ap-"

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -29,7 +29,7 @@
 #include "wifi_util.h"
 #include <cjson/cJSON.h>
 #include "scheduler.h"
-#include "base64.h"
+#include <trower-base64/base64.h>
 #include <unistd.h>
 #include <pthread.h>
 #ifdef WEBCONFIG_TESTS_OVER_QUEUE

--- a/source/dml/tr_181/sbapi/webpa_interface.c
+++ b/source/dml/tr_181/sbapi/webpa_interface.c
@@ -18,7 +18,7 @@
  */
 
 #include "webpa_interface.h"
-#include "base64.h"
+#include <trower-base64/base64.h>
 #include "ccsp_dm_api.h"
 #include "collection.h"
 #include "cosa_apis.h"
@@ -28,7 +28,7 @@
 #include "stdlib.h"
 #include "wifi_ctrl.h"
 #include "wifi_util.h"
-#include <libparodus.h>
+#include <libparodus/libparodus.h>
 #include <math.h>
 #include <syscfg/syscfg.h>
 #include <sysevent/sysevent.h>

--- a/source/dml/tr_181/sbapi/webpa_interface.h
+++ b/source/dml/tr_181/sbapi/webpa_interface.h
@@ -26,7 +26,7 @@
 #ifndef _WEBPA_INTERFACE_H_
 #define _WEBPA_INTERFACE_H_
 
-#include <libparodus.h>
+#include <libparodus/libparodus.h>
 #include "collection.h"
   
 #ifdef __cplusplus

--- a/source/platform/rdkb/bus.h
+++ b/source/platform/rdkb/bus.h
@@ -21,7 +21,7 @@
 #define BUS_H
 
 #include "bus_common.h"
-#include <rbus.h>
+#include <rbus/rbus.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/source/sampleapps/webconfig_consumer_apis.c
+++ b/source/sampleapps/webconfig_consumer_apis.c
@@ -27,7 +27,7 @@
 #include "scheduler.h"
 #include <unistd.h>
 #include <pthread.h>
-#include <rbus.h>
+#include <rbus/rbus.h>
 #include <libgen.h>
 #include <pcap.h>
 #include "wifi_hal_rdk.h"

--- a/source/sampleapps/wifi_webconfig_consumer.c
+++ b/source/sampleapps/wifi_webconfig_consumer.c
@@ -28,7 +28,7 @@
 #include "scheduler.h"
 #include <unistd.h>
 #include <pthread.h>
-#include <rbus.h>
+#include <rbus/rbus.h>
 #include <libgen.h>
 #include "wifi_webconfig_consumer.h"
 #define CONSUMER_APP_FILE "/tmp/wifi_webconfig_consumer_app"

--- a/source/sampleapps/wifi_webconfig_consumer.h
+++ b/source/sampleapps/wifi_webconfig_consumer.h
@@ -20,7 +20,7 @@
 #ifndef WIFI_WEBCONFIG_CONSUMER_H
 #define WIFI_WEBCONFIG_CONSUMER_H
 
-#include "rbus.h"
+#include <rbus/rbus.h>
 #include "wifi_webconfig.h"
 
 #ifdef __cplusplus

--- a/source/sampleapps/wifievents_consumer_sample.c
+++ b/source/sampleapps/wifievents_consumer_sample.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <getopt.h>
-#include <rbus.h>
+#include <rbus/rbus.h>
 #include <signal.h>
 #include <wifi_hal.h>
 #include <collection.h>

--- a/source/test/wifi_api2.c
+++ b/source/test/wifi_api2.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <getopt.h>
-#include <rbus.h>
+#include <rbus/rbus.h>
 
 #define WIFI_RBUS_WIFIAPI_COMMAND               "Device.WiFi.WiFiAPI.command"
 #define WIFI_RBUS_WIFIAPI_RESULT                "Device.WiFi.WiFiAPI.result"


### PR DESCRIPTION
Reason for change:
more robust inclusion of libparodus.h, base64.h & rbus.h Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy armccurdy@gmail.com