### PR TITLE
Observed "integer expression expected" error message in SelfHeal logs

### DIFF
--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -204,6 +204,11 @@ onewifi_mem_restart() {
     now=$(date +%s)
     time_since_last_restart=$((now - onewifi_last_restart))
 
+    if [ -z "$vmrss" -o -z "$threshold2" -o -z "$threshold1" ]; then
+        echo_t "Invalid vmrss=$vmrss, threshold1=$threshold1, threshold2=$threshold2" >> $LOG_FILE
+        return
+    fi
+
     if [ "$vmrss" -ge "$threshold2" ]; then
         if [ "$time_since_last_restart" -ge 86400 ]; then
             echo_t "RSS Memory of Onewifi exceeds RSS threshold2 value and restarting Onewifi [Rss : ($vmrss kB) Threshold2 : ($threshold2 kB)]" >> $LOG_FILE


### PR DESCRIPTION
RDKB-60024 Observed "integer expression expected" error message in SelfHeal logs

Test Procedure: After booting, grep -ir "integer expression expected" /rdklogs/logs/*

Priority: P1
Risks: No