### PR TITLE
RDKCOM-1035: Testing changes, Not to review and merge

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,39 +147,6 @@ AM_CONDITIONAL([FEATURE_OFF_CHANNEL_SCAN_5G], [test x$FEATURE_OFF_CHANNEL_SCAN_5
 AM_CONDITIONAL([USE_DML_SOURCES], [test x$DEVICE_EXTENDER != xtrue])
 AM_CONDITIONAL([USE_EXTENDER_MISC], [test x$DEVICE_EXTENDER = xtrue])
 
-# Specify ccsp cpu arch
-
-AC_ARG_WITH([ccsp-arch],
-[AC_HELP_STRING([--with-ccsp-arch={arm,atom,pc,mips}],
-                [specify the ccsp board CPU platform])],
-[case x"$withval" in
-   xarm)
-     CCSP_ARCH=arm
-     ;;
-   xatom)
-     CCSP_ARCH=atom
-     ;;
-   xpc)
-     CCSP_ARCH=pc
-     ;;
-   xmips)
-     CCSP_ARCH=mips
-     ;;
-   *)
-     AC_MSG_ERROR([$withval is an invalid option to --with-ccsp-arch])
-     ;;
- esac],
-[CCSP_ARCH=''])
-if test x"${CCSP_ARCH}" != x; then
-  AC_DEFINE_UNQUOTED(CCSP_ARCH, "$CCSP_ARCH",
-                     [The board CPU architecture])
-fi
-
-AM_CONDITIONAL(CCSP_ARCH_ARM, test "x$CCSP_ARCH" = xarm)
-AM_CONDITIONAL(CCSP_ARCH_ATOM, test "x$CCSP_ARCH" = xatom)
-AM_CONDITIONAL(CCSP_ARCH_PC, test "x$CCSP_ARCH" = xpc)
-AM_CONDITIONAL(CCSP_ARCH_MIPS, test "x$CCSP_ARCH" = xmips)
-
 AC_ARG_ENABLE([libwebconfig],
              [  --enable-libwebconfig    Turn on building libwebconfig, otherwise link against sysroot],
              [case "${enableval}" in
@@ -201,30 +168,6 @@ AC_ARG_ENABLE([rdk-wifi-libhostap],
 [CCSP_HOSTAP_AUTH=''])
 if test x"${CCSP_HOSTAP_AUTH}" != x; then
   AC_DEFINE_UNQUOTED(CCSP_HOSTAP_AUTH, "$CCSP_HOSTAP_AUTH",
-                     [The CCSP platform device])
-fi
-# Specify ccsp platform (device)
-
-AC_ARG_WITH([ccsp-platform],
-[AC_HELP_STRING([--with-ccsp-platform={intel_usg,pc,bcm}],
-                [specify the ccsp platform])],
-[case x"$withval" in
-   xintel_usg)
-     CCSP_PLATFORM=intel_usg
-     ;;
-   xpc)
-     CCSP_PLATFORM=pc
-     ;;
-   xbcm)
-     CCSP_PLATFORM=bcm
-     ;;
-   *)
-     AC_MSG_ERROR([$withval is an invalid option to --with-ccsp-platform])
-     ;;
- esac],
-[CCSP_PLATFORM=''])
-if test x"${CCSP_PLATFORM}" != x; then
-  AC_DEFINE_UNQUOTED(CCSP_PLATFORM, "$CCSP_PLATFORM",
                      [The CCSP platform device])
 fi
 

--- a/lib/log/Makefile.am
+++ b/lib/log/Makefile.am
@@ -27,5 +27,5 @@ if JOURNALCTL_SUPPORT
 CcspWifiSsp_SOURCES += log_journal.c
 endif
 
-CcspWifiSsp_LDFLAGS_LDFLAGS += -lev
+CcspWifiSsp_LDFLAGS += -lev
 

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -1991,7 +1991,11 @@ void process_wpa3_rfc(bool type)
             }
             vapInfo->u.bss_info.security.mode = wifi_security_mode_wpa3_transition;
             vapInfo->u.bss_info.security.wpa3_transition_disable = false;
+#if defined(WIFI_HAL_VERSION_3)
             vapInfo->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
+#else
+#error "WIFI_HAL_VERSION_3 is currently required"
+#endif
             vapInfo->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
         } else {
             if (vapInfo->u.bss_info.security.mode == wifi_security_mode_wpa2_personal) {

--- a/source/core/wifi_easy_connect.c
+++ b/source/core/wifi_easy_connect.c
@@ -32,7 +32,7 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include "collection.h"
-#include "wifi_hal.h"
+#include <wifi_hal.h>
 #include "wifi_easy_connect.h"
 #include "wifi_data_plane_types.h"
 #include <sys/socket.h>
@@ -45,8 +45,6 @@
 
 static const char *wifi_health_log = "/rdklogs/logs/wifihealth.txt";
 
-extern bool is_device_associated(int ap_index, char *mac);
-extern bool wifi_api_is_device_associated(int ap_index, char *mac);
 static wifi_easy_connect_t g_easy_connect = {0};
 
 PCOSA_DML_WIFI_DPP_STA_CFG find_dpp_sta_dml_wifi_ap(unsigned int ap_index, mac_address_t sta_mac);

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -76,7 +76,7 @@
 #include "ccsp_psm_helper.h"
 #include "cosa_dbus_api.h"
 #include "collection.h"
-#include "wifi_hal.h"
+#include <wifi_hal.h>
 #include "../../../stubs/wifi_stubs.h"
 #include "wifi_monitor.h"
 
@@ -114,7 +114,6 @@ extern unsigned int startTime[MAX_NUM_RADIOS];
 uint8_t g_radio_instance_num = 0;
 extern void* g_pDslhDmlAgent;
 extern int gChannelSwitchingCount;
-extern bool wifi_api_is_device_associated(int ap_index, char *mac);
 
 /***********************************************************************
  IMPORTANT NOTE:


### PR DESCRIPTION
Reason for change:
Testing changes for internal validation, Not to review and merge. 
Test Procedure: Sanity.

(cherry picked from commit c50dc6fb77e5b39cb341ccbde898a6daea3e6e13) 
Signed-off-by: Andre McCurdy amccurdy@libertyglobal.com