### PR TITLE
RDKBWIFI-39: Allows sta VAPs to have empty SSIDs, in the case of a wildcard scan

### DIFF
--- a/source/core/services/vap_svc_mesh_ext.c
+++ b/source/core/services/vap_svc_mesh_ext.c
@@ -511,6 +511,8 @@ void ext_start_scan(vap_svc_t *svc)
     vap_svc_ext_t   *ext;
     wifi_ctrl_t *ctrl;
     unsigned int radio_index;
+    ssid_t ssid;
+    bool found = false;
     wifi_channels_list_t channels;
     wifi_radio_operationParam_t *radio_oper_param;
     wifi_mgr_t *mgr = (wifi_mgr_t *)get_wifimgr_obj();
@@ -547,9 +549,6 @@ void ext_start_scan(vap_svc_t *svc)
             continue;
         }
 
-        wifi_util_dbg_print(WIFI_CTRL, "%s:%d start Scan on radio index %u\n", __func__, __LINE__,
-            radio_index);
-
         radio_oper_param = get_wifidb_radio_map(radio_index);
         if (get_allowed_channels(radio_oper_param->band, &mgr->hal_cap.wifi_prop.radiocap[radio_index],
                 channels_list, &num_channels,
@@ -560,6 +559,21 @@ void ext_start_scan(vap_svc_t *svc)
                sizeof(*channels_list) * num_channels);
         channels.num_channels = num_channels;
 
+        if (get_sta_ssid_from_radio_config_by_radio_index(radio_index, ssid)) {
+            // Didn't find a STA for this radio index
+            continue;
+        }
+        if (strlen(ssid) == 0) {
+            // SSID is wildcard SSID
+            continue;
+        }
+        found = true;
+        break;
+    }
+
+    if (found) {
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d start Scan on radio index %u\n", __func__, __LINE__,
+            radio_index);
         wifi_hal_startScan(radio_index, WIFI_RADIO_SCAN_MODE_OFFCHAN, dwell_time,
             channels.num_channels, channels.channels_list);
     }
@@ -1316,6 +1330,7 @@ int process_ext_scan_results(vap_svc_t *svc, void *arg)
     mac_addr_str_t bssid_str;
     vap_svc_ext_t *ext;
     wifi_ctrl_t *ctrl;
+    ssid_t sta_ssid;
 
     ctrl = svc->ctrl;
     ext = &svc->u.ext;
@@ -1333,6 +1348,22 @@ int process_ext_scan_results(vap_svc_t *svc, void *arg)
     if (ext->conn_state >= connection_state_disconnected_scan_list_all) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Received scan resuts when already have result or connection in progress, should not happen\n",
                         __FUNCTION__,__LINE__);
+        return 0;
+    }
+
+    if (get_sta_ssid_from_radio_config_by_radio_index(results->radio_index, sta_ssid)) {
+        // Didn't find a STA for this radio index
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d Received scan resuts but couldn't find STA for radio index: %d\n", __FUNCTION__,
+            __LINE__, results->radio_index);
+        return 0;
+    }
+    if (strlen(sta_ssid) == 0) {
+        // SSID is wildcard SSID.
+        //  We cannot possibly know the password for whichever network is closest so ignore
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d Recieved scan results for station with wildcard SSID (%d). Ignoring...\n",
+            __FUNCTION__, __LINE__, results->radio_index);
         return 0;
     }
 


### PR DESCRIPTION
Reason for change:

Currently, if a station has an empty SSID:
1. The subdoc will be considered invalid. This should not be considered the case since it can be valid (now) when we are attempting a wildcard scan
2. When a wildcard scan does succeed and therefore the SSID is empty, all the results will be returned but this service will attempt to authenticate against the AP with the best RSSI, despite us not having any valid credentials for it.

This PR eliminates the case where the service is in a loop of attempting to authenticate to an AP that it does not have the credentials for.

Test Procedure:

Set the SSID to "" in the `EasymeshCfg.json` and start OneWifi. After the initial bootup, there should be no authentication attempts because no AP can have an SSID of "".

Priority: P1
Risks: Low

Related to: 
- https://github.com/rdkcentral/rdk-wifi-hal/pull/228
- https://github.com/rdkcentral/OneWifi/pull/386
