### PR TITLE
RDKCOM-5330: RDKBDEV-3190 add WIFI_HAL_VERSION_3 compile time check

### DIFF
--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -1906,7 +1906,11 @@ void process_wpa3_rfc(bool type)
             }
             vapInfo->u.bss_info.security.mode = wifi_security_mode_wpa3_transition;
             vapInfo->u.bss_info.security.wpa3_transition_disable = false;
+#if defined(WIFI_HAL_VERSION_3)
             vapInfo->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
+#else
+#error "WIFI_HAL_VERSION_3 is currently required"
+#endif
             vapInfo->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
         } else {
             if (vapInfo->u.bss_info.security.mode == wifi_security_mode_wpa2_personal) {


### PR DESCRIPTION
Reason for change:
Code currently relies on WIFI_HAL_VERSION_3 with no alternative available.
Test Procedure: Sanity.
Signed-off-by: Andre McCurdy <amccurdy@libertyglobal.com>