### PR TITLE
RDKB-59881: [XLE] SSID needs to be enabled and broadcasted when pushed via XPC blob (#360)

### DIFF
--- a/source/core/services/vap_svc_private.c
+++ b/source/core/services/vap_svc_private.c
@@ -75,7 +75,12 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
         // VAP is enabled in HAL if it is present in VIF_Config and enabled. Absent VAP entries are
         // saved to VAP_Config with exist flag set to 0 and default values.
         enabled = p_tgt_vap_map->vap_array[0].u.bss_info.enabled;
-#if !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_PP203X_PRODUCT_REQ_)
+#if defined(_WNXL11BWL_PRODUCT_REQ_)
+        if (rdk_vap_info[i].exists == false && isVapPrivate(map->vap_array[i].vap_index)) {
+            wifi_util_error_print(WIFI_CTRL,"%s:%d VAP_EXISTS_FALSE for vap_index=%d, setting to TRUE \n",__FUNCTION__,__LINE__,map->vap_array[i].vap_index);
+            rdk_vap_info[i].exists = true;
+        }
+#elif !defined(_PP203X_PRODUCT_REQ_)
         if(rdk_vap_info[i].exists == false) {
 #if defined(_SR213_PRODUCT_REQ_)
             if(map->vap_array[i].vap_index != 2 && map->vap_array[i].vap_index != 3) {
@@ -87,7 +92,7 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
             rdk_vap_info[i].exists = true;
 #endif /* _SR213_PRODUCT_REQ_ */
         }
-#endif /* !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_PP203X_PRODUCT_REQ_) */
+#endif /* !defined(_PP203X_PRODUCT_REQ_) */
         p_tgt_vap_map->vap_array[0].u.bss_info.enabled &= rdk_vap_info[i].exists;
 
         ret = wifi_hal_createVAP(radio_index, p_tgt_vap_map);


### PR DESCRIPTION
Reason for change: Ignore exists condition for XLE on private vaps.

Test Procedure: 1. Builds should passed
		2. FR XLE, configure it in GFO.
		3. Private vaps should get enabled and able to connect clients without any issues.

Risks: Low
Priority: P1