### PR TITLE
SHARMAN-3535 : WPS disable config failed to persist after reboot

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4515,7 +4515,7 @@ void wifidb_vap_config_correction(wifi_vap_info_map_t *l_vap_map_param)
 
         if (isVapPrivate(vap_config->vap_index) &&
             is_sec_mode_personal(vap_config->u.bss_info.security.mode)) {
-#ifdef FEATURE_SUPPORT_WPS
+#if defined(FEATURE_SUPPORT_WPS) &&  !defined(_SR213_PRODUCT_REQ_)
             if (vap_config->u.bss_info.wps.enable == false) {
                 vap_config->u.bss_info.wps.enable = true;
                 wifi_util_info_print(WIFI_DB, "%s:%d: force wps enabled for private_vap:%d\r\n",

--- a/source/dml/tr_181/ml/cosa_wifi_internal.c
+++ b/source/dml/tr_181/ml/cosa_wifi_internal.c
@@ -301,7 +301,6 @@ void CosaDmlWiFiGetFromPSM(void)
     wifi_radio_operationParam_t radio_cfg;
     wifi_radio_feature_param_t radio_feat_cfg;
     wifi_vap_info_t vap_config;
-    rdk_wifi_vap_info_t rdk_vap_config;
     wifi_front_haul_bss_t *bss_cfg;
     wifi_global_param_t global_cfg;
     UINT vap_index;
@@ -560,8 +559,6 @@ void CosaDmlWiFiGetFromPSM(void)
 
             vap_index = VAP_INDEX(((webconfig_dml_t *)get_webconfig_dml())->hal_cap, vap_array_index);
             instance_number = vap_index + 1;
-            memset(&vap_config, 0, sizeof(vap_config));
-            wifidb_init_vap_config_default(vap_index, &vap_config, &rdk_vap_config);
 
             if (isVapSTAMesh(vap_index)) {
                 continue;


### PR DESCRIPTION
Reason for change:  wifidb_init_vap_config_default called after Db read causing config to go back to default
Test Procedure: NA
Risks: Low