### PR TITLE
RDKB-59766: Onewifi Memory leak [self-heal] script 

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -2043,6 +2043,36 @@ INSTMSMT_PH2 -->
                         </object>
                     </objects>
                 </object>
+                    <object>
+                        <name>WiFiRestart</name>
+                        <objectType>object</objectType>
+                        <functions></functions>
+	                    <parameters></parameters>
+                        <objects>
+                            <object>
+                                <name>RSSMemory</name>
+                                <objectType>object</objectType>
+                                <functions>
+                                    <func_GetParamUlongValue>RSSMemory_GetParamUlongValue</func_GetParamUlongValue>
+                                    <func_SetParamUlongValue>RSSMemory_SetParamUlongValue</func_SetParamUlongValue>
+                                </functions>
+                                <parameters>
+                                    <parameter>
+                                        <name>Threshold1</name>
+                                        <type>unsignedInt</type>
+                                        <syntax>uint32</syntax>
+                                        <writable>true</writable>
+                                    </parameter>
+                                    <parameter>
+                                        <name>Threshold2</name>
+                                        <type>unsignedInt</type>
+                                        <syntax>uint32</syntax>
+                                        <writable>true</writable>
+                                    </parameter>
+                                </parameters>
+                            </object>
+                        </objects>
+                    </object>
                 <object>
                     <name>AccessPoint</name>
                     <objectType>staticTable</objectType>

