### PR TITLE
RDKBWIFI-39: Adds the ability to trigger station channel scan and consolidates results publishers.

### DIFF
--- a/include/wifi_events.h
+++ b/include/wifi_events.h
@@ -160,6 +160,7 @@ typedef enum {
     wifi_event_type_toggle_disconn_steady_state,
     wifi_event_type_rsn_override_rfc,
     wifi_event_type_sta_client_info,
+    wifi_event_type_start_sta_channel_scan,
     wifi_event_command_max,
 
     wifi_event_monitor_diagnostics = wifi_event_type_base

--- a/source/apps/easyconnect/wifi_easyconnect.c
+++ b/source/apps/easyconnect/wifi_easyconnect.c
@@ -24,71 +24,23 @@
 #define ARRAYSIZE(a) (sizeof(a) / sizeof(*(a)))
 #endif // ARRAYSIZE
 
-/**
- * @brief Is this IE a Wi-Fi Alliance CCE IE?
- *
- * @param ie The information element in question
- * @param ie_len Length of the information element in bytes.
- * @return true if this IE is a WFA CCE IE, otherwise false
- */
-static bool is_cce_ie(const uint8_t *const ie, size_t ie_len)
+static void publish_bss_info(const uint8_t *bss_buffer, int count, unsigned radio_idx)
 {
-    static const uint8_t OUI_WFA[3] = { 0x50, 0x6F, 0x9A };
-    static const uint8_t CCE_CONSTANT = 0x1E;
-    if (ie_len < 4)
-        return false;
-    return memcmp(ie, OUI_WFA, sizeof(OUI_WFA)) == 0 && *(ie + 3) == CCE_CONSTANT;
-}
-
-static void publish_cce_ie_info(const wifi_bss_info_t *bss_info, unsigned radio_idx)
-{
-    if (bss_info == NULL) {
-        wifi_util_error_print(WIFI_EC, "%s:%d: NULL BSS info!\n", __func__, __LINE__);
-        return;
+    if (count == 0) {
+        wifi_util_dbg_print(WIFI_EC, "%s:%d publishing 0 length buffer since no bsses match\n",
+            __func__, __LINE__);
     }
     wifi_ctrl_t *ctrl = get_wifictrl_obj();
     raw_data_t rdata = { 0 };
-    rdata.raw_data.bytes = malloc(sizeof(wifi_bss_info_t));
-    if (rdata.raw_data.bytes == NULL) {
-        wifi_util_error_print(WIFI_EC, "%s:%d: Failed to malloc for wifi_bss_info_t!\n", __func__,
-            __LINE__);
-        return;
-    }
+    rdata.raw_data.bytes = (uint8_t *)bss_buffer;
     rdata.data_type = bus_data_type_bytes;
-    memcpy(rdata.raw_data.bytes, bss_info, sizeof(*bss_info));
-    rdata.raw_data_len = sizeof(*bss_info);
-    char path[256] = { 0 };
-    snprintf(path, sizeof(path), "Device.WiFi.Radio.%d.CCEInd", radio_idx + 1);
-    get_bus_descriptor()->bus_event_publish_fn(&ctrl->handle, path, &rdata);
-    free(rdata.raw_data.bytes);
-}
+    rdata.raw_data_len = count * sizeof(wifi_bss_info_t);
 
-static void publish_bss_info(const wifi_bss_info_t *bss_info)
-{
-    if (bss_info == NULL) {
-        wifi_util_error_print(WIFI_EC, "%s:%d: NULL BSS info!\n", __func__, __LINE__);
-        return;
-    }
-    wifi_ctrl_t *ctrl = get_wifictrl_obj();
-    raw_data_t rdata = { 0 };
-    rdata.raw_data.bytes = malloc(sizeof(wifi_bss_info_t));
-    if (rdata.raw_data.bytes == NULL) {
-        wifi_util_error_print(WIFI_EC, "%s:%d: Failed to malloc for wifi_bss_info_t!\n", __func__,
-            __LINE__);
-        return;
-    }
-    rdata.data_type = bus_data_type_bytes;
-    memcpy(rdata.raw_data.bytes, bss_info, sizeof(*bss_info));
-    rdata.raw_data_len = sizeof(*bss_info);
-    char path[256] = { 0 };
     get_bus_descriptor()->bus_event_publish_fn(&ctrl->handle, WIFI_EASYCONNECT_BSS_INFO, &rdata);
-    free(rdata.raw_data.bytes);
 }
 
 static void handle_wifi_event_scan_results(wifi_app_t *app, void *data)
 {
-    int i;
-    int n = 0;
     scan_results_t *scan_results = (scan_results_t *)data;
     if (!scan_results) {
         wifi_util_error_print(WIFI_EC, "%s:%d: NULL scan data!\n", __func__, __LINE__);
@@ -96,53 +48,29 @@ static void handle_wifi_event_scan_results(wifi_app_t *app, void *data)
     }
     wifi_util_dbg_print(WIFI_EC, "%s:%d: Got scan results on radio %d\n", __func__, __LINE__,
         scan_results->radio_index);
-    if (app->data.u.ec.subscriptions[scan_results->radio_index] == false) {
-        wifi_util_dbg_print(WIFI_EC,
-            "%s:%d: Got a scan result on radio %d but there are no subscribers, skipping...\n",
-            __func__, __LINE__, scan_results->radio_index);
+
+    uint8_t *bss_info_buffer = calloc(scan_results->num, sizeof(wifi_bss_info_t));
+    
+    if (bss_info_buffer == NULL) {
+        wifi_util_error_print(WIFI_EC, "%s:%d: BSS Info failed to allocate!\n", 
+                            __func__, __LINE__);
         return;
     }
-    for (i = 0; i < scan_results->num; i++) {
-        wifi_bss_info_t *bss_info = &scan_results->bss[i];
-        if (!bss_info || !bss_info->ie || bss_info->ie_len == 0) {
-            wifi_util_dbg_print(WIFI_EC, "%s:%d: Invalid BSS info! #%d\n", __func__, __LINE__, i);
-            continue;
-        }
-        uint8_t *ie_pos = bss_info->ie;
-        size_t ie_len_remaining = bss_info->ie_len;
-        while (ie_len_remaining > 2) {
-            uint8_t id = ie_pos[0];
-            uint8_t ie_len = ie_pos[1];
-            if (ie_len + 2 > ie_len_remaining)
-                break;
-            // 0xdd == Vendor IE
-            if (id == 0xdd && is_cce_ie(ie_pos + 2, ie_len)) {
-                wifi_util_dbg_print(WIFI_EC,
-                    "%s:%d: BSS %s Beacon and/or Probe Response from BSSID " MACSTRFMT
-                    " contains WFA CCE IE!\n",
-                    __func__, __LINE__, bss_info->ssid, MAC2STR(bss_info->bssid));
-                publish_cce_ie_info(bss_info, scan_results->radio_index);
-                n++;
-            }
-            // next IE
-            ie_len_remaining -= (ie_len + 2);
-            ie_pos += (ie_len + 2);
-        }
-    }
-    wifi_util_dbg_print(WIFI_EC, "%s:%d parsed and published %d frames containing CCE IE\n",
-        __func__, __LINE__, n);
 
+    for (int i = 0; i < scan_results->num; i++) {
+        wifi_bss_info_t *bss_info = &scan_results->bss[i];
+        memcpy(bss_info_buffer + (i * sizeof(wifi_bss_info_t)), bss_info, sizeof(wifi_bss_info_t));
+    }
     // According to EasyConnect 6.5.2, for Reconfiguration,
     // an Enrollee must broadcast a Reconfiguration Annoncement
     // on each channel where the Configuration Response's SSID is heard.
     // So, publish the whole BSS info to a different path for
     // subscribers to work with.
-    for (i = 0; i < scan_results->num; i++) {
-        wifi_bss_info_t *bss_info = &scan_results->bss[i];
-        if (!bss_info) continue;
-        publish_bss_info(bss_info);
-    }
-
+    publish_bss_info(bss_info_buffer, scan_results->num, scan_results->radio_index);
+    free(bss_info_buffer);
+    
+    wifi_util_dbg_print(WIFI_EC, "%s:%d parsed and published %d frames\n",
+        __func__, __LINE__, scan_results->num);
 }
 
 static void handle_hal_event(wifi_app_t *app, wifi_event_subtype_t event_subtype, void *data)
@@ -182,31 +110,6 @@ static bus_error_t event_sub_handler(char *eventName, bus_event_sub_action_t act
     }
 
     *autoPublish = false;
-    if (sscanf(eventName, "Device.WiFi.Radio.%d.CCEInd", &radio_idx) != 1) {
-        wifi_util_error_print(WIFI_EC,
-            "%s:%d: sscanf failed for event %s, searching on bus path %s\n", __func__, __LINE__,
-            eventName, WIFI_EASYCONNECT_RADIO_CCE_IND);
-        return bus_error_general;
-    }
-    // ensure radio index is valid
-    if (radio_idx < 0 || radio_idx > MAX_NUM_RADIOS) {
-        wifi_util_error_print(WIFI_EC, "%s:%d: invalid radio index: %d\n", __func__, __LINE__,
-            radio_idx);
-        return bus_error_general;
-    }
-    if (action == bus_event_action_subscribe) {
-        wifi_util_info_print(WIFI_EC, "%s:%d: Adding subscrption for radio %d\n", __func__,
-            __LINE__, radio_idx);
-        wifi_app->data.u.ec.subscriptions[radio_idx - 1] = true;
-    } else if (action == bus_event_action_unsubscribe) {
-        wifi_app->data.u.ec.subscriptions[radio_idx - 1] = false;
-        wifi_util_info_print(WIFI_EC, "%s:%d: Removing subscription for radio %d\n", __func__,
-            __LINE__, radio_idx);
-    } else {
-        wifi_util_dbg_print(WIFI_EC, "%s:%d: unhandled action %d for radio %d\n", __func__,
-            __LINE__, action, radio_idx);
-        return bus_error_invalid_event;
-    }
     return bus_error_success;
 }
 
@@ -244,17 +147,9 @@ int easyconnect_init(wifi_app_t *app, unsigned int create_flags)
 {
     wifi_util_dbg_print(WIFI_EC, "%s called.", __func__);
     char *app_name = "WifiAppsEasyConnect";
-    for (int i = 0; i < ARRAYSIZE(app->data.u.ec.subscriptions); i++) {
-        app->data.u.ec.subscriptions[i] = false;
-    }
+
     // clang-format off
     bus_data_element_t data_elements[] = {
-        { WIFI_EASYCONNECT_RADIO_TABLE,   bus_element_type_table,
-         { NULL, NULL, easyconnect_radio_addrowhandler, easyconnect_radio_removerowhandler, NULL,
-          NULL }, slow_speed, MAX_NUM_RADIOS, { bus_data_type_object, false, 0, 0, 0, NULL } },
-        { WIFI_EASYCONNECT_RADIO_CCE_IND, bus_element_type_event,
-         { NULL, NULL, NULL, NULL, event_sub_handler, NULL }, slow_speed, ZERO_TABLE,
-         { bus_data_type_bytes, false, 0, 0, 0, NULL } },
         { WIFI_EASYCONNECT_BSS_INFO, bus_element_type_method,
          { NULL, NULL, NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
          { bus_data_type_bytes, false, 0, 0, 0, NULL } } ,
@@ -280,9 +175,6 @@ int easyconnect_init(wifi_app_t *app, unsigned int create_flags)
 int easyconnect_deinit(wifi_app_t *app)
 {
     wifi_util_info_print(WIFI_EC, "%s:%d: %s called.", __func__, __LINE__, __func__);
-    for (int i = 0; i < ARRAYSIZE(app->data.u.ec.subscriptions); i++) {
-        app->data.u.ec.subscriptions[i] = false;
-    }
     app_deinit(app, app->desc.create_flag);
     return 0;
 }

--- a/source/apps/easyconnect/wifi_easyconnect.h
+++ b/source/apps/easyconnect/wifi_easyconnect.h
@@ -24,15 +24,7 @@
 extern "C" {
 #endif // __cplusplus
 
-#define WIFI_EASYCONNECT_RADIO_TABLE        "Device.WiFi.Radio.{i}"
-#define WIFI_EASYCONNECT_RADIO_CCE_IND      "Device.WiFi.Radio.{i}.CCEInd"
 #define WIFI_EASYCONNECT_BSS_INFO           "Device.WiFi.EC.BSSInfo"
-
-typedef struct _easyconnect_data {
-    bool subscriptions[MAX_NUM_RADIOS];
-} easyconnect_data_t;
-
-// EasyConnect relevant constructs
 
 #ifdef __cplusplus
 }

--- a/source/apps/easyconnect/wifi_easyconnect.h
+++ b/source/apps/easyconnect/wifi_easyconnect.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif // __cplusplus
 
 #define WIFI_EASYCONNECT_BSS_INFO           "Device.WiFi.EC.BSSInfo"
+#define WIFI_TRIGGER_STA_SCAN_REQ           "Device.WiFi.EC.TriggerStaScan"
 
 #ifdef __cplusplus
 }

--- a/source/apps/wifi_apps_mgr.h
+++ b/source/apps/wifi_apps_mgr.h
@@ -92,9 +92,6 @@ typedef struct {
 #ifdef ONEWIFI_STA_MGR_APP_SUPPORT
         sta_mgr_data_t sta_mgr;
 #endif //ONEWIFI_STA_MGR_APP_SUPPORT
-#ifdef ONEWIFI_EASYCONNECT_APP_SUPPORT
-        easyconnect_data_t ec;
-#endif // ONEWIFI_EASYCONNECT_APP_SUPPORT
 #ifdef EM_APP
         em_data_t            em_data;
 #endif //EM_APP


### PR DESCRIPTION
Reason for change: 
- Currently there is no way to call `wifi_hal_startScan` from outside of OneWifi which is the only scanning method capable of scanning station interfaces. 
- Additionally, reduced the amount of publishers in the EC app due to redundancies. 

Test Procedure: 

With the EC app built with OneWifi, call `Device.WiFi.EC.SendStaScan` while viewing `/tmp/wifiHalStats` and view the logs showing the scan was initiated.

Priority: P1
Risks: Low

Related to: 
- https://github.com/rdkcentral/rdk-wifi-hal/pull/228
- https://github.com/rdkcentral/OneWifi/pull/387