### PR TITLE
RDKCOM-5334: RDKBDEV-3194 fix definition of CcspWifiSsp_LDFLAGS

### DIFF
--- a/lib/log/Makefile.am
+++ b/lib/log/Makefile.am
@@ -27,5 +27,5 @@ if JOURNALCTL_SUPPORT
 CcspWifiSsp_SOURCES += log_journal.c
 endif
 
-CcspWifiSsp_LDFLAGS_LDFLAGS += -lev
+CcspWifiSsp_LDFLAGS += -lev
 


### PR DESCRIPTION
Reason for change:
fix definition of CcspWifiSsp_LDFLAGS in lib/log/Makefile.am Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy [amccurdy@libertyglobal.com](mailto:amccurdy@libertyglobal.com)
(cherry picked from commit db62fefc6af87962965515bf59c342ad311d1a71)