--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -1,6 +1,6 @@
 {
   "name": "Wifi_Rdk_Database",
-  "version": "1.00.034",
+  "version": "1.00.035",
   "cksum": "2353365742 523",
   "tables": {
     "Wifi_Device_Config": {
@@ -1959,6 +1959,24 @@
           }
         },
         "whix_chutility_loginterval": {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "rss_memory_restart_threshold_low" : {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "rss_memory_restart_threshold_high" : {
           "type": {
             "key": {
               "type": "integer"

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -98,6 +98,9 @@ extern "C" {
 #define MIN_DIAG_INTERVAL   5000
 #define CSI_PING_INTERVAL   100
 
+#define RSS_MEM_THRESHOLD1_DEFAULT 81920 /*Threshold1 is 80MB*/
+#define RSS_MEM_THRESHOLD2_DEFAULT 112640 /*Threshold2 is 110MB*/
+
 #define wifi_sub_component_base     0x01
 #define wifi_app_inst_base          0x01
 
@@ -441,6 +444,8 @@ typedef struct {
     int  assoc_gate_time;
     int  whix_log_interval; //seconds
     int  whix_chutility_loginterval; //seconds
+    ULONG rss_memory_restart_threshold_low;
+    ULONG rss_memory_restart_threshold_high;
     int  assoc_monitor_duration;
     bool rapid_reconnect_enable;
     bool vap_stats_feature;

--- a/lib/inc/schema_gen.h
+++ b/lib/inc/schema_gen.h
@@ -1604,6 +1604,8 @@
         PJS_OVS_INT(assoc_gate_time) \
         PJS_OVS_INT(whix_log_interval) \
         PJS_OVS_INT(whix_chutility_loginterval) \
+        PJS_OVS_INT(rss_memory_restart_threshold_low) \
+        PJS_OVS_INT(rss_memory_restart_threshold_high) \
         PJS_OVS_INT(assoc_monitor_duration) \
         PJS_OVS_BOOL(rapid_reconnect_enable) \
         PJS_OVS_BOOL(vap_stats_feature) \
@@ -3258,6 +3260,8 @@
     COLUMN(assoc_gate_time) \
     COLUMN(whix_log_interval) \
     COLUMN(whix_chutility_loginterval) \
+    COLUMN(rss_memory_restart_threshold_low) \
+    COLUMN(rss_memory_restart_threshold_high) \
     COLUMN(assoc_monitor_duration) \
     COLUMN(rapid_reconnect_enable) \
     COLUMN(vap_stats_feature) \
@@ -4506,6 +4510,8 @@
 #define SCHEMA__Wifi_Global_Config__assoc_gate_time "assoc_gate_time"
 #define SCHEMA__Wifi_Global_Config__whix_log_interval "whix_log_interval"
 #define SCHEMA__Wifi_Global_Config__whix_chutility_loginterval "whix_chutility_loginterval"
+#define SCHEMA__Wifi_Global_Config__threshold1 "rss_memory_restart_threshold_low"
+#define SCHEMA__Wifi_Global_Config__threshold2 "rss_memory_restart_threshold_high"
 #define SCHEMA__Wifi_Global_Config__assoc_monitor_duration "assoc_monitor_duration"
 #define SCHEMA__Wifi_Global_Config__rapid_reconnect_enable "rapid_reconnect_enable"
 #define SCHEMA__Wifi_Global_Config__vap_stats_feature "vap_stats_feature"

--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -30,6 +30,7 @@ cur_rxprobe_req_5g_cnt=0
 pre_txprobe_resp_5g_cnt=0
 cur_txprobe_resp_5g_cnt=0
 force_reset_subdoc=0
+onewifi_last_restart=0
 webcfg_rfc_enabled=""
 
 SW_UPGRADE_DEFAULT_FILE="/tmp/sw_upgrade_private_defaults"
@@ -176,6 +177,52 @@ check_bss_queue_one_min()
             break
         fi
     done
+}
+
+onewifi_mem_restart() {
+    # Find the OneWifi process PID
+    onewifi_pid=$(ps | grep "/usr/bin/OneWifi -subsys eRT\." | grep -v grep | awk '{print $1}')
+    STATUS_FILE="/proc/$onewifi_pid/status"
+    if [ -z "$onewifi_pid" ]; then
+        echo_t "OneWifi process not found in ps output" >> $LOG_FILE
+        return
+    fi
+
+    checkMaintenanceWindow
+    m_win=0
+    if [ "$reb_window" == "1" ]; then
+        m_win=1
+    fi
+
+    # Get memory usage (VmRSS in kB)
+    vmrss=$(grep -i 'VmRSS' "$STATUS_FILE" | awk '{print $2}')
+
+    # Get thresholds (in kB)
+    threshold1=$(dmcli eRT retv Device.WiFi.WiFiRestart.RSSMemory.Threshold1)
+    threshold2=$(dmcli eRT retv Device.WiFi.WiFiRestart.RSSMemory.Threshold2)
+
+    now=$(date +%s)
+    time_since_last_restart=$((now - onewifi_last_restart))
+
+    if [ "$vmrss" -ge "$threshold2" ]; then
+        if [ "$time_since_last_restart" -ge 86400 ]; then
+            echo_t "RSS Memory of Onewifi exceeds RSS threshold2 value and restarting Onewifi [Rss : ($vmrss kB) Threshold2 : ($threshold2 kB)]" >> $LOG_FILE
+            systemctl restart onewifi.service
+            onewifi_last_restart=$now
+        else
+            echo_t "OneWifi restart skipped for RSS threshold2 since last restart time is less than 24 hrs [Rss : ($vmrss kB) Threshold2 : ($threshold2 kB)]" >> $LOG_FILE
+        fi
+    elif [ "$vmrss" -ge "$threshold1" ] && [ "$m_win" -eq 1 ]; then
+        if [ "$time_since_last_restart" -ge 86400 ]; then
+            echo_t "RSS Memory of Onewifi exceeds RSS threshold1 value during maintenance window and restarting Onewifi [Rss : ($vmrss kB) Threshold1 : ($threshold1 kB)]" >> $LOG_FILE
+            systemctl restart onewifi.service
+            onewifi_last_restart=$now
+        else
+            echo_t "OneWifi restart skipped for RSS threshold1 since last restart time is less than 24 hrs [Rss : ($vmrss kB) Threshold1 : ($threshold1 kB)]" >> $LOG_FILE
+        fi
+    else
+        echo_t "RSS Memory usage of Onewifi is within the RSS threshold values [Rss : ($vmrss kB)]" >> $LOG_FILE
+    fi
 }
 
 while true
@@ -361,6 +408,8 @@ do
         ((force_reset_subdoc++))
     fi
 
+    # Check if OneWifi process RSS memory usage exceeds threshold, if does restart OneWifi.
+    onewifi_mem_restart
     sleep 5m
     ((check_count++))
 done

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -79,8 +79,8 @@
 
 #define ONEWIFI_DB_VERSION_WPA3_COMP_FLAG 100033
 #define WPA3_COMPATIBILITY 8192
-
 #define ONEWIFI_DB_VERSION_HOSTAP_MGMT_FRAME_CTRL_FLAG 100034
+#define ONEWIFI_DB_VERSION_RSS_MEMORY_THRESHOLD_FLAG 100035
 
 ovsdb_table_t table_Wifi_Radio_Config;
 ovsdb_table_t table_Wifi_VAP_Config;
@@ -1160,6 +1160,8 @@ void callback_Wifi_Global_Config(ovsdb_update_monitor_t *mon,
         g_wifidb->global_config.global_parameters.assoc_gate_time = new_rec->assoc_gate_time;
         g_wifidb->global_config.global_parameters.whix_log_interval = new_rec->whix_log_interval;
         g_wifidb->global_config.global_parameters.whix_chutility_loginterval = new_rec->whix_chutility_loginterval;
+        g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low = new_rec->rss_memory_restart_threshold_low;
+        g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high = new_rec->rss_memory_restart_threshold_high;
         g_wifidb->global_config.global_parameters.assoc_monitor_duration = new_rec->assoc_monitor_duration;
         g_wifidb->global_config.global_parameters.rapid_reconnect_enable = new_rec->rapid_reconnect_enable;
         g_wifidb->global_config.global_parameters.vap_stats_feature = new_rec->vap_stats_feature;
@@ -1189,7 +1191,7 @@ void callback_Wifi_Global_Config(ovsdb_update_monitor_t *mon,
             strncpy(g_wifidb->global_config.global_parameters.txrx_rate_list,new_rec->txrx_rate_list,sizeof(g_wifidb->global_config.global_parameters.txrx_rate_list)-1);
             g_wifidb->global_config.global_parameters.txrx_rate_list[sizeof(g_wifidb->global_config.global_parameters.txrx_rate_list)-1] = '\0';
         }
-        wifi_util_dbg_print(WIFI_DB,"%s:%d  notify_wifi_changes %d  prefer_private %d  prefer_private_configure %d  factory_reset %d  tx_overflow_selfheal %d  inst_wifi_client_enabled %d  inst_wifi_client_reporting_period %d  inst_wifi_client_mac = %s inst_wifi_client_def_reporting_period %d  wifi_active_msmt_enabled %d  wifi_active_msmt_pktsize %d  wifi_active_msmt_num_samples %d  wifi_active_msmt_sample_duration %d  vlan_cfg_version %d  wps_pin = %s bandsteering_enable %d  good_rssi_threshold %d  assoc_count_threshold %d  assoc_gate_time %d whix_loginterval %d assoc_monitor_duration %d  rapid_reconnect_enable %d  vap_stats_feature %d  mfp_config_feature %d  force_disable_radio_feature %d  force_disable_radio_status %d  fixed_wmm_params %d  wifi_region_code %s diagnostic_enable %d  validate_ssid %d device_network_mode:%d normalized_rssi_list %s snr_list %s cli_stat_list %s txrx_rate_list %s\r\n", __func__, __LINE__, new_rec->notify_wifi_changes,new_rec->prefer_private,new_rec->prefer_private_configure,new_rec->factory_reset,new_rec->tx_overflow_selfheal,new_rec->inst_wifi_client_enabled,new_rec->inst_wifi_client_reporting_period,new_rec->inst_wifi_client_mac, new_rec->inst_wifi_client_def_reporting_period,new_rec->wifi_active_msmt_enabled,new_rec->wifi_active_msmt_pktsize,new_rec->wifi_active_msmt_num_samples,new_rec->wifi_active_msmt_sample_duration,new_rec->vlan_cfg_version,new_rec->wps_pin, new_rec->bandsteering_enable,new_rec->good_rssi_threshold,new_rec->assoc_count_threshold,new_rec->assoc_gate_time, new_rec->whix_log_interval, new_rec->assoc_monitor_duration,new_rec->rapid_reconnect_enable,new_rec->vap_stats_feature,new_rec->mfp_config_feature,new_rec->force_disable_radio_feature,new_rec->force_disable_radio_status,new_rec->fixed_wmm_params,new_rec->wifi_region_code,new_rec->diagnostic_enable,new_rec->validate_ssid, new_rec->device_network_mode, new_rec->normalized_rssi_list, new_rec->snr_list, new_rec->cli_stat_list, new_rec->txrx_rate_list);
+        wifi_util_dbg_print(WIFI_DB,"%s:%d  notify_wifi_changes %d  prefer_private %d  prefer_private_configure %d  factory_reset %d  tx_overflow_selfheal %d  inst_wifi_client_enabled %d  inst_wifi_client_reporting_period %d  inst_wifi_client_mac = %s inst_wifi_client_def_reporting_period %d  wifi_active_msmt_enabled %d  wifi_active_msmt_pktsize %d  wifi_active_msmt_num_samples %d  wifi_active_msmt_sample_duration %d  vlan_cfg_version %d  wps_pin = %s bandsteering_enable %d  good_rssi_threshold %d  assoc_count_threshold %d  assoc_gate_time %d whix_loginterval %d  rss_memory_restart_threshold_low %lu rss_memory_restart_threshold_high %lu assoc_monitor_duration %d  rapid_reconnect_enable %d  vap_stats_feature %d  mfp_config_feature %d  force_disable_radio_feature %d  force_disable_radio_status %d  fixed_wmm_params %d  wifi_region_code %s diagnostic_enable %d  validate_ssid %d device_network_mode:%d normalized_rssi_list %s snr_list %s cli_stat_list %s txrx_rate_list %s\r\n", __func__, __LINE__, new_rec->notify_wifi_changes,new_rec->prefer_private,new_rec->prefer_private_configure,new_rec->factory_reset,new_rec->tx_overflow_selfheal,new_rec->inst_wifi_client_enabled,new_rec->inst_wifi_client_reporting_period,new_rec->inst_wifi_client_mac, new_rec->inst_wifi_client_def_reporting_period,new_rec->wifi_active_msmt_enabled,new_rec->wifi_active_msmt_pktsize,new_rec->wifi_active_msmt_num_samples,new_rec->wifi_active_msmt_sample_duration,new_rec->vlan_cfg_version,new_rec->wps_pin, new_rec->bandsteering_enable,new_rec->good_rssi_threshold,new_rec->assoc_count_threshold,new_rec->assoc_gate_time, new_rec->whix_log_interval, new_rec->rss_memory_restart_threshold_low, new_rec->rss_memory_restart_threshold_high, new_rec->assoc_monitor_duration,new_rec->rapid_reconnect_enable,new_rec->vap_stats_feature,new_rec->mfp_config_feature,new_rec->force_disable_radio_feature,new_rec->force_disable_radio_status,new_rec->fixed_wmm_params,new_rec->wifi_region_code,new_rec->diagnostic_enable,new_rec->validate_ssid, new_rec->device_network_mode, new_rec->normalized_rssi_list, new_rec->snr_list, new_rec->cli_stat_list, new_rec->txrx_rate_list);
         pthread_mutex_unlock(&g_wifidb->data_cache_lock);
     }
     else
@@ -2950,6 +2952,8 @@ int wifidb_update_wifi_global_config(wifi_global_param_t *config)
     cfg.assoc_gate_time = config->assoc_gate_time;
     cfg.whix_log_interval = config->whix_log_interval;
     cfg.whix_chutility_loginterval = config->whix_chutility_loginterval;
+    cfg.rss_memory_restart_threshold_low = config->rss_memory_restart_threshold_low;
+    cfg.rss_memory_restart_threshold_high = config->rss_memory_restart_threshold_high;
     cfg.assoc_monitor_duration = config->assoc_monitor_duration;
     cfg.rapid_reconnect_enable = config->rapid_reconnect_enable;
     cfg.vap_stats_feature = config->vap_stats_feature;
@@ -3038,6 +3042,8 @@ int wifidb_get_wifi_global_config(wifi_global_param_t *config)
         config->assoc_gate_time = pcfg->assoc_gate_time;
         config->whix_log_interval = pcfg->whix_log_interval;
         config->whix_chutility_loginterval = pcfg->whix_chutility_loginterval;
+        config->rss_memory_restart_threshold_low = pcfg->rss_memory_restart_threshold_low;
+        config->rss_memory_restart_threshold_high = pcfg->rss_memory_restart_threshold_high;
         config->assoc_monitor_duration = pcfg->assoc_monitor_duration;
         config->rapid_reconnect_enable = pcfg->rapid_reconnect_enable;
         config->vap_stats_feature = pcfg->vap_stats_feature;
@@ -4294,6 +4300,15 @@ static void wifidb_global_config_upgrade()
         } else {
             wifi_util_error_print(WIFI_DB,":%s:%d str value for whix_chutility_loginterval is null \r\n", __func__, __LINE__);
         }
+    }
+
+    if (g_wifidb->db_version < ONEWIFI_DB_VERSION_RSS_MEMORY_THRESHOLD_FLAG) {
+        wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade global config, old db version %d \n", __func__,
+            __LINE__, g_wifidb->db_version);
+        g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low =
+            RSS_MEM_THRESHOLD1_DEFAULT;
+        g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high =
+            RSS_MEM_THRESHOLD2_DEFAULT;
     }
 }
 
@@ -6859,6 +6874,8 @@ int wifidb_init_global_config_default(wifi_global_param_t *config)
     cfg.assoc_gate_time  = 0;
     cfg.whix_log_interval = 3600;
     cfg.whix_chutility_loginterval = 900;
+    cfg.rss_memory_restart_threshold_low = 81920;
+    cfg.rss_memory_restart_threshold_high = 112640;
     cfg.assoc_monitor_duration = 0;
     cfg.rapid_reconnect_enable = true;
     cfg.vap_stats_feature =  true;

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -16243,6 +16243,148 @@ AssociatedDevice1_GetParamStringValue
     return -1;
 }
 
+/**********************************************************************
+ APIs for Object:
+   WiFi.WiFiRestart.RssMemory
+
+   * RSSMemory_GetParamUlongValue
+   * RSSMemory_SetParamUlongValue
+
+************************************************************************/
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        RSSMemory_GetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG*                       pULong
+            );
+
+    description:
+
+        This function is called to retrieve Boolean parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+               ULONG*                       pULong
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+
+BOOL RSSMemory_GetParamUlongValue(ANSC_HANDLE hInsContext, char *ParamName, ULONG *pULong)
+{
+    wifi_util_error_print(WIFI_DMCLI, "Enters %s:%d\n", __func__, __LINE__);
+    UNREFERENCED_PARAMETER(hInsContext);
+    wifi_global_param_t *pcfg = (wifi_global_param_t *)get_dml_wifi_global_param();
+
+    if (pcfg == NULL) {
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d  NULL pointer Get fail\n", __FUNCTION__, __LINE__);
+        return FALSE;
+    }
+
+    if (AnscEqualString(ParamName, "Threshold1", TRUE)) {
+        /* collect value */
+        *pULong = pcfg->rss_memory_restart_threshold_low;
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d: RSS Threshold1 = %d\n", __func__, __LINE__,
+            *pULong);
+        return TRUE;
+    }
+
+    if (AnscEqualString(ParamName, "Threshold2", TRUE)) {
+        /* collect value */
+        *pULong = pcfg->rss_memory_restart_threshold_high;
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d: RSS Threshold2 = %d\n", __func__, __LINE__,
+            *pULong);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        RSSMemory_SetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG                       iValue
+            );
+
+    description:
+
+        This function is called to set ULONG parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                ULONG                       iValue
+                The updated value;
+
+    return:     TRUE if succeeded.
+**********************************************************************/
+
+BOOL RSSMemory_SetParamUlongValue(ANSC_HANDLE hInsContext, char *ParamName, ULONG iValue)
+{
+    wifi_util_error_print(WIFI_DMCLI, "Enters %s:%d\n", __func__, __LINE__);
+    UNREFERENCED_PARAMETER(hInsContext);
+    wifi_global_config_t *global_wifi_config;
+    global_wifi_config = (wifi_global_config_t *)get_dml_cache_global_wifi_config();
+
+    if (global_wifi_config == NULL) {
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Unable to get Global Config\n", __FUNCTION__,
+            __LINE__);
+        return FALSE;
+    }
+    /* check the parameter name and set the corresponding value */
+    if (AnscEqualString(ParamName, "Threshold1", TRUE)) {
+        if (global_wifi_config->global_parameters.rss_memory_restart_threshold_low == iValue) {
+            return TRUE;
+        }
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d: RSS Threshold1 = %d New Value = %d\n", __func__,
+            __LINE__, global_wifi_config->global_parameters.rss_memory_restart_threshold_low,
+            iValue);
+        global_wifi_config->global_parameters.rss_memory_restart_threshold_low = iValue;
+        if (push_global_config_dml_cache_to_one_wifidb() != RETURN_OK) {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d: Failed to push RSS Threshold1 value to onewifi db\n", __func__, __LINE__);
+        }
+        return TRUE;
+    }
+
+    if (AnscEqualString(ParamName, "Threshold2", TRUE)) {
+        if (global_wifi_config->global_parameters.rss_memory_restart_threshold_high == iValue) {
+            return TRUE;
+        }
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d: RSS Threshold2 = %d New Value = %d\n", __func__,
+            __LINE__, global_wifi_config->global_parameters.rss_memory_restart_threshold_high,
+            iValue);
+        global_wifi_config->global_parameters.rss_memory_restart_threshold_high = iValue;
+        if (push_global_config_dml_cache_to_one_wifidb() != RETURN_OK) {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d: Failed to push RSS Threshold2 value to onewifi db\n", __func__, __LINE__);
+        }
+        return TRUE;
+    }
+    return FALSE;
+}
 
 /***********************************************************************
 

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -2212,6 +2212,12 @@ webconfig_error_t decode_wifi_global_config(const cJSON *global_cfg, wifi_global
     decode_param_integer(global_cfg, "whix_chutility_loginterval", param);
     global_info->whix_chutility_loginterval = param->valuedouble;
 
+    //Rss threshold
+    decode_param_integer(global_cfg, "rss_memory_restart_threshold_low", param);
+    global_info->rss_memory_restart_threshold_low = param->valuedouble;
+
+    decode_param_integer(global_cfg, "rss_memory_restart_threshold_high", param);
+    global_info->rss_memory_restart_threshold_high = param->valuedouble;
 
     //AssocMonitorDuration
     decode_param_integer(global_cfg, "AssocMonitorDuration", param);

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -694,6 +694,12 @@ webconfig_error_t encode_wifi_global_config(const wifi_global_param_t *global_in
     //Whix_ChUtility_Loginterval
     cJSON_AddNumberToObject(global_obj, "whix_chutility_loginterval", global_info->whix_chutility_loginterval);
 
+    // RSS Mem threshold1
+    cJSON_AddNumberToObject(global_obj, "rss_memory_restart_threshold_low", global_info->rss_memory_restart_threshold_low);
+
+    // RSS Mem threshold2
+    cJSON_AddNumberToObject(global_obj, "rss_memory_restart_threshold_high", global_info->rss_memory_restart_threshold_high);
+
     //AssocMonitorDuration
     cJSON_AddNumberToObject(global_obj, "AssocMonitorDuration", global_info->assoc_monitor_duration);
 


### PR DESCRIPTION
RDKB-59766: Onewifi Memory leak script

Impacted Platforms: All RDKB platforms.
Reason for change: to restart the process when onewifi memory goes beyond threshold.

Test Procedure:
1. Load the above mentioned build.
2. Connect some clients to 2.4Ghz and 5Ghz band.
3. Monitor the RSS of onewifi memory.

Risks: Medium
Priority: P1
Signed-off-by:sanjayvenkatesan1902@gmail.com
---------