### PR TITLE
RDKB-59928: implement rate limit for mgt frames (#362)

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -918,6 +918,43 @@ INSTMSMT_PH2 -->
 			</objects>
 		</object>
 
+               <object>
+                    <name>X_RDKCENTRAL-COM_MgtFrameRateLimit</name>
+                    <objectType>object</objectType>
+                    <functions>
+                        <func_GetParamBoolValue>MgtFrameRateLimit_GetParamBoolValue</func_GetParamBoolValue>
+                        <func_SetParamBoolValue>MgtFrameRateLimit_SetParamBoolValue</func_SetParamBoolValue>
+                        <func_GetParamUlongValue>MgtFrameRateLimit_GetParamUlongValue</func_GetParamUlongValue>
+                        <func_SetParamUlongValue>MgtFrameRateLimit_SetParamUlongValue</func_SetParamUlongValue>
+                    </functions>
+                        <parameters>
+                        <parameter>
+                            <name>Enable</name>
+                            <type>boolean</type>
+                            <syntax>bool</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
+                            <name>RateLimit</name>
+                            <type>unsignedInt</type>
+                            <syntax>uint32</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
+                            <name>WindowSize</name>
+                            <type>unsignedInt</type>
+                            <syntax>uint32</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
+                            <name>CooldownTime</name>
+                            <type>unsignedInt</type>
+                            <syntax>uint32</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                    </parameters>
+                </object>
+
                 <object>
                     <name>Radio</name>
                     <objectType>staticTable</objectType>

--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -1,6 +1,6 @@
 {
   "name": "Wifi_Rdk_Database",
-  "version": "1.00.035",
+  "version": "1.00.036",
   "cksum": "2353365742 523",
   "tables": {
     "Wifi_Device_Config": {
@@ -2112,6 +2112,42 @@
           }
         },
         "device_network_mode": {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mgt_frame_rate_limit_enable": {
+          "type": {
+            "key": {
+              "type": "boolean"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mgt_frame_rate_limit": {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mgt_frame_rate_limit_window_size": {
+          "type": {
+            "key": {
+              "type": "integer"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mgt_frame_rate_limit_cooldown_time": {
           "type": {
             "key": {
               "type": "integer"

--- a/config/subdoc_schemas_1_4/dml_subdoc_schema
+++ b/config/subdoc_schemas_1_4/dml_subdoc_schema
@@ -43,7 +43,11 @@
 		"NormalizedRssiList": "1,2",
 		"SNRList": "1,2",
 		"CliStatList": "1,2",
-		"TxRxRateList": "1,2"
+		"TxRxRateList": "1,2",
+		"MgtFrameRateLimitEnable": false,
+		"MgtFrameRateLimit": 10,
+		"MgtFrameRateLimitWindowSize": 1,
+		"MgtFrameRateLimitCooldownTime": 30
 	},
 	"WifiRadioConfig": [
 		{

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -461,6 +461,10 @@ typedef struct {
     char cli_stat_list[MAX_BUF_LENGTH];
     char snr_list[MAX_BUF_LENGTH];
     char txrx_rate_list[MAX_BUF_LENGTH];
+    bool mgt_frame_rate_limit_enable;
+    int mgt_frame_rate_limit;
+    int mgt_frame_rate_limit_window_size;
+    int mgt_frame_rate_limit_cooldown_time;
 } __attribute__((packed)) wifi_global_param_t;
 
 typedef struct {

--- a/lib/inc/schema_gen.h
+++ b/lib/inc/schema_gen.h
@@ -1621,6 +1621,10 @@
         PJS_OVS_STRING(snr_list, 128 + 1) \
         PJS_OVS_STRING(cli_stat_list, 128 + 1) \
         PJS_OVS_STRING(txrx_rate_list, 128 + 1) \
+        PJS_OVS_BOOL(mgt_frame_rate_limit_enable) \
+        PJS_OVS_INT(mgt_frame_rate_limit) \
+        PJS_OVS_INT(mgt_frame_rate_limit_window_size) \
+        PJS_OVS_INT(mgt_frame_rate_limit_cooldown_time) \
     )
 
 #define PJS_SCHEMA_Wifi_Preassoc_Control_Config \
@@ -3277,6 +3281,10 @@
     COLUMN(snr_list) \
     COLUMN(cli_stat_list) \
     COLUMN(txrx_rate_list) \
+    COLUMN(mgt_frame_rate_limit_enable) \
+    COLUMN(mgt_frame_rate_limit) \
+    COLUMN(mgt_frame_rate_limit_window_size) \
+    COLUMN(mgt_frame_rate_limit_cooldown_time) \
 
 #define SCHEMA__Wifi_Preassoc_Control_Config "Wifi_Preassoc_Control_Config"
 #define SCHEMA_COLUMN__Wifi_Preassoc_Control_Config(COLUMN) \
@@ -4527,6 +4535,10 @@
 #define SCHEMA__Wifi_Global_Config__snr_list "snr_list"
 #define SCHEMA__Wifi_Global_Config__cli_stat_list "cli_stat_list"
 #define SCHEMA__Wifi_Global_Config__txrx_rate_list "txrx_rate_list"
+#define SCHEMA__Wifi_Global_Config__mgt_frame_rate_limit_enable "mgt_frame_rate_limit_enable"
+#define SCHEMA__Wifi_Global_Config__mgt_frame_rate_limit "mgt_frame_rate_limit"
+#define SCHEMA__Wifi_Global_Config__mgt_frame_rate_limit_window_size "mgt_frame_rate_limit_window_size"
+#define SCHEMA__Wifi_Global_Config__mgt_frame_rate_limit_cooldown_time "mgt_frame_rate_limit_cooldown_time"
 
 #define SCHEMA__Wifi_Preassoc_Control_Config__rssi_up_threshold "rssi_up_threshold"
 #define SCHEMA__Wifi_Preassoc_Control_Config__snr_threshold "snr_threshold"

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1481,6 +1481,7 @@ int wifi_hal_platform_post_init()
     unsigned int index = 0;
     wifi_vap_info_map_t vap_map[MAX_NUM_RADIOS];
     wifi_vap_info_map_t *p_vap_map = NULL;
+    wifi_global_param_t *global_param;
 
     memset(vap_map, 0, sizeof(vap_map));
 
@@ -1499,6 +1500,13 @@ int wifi_hal_platform_post_init()
     if (ret != RETURN_OK) {
         wifi_util_error_print(WIFI_CTRL,"%s start wifi apps failed, ret:%d\n",__FUNCTION__, ret);
         return RETURN_ERR;
+    }
+
+    global_param = get_wifidb_wifi_global_param();
+    if (global_param != NULL) {
+        wifi_hal_set_mgt_frame_rate_limit(global_param->mgt_frame_rate_limit_enable,
+            global_param->mgt_frame_rate_limit, global_param->mgt_frame_rate_limit_window_size,
+            global_param->mgt_frame_rate_limit_cooldown_time);
     }
 
     return RETURN_OK;

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -1203,6 +1203,7 @@ int webconfig_vif_neighbors_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_da
 int webconfig_global_config_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data)
 {
     wifi_util_dbg_print(WIFI_CTRL,"Inside webconfig_global_config_apply\n");
+    wifi_global_param_t *param;
     wifi_global_config_t *data_global_config;
     data_global_config = &data->config;
     bool global_param_changed = false;
@@ -1217,9 +1218,16 @@ int webconfig_global_config_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_da
     }
 
     if (global_param_changed) {
-        wifi_util_dbg_print(WIFI_CTRL,"Global config value is changed hence update the global config in DB\n");
-        if(update_wifi_global_config(&data_global_config->global_parameters) == -1) {
-            wifi_util_dbg_print(WIFI_CTRL,"Global config value is not updated in DB\n");
+        param = &data_global_config->global_parameters;
+
+        wifi_hal_set_mgt_frame_rate_limit(param->mgt_frame_rate_limit_enable,
+            param->mgt_frame_rate_limit, param->mgt_frame_rate_limit_window_size,
+            param->mgt_frame_rate_limit_cooldown_time);
+
+        wifi_util_dbg_print(WIFI_CTRL,
+            "Global config value is changed hence update the global config in DB\n");
+        if (update_wifi_global_config(param) == -1) {
+            wifi_util_dbg_print(WIFI_CTRL, "Global config value is not updated in DB\n");
             return RETURN_ERR;
         }
     }

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -81,6 +81,7 @@
 #define WPA3_COMPATIBILITY 8192
 #define ONEWIFI_DB_VERSION_HOSTAP_MGMT_FRAME_CTRL_FLAG 100034
 #define ONEWIFI_DB_VERSION_RSS_MEMORY_THRESHOLD_FLAG 100035
+#define ONEWIFI_DB_VERSION_MGT_FRAME_RATE_LIMIT 100036
 
 ovsdb_table_t table_Wifi_Radio_Config;
 ovsdb_table_t table_Wifi_VAP_Config;
@@ -1191,7 +1192,51 @@ void callback_Wifi_Global_Config(ovsdb_update_monitor_t *mon,
             strncpy(g_wifidb->global_config.global_parameters.txrx_rate_list,new_rec->txrx_rate_list,sizeof(g_wifidb->global_config.global_parameters.txrx_rate_list)-1);
             g_wifidb->global_config.global_parameters.txrx_rate_list[sizeof(g_wifidb->global_config.global_parameters.txrx_rate_list)-1] = '\0';
         }
-        wifi_util_dbg_print(WIFI_DB,"%s:%d  notify_wifi_changes %d  prefer_private %d  prefer_private_configure %d  factory_reset %d  tx_overflow_selfheal %d  inst_wifi_client_enabled %d  inst_wifi_client_reporting_period %d  inst_wifi_client_mac = %s inst_wifi_client_def_reporting_period %d  wifi_active_msmt_enabled %d  wifi_active_msmt_pktsize %d  wifi_active_msmt_num_samples %d  wifi_active_msmt_sample_duration %d  vlan_cfg_version %d  wps_pin = %s bandsteering_enable %d  good_rssi_threshold %d  assoc_count_threshold %d  assoc_gate_time %d whix_loginterval %d  rss_memory_restart_threshold_low %lu rss_memory_restart_threshold_high %lu assoc_monitor_duration %d  rapid_reconnect_enable %d  vap_stats_feature %d  mfp_config_feature %d  force_disable_radio_feature %d  force_disable_radio_status %d  fixed_wmm_params %d  wifi_region_code %s diagnostic_enable %d  validate_ssid %d device_network_mode:%d normalized_rssi_list %s snr_list %s cli_stat_list %s txrx_rate_list %s\r\n", __func__, __LINE__, new_rec->notify_wifi_changes,new_rec->prefer_private,new_rec->prefer_private_configure,new_rec->factory_reset,new_rec->tx_overflow_selfheal,new_rec->inst_wifi_client_enabled,new_rec->inst_wifi_client_reporting_period,new_rec->inst_wifi_client_mac, new_rec->inst_wifi_client_def_reporting_period,new_rec->wifi_active_msmt_enabled,new_rec->wifi_active_msmt_pktsize,new_rec->wifi_active_msmt_num_samples,new_rec->wifi_active_msmt_sample_duration,new_rec->vlan_cfg_version,new_rec->wps_pin, new_rec->bandsteering_enable,new_rec->good_rssi_threshold,new_rec->assoc_count_threshold,new_rec->assoc_gate_time, new_rec->whix_log_interval, new_rec->rss_memory_restart_threshold_low, new_rec->rss_memory_restart_threshold_high, new_rec->assoc_monitor_duration,new_rec->rapid_reconnect_enable,new_rec->vap_stats_feature,new_rec->mfp_config_feature,new_rec->force_disable_radio_feature,new_rec->force_disable_radio_status,new_rec->fixed_wmm_params,new_rec->wifi_region_code,new_rec->diagnostic_enable,new_rec->validate_ssid, new_rec->device_network_mode, new_rec->normalized_rssi_list, new_rec->snr_list, new_rec->cli_stat_list, new_rec->txrx_rate_list);
+
+        g_wifidb->global_config.global_parameters.mgt_frame_rate_limit_enable =
+            new_rec->mgt_frame_rate_limit_enable;
+        g_wifidb->global_config.global_parameters.mgt_frame_rate_limit =
+            new_rec->mgt_frame_rate_limit;
+        g_wifidb->global_config.global_parameters.mgt_frame_rate_limit_window_size =
+            new_rec->mgt_frame_rate_limit_window_size;
+        g_wifidb->global_config.global_parameters.mgt_frame_rate_limit_cooldown_time =
+            new_rec->mgt_frame_rate_limit_cooldown_time;
+
+        wifi_util_dbg_print(WIFI_DB,
+            "%s:%d notify_wifi_changes %d prefer_private %d prefer_private_configure %d "
+            "factory_reset %d tx_overflow_selfheal %d inst_wifi_client_enabled %d "
+            "inst_wifi_client_reporting_period %d inst_wifi_client_mac %s "
+            "inst_wifi_client_def_reporting_period %d wifi_active_msmt_enabled %d "
+            "wifi_active_msmt_pktsize %d wifi_active_msmt_num_samples %d "
+            "wifi_active_msmt_sample_duration %d vlan_cfg_version %d wps_pin %s "
+            "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d "
+            "assoc_gate_time %d whix_loginterval %d rss_memory_restart_threshold_low %lu "
+            "rss_memory_restart_threshold_high %lu assoc_monitor_duration %d "
+            "rapid_reconnect_enable %d vap_stats_feature %d mfp_config_feature %d "
+            "force_disable_radio_feature %d force_disable_radio_status %d fixed_wmm_params %d "
+            "wifi_region_code %s diagnostic_enable %d validate_ssid %d device_network_mode %d "
+            "normalized_rssi_list %s snr_list %s cli_stat_list %s txrx_rate_list %s "
+            "mgt_frame_rate_limit_enable %d mgt_frame_rate_limit %d mgt_frame_window_size %d"
+            "mgt_frame_cooldown_time %d\n",
+            __func__, __LINE__, new_rec->notify_wifi_changes, new_rec->prefer_private,
+            new_rec->prefer_private_configure, new_rec->factory_reset,
+            new_rec->tx_overflow_selfheal, new_rec->inst_wifi_client_enabled,
+            new_rec->inst_wifi_client_reporting_period, new_rec->inst_wifi_client_mac,
+            new_rec->inst_wifi_client_def_reporting_period, new_rec->wifi_active_msmt_enabled,
+            new_rec->wifi_active_msmt_pktsize, new_rec->wifi_active_msmt_num_samples,
+            new_rec->wifi_active_msmt_sample_duration, new_rec->vlan_cfg_version, new_rec->wps_pin,
+            new_rec->bandsteering_enable, new_rec->good_rssi_threshold,
+            new_rec->assoc_count_threshold, new_rec->assoc_gate_time, new_rec->whix_log_interval,
+            new_rec->rss_memory_restart_threshold_low, new_rec->rss_memory_restart_threshold_high,
+            new_rec->assoc_monitor_duration, new_rec->rapid_reconnect_enable,
+            new_rec->vap_stats_feature, new_rec->mfp_config_feature,
+            new_rec->force_disable_radio_feature, new_rec->force_disable_radio_status,
+            new_rec->fixed_wmm_params, new_rec->wifi_region_code, new_rec->diagnostic_enable,
+            new_rec->validate_ssid, new_rec->device_network_mode, new_rec->normalized_rssi_list,
+            new_rec->snr_list, new_rec->cli_stat_list, new_rec->txrx_rate_list,
+            new_rec->mgt_frame_rate_limit_enable, new_rec->mgt_frame_rate_limit,
+            new_rec->mgt_frame_rate_limit_window_size, new_rec->mgt_frame_rate_limit_cooldown_time);
+
         pthread_mutex_unlock(&g_wifidb->data_cache_lock);
     }
     else
@@ -2978,11 +3023,44 @@ int wifidb_update_wifi_global_config(wifi_global_param_t *config)
     strncpy(cfg.txrx_rate_list,config->txrx_rate_list,sizeof(cfg.txrx_rate_list)-1);
     cfg.txrx_rate_list[sizeof(cfg.txrx_rate_list)-1] = '\0';
 
+    cfg.mgt_frame_rate_limit_enable = config->mgt_frame_rate_limit_enable;
+    cfg.mgt_frame_rate_limit = config->mgt_frame_rate_limit;
+    cfg.mgt_frame_rate_limit_window_size = config->mgt_frame_rate_limit_window_size;
+    cfg.mgt_frame_rate_limit_cooldown_time = config->mgt_frame_rate_limit_cooldown_time;
+
 #ifndef NEWPLATFORM_PORT
     wifidml_desc_t *p_desc = &get_wifidml_obj()->desc;
     p_desc->push_data_to_ssp_queue_fn(config, sizeof(wifi_global_param_t), ssp_event_type_psm_write, global_config);
 #endif // NEWPLATFORM_PORT
-    wifi_util_dbg_print(WIFI_DB,"\n %s:%d  notify_wifi_changes %d  prefer_private %d  prefer_private_configure %d  factory_reset %d  tx_overflow_selfheal %d  inst_wifi_client_enabled %d  inst_wifi_client_reporting_period %d  inst_wifi_client_mac = %s inst_wifi_client_def_reporting_period %d  wifi_active_msmt_enabled %d  wifi_active_msmt_pktsize %d  wifi_active_msmt_num_samples %d  wifi_active_msmt_sample_duration %d  vlan_cfg_version %d  wps_pin = %s bandsteering_enable %d  good_rssi_threshold %d  assoc_count_threshold %d  assoc_gate_time %d  assoc_monitor_duration %d  rapid_reconnect_enable %d  vap_stats_feature %d  mfp_config_feature %d  force_disable_radio_feature %d  force_disable_radio_status %d  fixed_wmm_params %d  wifi_region_code %s diagnostic_enable %d  validate_ssid %d device_network_mode:%d normalized_rssi_list %s snr_list %s cli_stat_list %s txrx_rate_list %s\r\n", __func__, __LINE__, config->notify_wifi_changes,config->prefer_private,config->prefer_private_configure,config->factory_reset,config->tx_overflow_selfheal,config->inst_wifi_client_enabled,config->inst_wifi_client_reporting_period,config->inst_wifi_client_mac, config->inst_wifi_client_def_reporting_period,config->wifi_active_msmt_enabled,config->wifi_active_msmt_pktsize,config->wifi_active_msmt_num_samples,config->wifi_active_msmt_sample_duration,config->vlan_cfg_version,config->wps_pin, config->bandsteering_enable,config->good_rssi_threshold,config->assoc_count_threshold,config->assoc_gate_time,config->assoc_monitor_duration,config->rapid_reconnect_enable,config->vap_stats_feature,config->mfp_config_feature,config->force_disable_radio_feature,config->force_disable_radio_status,config->fixed_wmm_params,config->wifi_region_code,config->diagnostic_enable,config->validate_ssid, config->device_network_mode,config->normalized_rssi_list,config->snr_list,config->cli_stat_list,config->txrx_rate_list);
+    wifi_util_dbg_print(WIFI_DB,
+        "%s:%d notify_wifi_changes %d prefer_private %d prefer_private_configure %d "
+        "factory_reset %d tx_overflow_selfheal %d inst_wifi_client_enabled %d "
+        "inst_wifi_client_reporting_period %d inst_wifi_client_mac %s "
+        "inst_wifi_client_def_reporting_period %d wifi_active_msmt_enabled %d "
+        "wifi_active_msmt_pktsize %d wifi_active_msmt_num_samples %d "
+        "wifi_active_msmt_sample_duration %d vlan_cfg_version %d wps_pin %s "
+        "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d assoc_gate_time "
+        "%d assoc_monitor_duration %d rapid_reconnect_enable %d vap_stats_feature %d "
+        "mfp_config_feature %d force_disable_radio_feature %d force_disable_radio_status %d "
+        "fixed_wmm_params %d wifi_region_code %s diagnostic_enable %d validate_ssid %d "
+        "device_network_mode:%d normalized_rssi_list %s snr_list %s cli_stat_list %s "
+        "txrx_rate_list %s mgt_frame_rate_limit_enable %d mgt_frame_rate_limit %d "
+        "mgt_frame_rate_limit_window_size %d mgt_frame_rate_limit_cooldown_time %d\n",
+        __func__, __LINE__, config->notify_wifi_changes, config->prefer_private,
+        config->prefer_private_configure, config->factory_reset, config->tx_overflow_selfheal,
+        config->inst_wifi_client_enabled, config->inst_wifi_client_reporting_period,
+        config->inst_wifi_client_mac, config->inst_wifi_client_def_reporting_period,
+        config->wifi_active_msmt_enabled, config->wifi_active_msmt_pktsize,
+        config->wifi_active_msmt_num_samples, config->wifi_active_msmt_sample_duration,
+        config->vlan_cfg_version, config->wps_pin, config->bandsteering_enable,
+        config->good_rssi_threshold, config->assoc_count_threshold, config->assoc_gate_time,
+        config->assoc_monitor_duration, config->rapid_reconnect_enable, config->vap_stats_feature,
+        config->mfp_config_feature, config->force_disable_radio_feature,
+        config->force_disable_radio_status, config->fixed_wmm_params, config->wifi_region_code,
+        config->diagnostic_enable, config->validate_ssid, config->device_network_mode,
+        config->normalized_rssi_list, config->snr_list, config->cli_stat_list,
+        config->txrx_rate_list, config->mgt_frame_rate_limit_enable, config->mgt_frame_rate_limit,
+        config->mgt_frame_rate_limit_window_size, config->mgt_frame_rate_limit_cooldown_time);
 
     if (wifidb_update_table_entry(NULL,NULL,OCLM_UUID,&table_Wifi_Global_Config,&cfg,filter_global) <= 0)
     {
@@ -3074,8 +3152,42 @@ int wifidb_get_wifi_global_config(wifi_global_param_t *config)
             config->txrx_rate_list[sizeof(config->txrx_rate_list)-1] = '\0';
         }
 
-        wifi_util_dbg_print(WIFI_DB,"%s:%d  notify_wifi_changes %d  prefer_private %d  prefer_private_configure %d  factory_reset %d  tx_overflow_selfheal %d  inst_wifi_client_enabled %d  inst_wifi_client_reporting_period %d  inst_wifi_client_mac = %s inst_wifi_client_def_reporting_period %d  wifi_active_msmt_enabled %d  wifi_active_msmt_pktsize %d  wifi_active_msmt_num_samples %d  wifi_active_msmt_sample_duration %d  vlan_cfg_version %d  wps_pin = %s bandsteering_enable %d  good_rssi_threshold %d  assoc_count_threshold %d  assoc_gate_time %d  assoc_monitor_duration %d  rapid_reconnect_enable %d  vap_stats_feature %d  mfp_config_feature %d  force_disable_radio_feature %d  force_disable_radio_status %d  fixed_wmm_params %d  wifi_region_code %s diagnostic_enable %d  validate_ssid %d device_network_mode:%d normalized_rssi_list %s snr list %s txrx_rate_list %s cli_stat_list %s\r\n", __func__, __LINE__, config->notify_wifi_changes,config->prefer_private,config->prefer_private_configure,config->factory_reset,config->tx_overflow_selfheal,config->inst_wifi_client_enabled,config->inst_wifi_client_reporting_period,config->inst_wifi_client_mac, config->inst_wifi_client_def_reporting_period,config->wifi_active_msmt_enabled,config->wifi_active_msmt_pktsize,config->wifi_active_msmt_num_samples,config->wifi_active_msmt_sample_duration,config->vlan_cfg_version,config->wps_pin, config->bandsteering_enable,config->good_rssi_threshold,config->assoc_count_threshold,config->assoc_gate_time,config->assoc_monitor_duration,config->rapid_reconnect_enable,config->vap_stats_feature,config->mfp_config_feature,config->force_disable_radio_feature,config->force_disable_radio_status,config->fixed_wmm_params,config->wifi_region_code,config->diagnostic_enable,config->validate_ssid, config->device_network_mode,config->normalized_rssi_list, config->snr_list, config->txrx_rate_list, config->cli_stat_list);
+        config->mgt_frame_rate_limit_enable = pcfg->mgt_frame_rate_limit_enable;
+        config->mgt_frame_rate_limit = pcfg->mgt_frame_rate_limit;
+        config->mgt_frame_rate_limit_window_size = pcfg->mgt_frame_rate_limit_window_size;
+        config->mgt_frame_rate_limit_cooldown_time = pcfg->mgt_frame_rate_limit_cooldown_time;
 
+        wifi_util_dbg_print(WIFI_DB,
+            "%s:%d notify_wifi_changes %d prefer_private %d prefer_private_configure %d "
+            "factory_reset %d tx_overflow_selfheal %d inst_wifi_client_enabled %d "
+            "inst_wifi_client_reporting_period %d inst_wifi_client_mac %s "
+            "inst_wifi_client_def_reporting_period %d wifi_active_msmt_enabled %d "
+            "wifi_active_msmt_pktsize %d wifi_active_msmt_num_samples %d "
+            "wifi_active_msmt_sample_duration %d vlan_cfg_version %d wps_pin %s "
+            "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d "
+            "assoc_gate_time %d assoc_monitor_duration %d rapid_reconnect_enable %d "
+            "vap_stats_feature %d mfp_config_feature %d force_disable_radio_feature %d "
+            "force_disable_radio_status %d fixed_wmm_params %d wifi_region_code %s "
+            "diagnostic_enable %d validate_ssid %d device_network_mode:%d normalized_rssi_list %s "
+            "snr list %s txrx_rate_list %s cli_stat_list %s mgt_frame_rate_limit_enable %d"
+            "mgt_frame_rate_limit %d mgt_frame_rate_limit_window_size %d "
+            "mgt_frame_rate_limit_cooldown_time %d\n",
+            __func__, __LINE__, config->notify_wifi_changes, config->prefer_private,
+            config->prefer_private_configure, config->factory_reset, config->tx_overflow_selfheal,
+            config->inst_wifi_client_enabled, config->inst_wifi_client_reporting_period,
+            config->inst_wifi_client_mac, config->inst_wifi_client_def_reporting_period,
+            config->wifi_active_msmt_enabled, config->wifi_active_msmt_pktsize,
+            config->wifi_active_msmt_num_samples, config->wifi_active_msmt_sample_duration,
+            config->vlan_cfg_version, config->wps_pin, config->bandsteering_enable,
+            config->good_rssi_threshold, config->assoc_count_threshold, config->assoc_gate_time,
+            config->assoc_monitor_duration, config->rapid_reconnect_enable,
+            config->vap_stats_feature, config->mfp_config_feature,
+            config->force_disable_radio_feature, config->force_disable_radio_status,
+            config->fixed_wmm_params, config->wifi_region_code, config->diagnostic_enable,
+            config->validate_ssid, config->device_network_mode, config->normalized_rssi_list,
+            config->snr_list, config->txrx_rate_list, config->cli_stat_list,
+            config->mgt_frame_rate_limit_enable, config->mgt_frame_rate_limit,
+            config->mgt_frame_rate_limit_window_size, config->mgt_frame_rate_limit_cooldown_time);
     }
     free(pcfg);
     return 0;
@@ -4309,6 +4421,15 @@ static void wifidb_global_config_upgrade()
             RSS_MEM_THRESHOLD1_DEFAULT;
         g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high =
             RSS_MEM_THRESHOLD2_DEFAULT;
+    }
+
+    if (g_wifidb->db_version < ONEWIFI_DB_VERSION_MGT_FRAME_RATE_LIMIT) {
+        wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade global config, old db version %d \n", __func__,
+            __LINE__, g_wifidb->db_version);
+        g_wifidb->global_config.global_parameters.mgt_frame_rate_limit_enable = false;
+        g_wifidb->global_config.global_parameters.mgt_frame_rate_limit = 10;
+        g_wifidb->global_config.global_parameters.mgt_frame_rate_limit_window_size = 1;
+        g_wifidb->global_config.global_parameters.mgt_frame_rate_limit_cooldown_time = 30;
     }
 }
 
@@ -6920,6 +7041,11 @@ int wifidb_init_global_config_default(wifi_global_param_t *config)
     cfg.cli_stat_list[sizeof(cfg.cli_stat_list)-1] = '\0';
     strncpy(cfg.txrx_rate_list, tempBuf, sizeof(cfg.txrx_rate_list)-1);
     cfg.txrx_rate_list[sizeof(cfg.txrx_rate_list)-1] = '\0';
+
+    cfg.mgt_frame_rate_limit_enable = false;
+    cfg.mgt_frame_rate_limit = 10;
+    cfg.mgt_frame_rate_limit_window_size = 1;
+    cfg.mgt_frame_rate_limit_cooldown_time = 30;
 
 #ifdef ONEWIFI_DEFAULT_NETWORKING_MODE
     cfg.device_network_mode = ONEWIFI_DEFAULT_NETWORKING_MODE;

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -20232,3 +20232,279 @@ Passpoint_SetParamStringValue
     return FALSE;
 }
 
+/***********************************************************************
+
+ APIs for Object:
+
+    WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.
+
+    *  MgtFrameRateLimit_GetParamBoolValue
+    *  MgtFrameRateLimit_SetParamBoolValue
+    *  MgtFrameRateLimit_GetParamUlongValue
+    *  MgtFrameRateLimit_SetParamUlongValue
+
+***********************************************************************/
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        MgtFrameRateLimit_GetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL*                       pBool
+            );
+
+    description:
+
+        This function is called to retrieve Boolean parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL*                       pBool
+                The buffer of returned boolean value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+BOOL MgtFrameRateLimit_GetParamBoolValue(ANSC_HANDLE hInsContext, char *ParamName, BOOL *pBool)
+{
+    wifi_global_param_t *pcfg = get_dml_wifi_global_param();
+
+    UNREFERENCED_PARAMETER(hInsContext);
+
+    if (pcfg == NULL) {
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Failed to get global config\n", __func__, __LINE__);
+        return FALSE;
+    }
+
+    if (AnscEqualString(ParamName, "Enable", TRUE)) {
+        *pBool = pcfg->mgt_frame_rate_limit_enable;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/**********************************************************************  
+ 
+	 caller:	 owner of this object 
+ 
+	 prototype: 
+ 
+		 BOOL
+		 MgtFrameRateLimit_SetParamBoolValue
+			 (
+				 ANSC_HANDLE					hInsContext,
+				 char*						ParamName,
+				 BOOL						bValue
+			 );
+ 
+	 description:
+ 
+		 This function is called to set BOOL parameter value; 
+ 
+	 argument:	 ANSC_HANDLE				 hInsContext,
+				 The instance handle;
+ 
+				 char*						 ParamName,
+				 The parameter name;
+ 
+				 BOOL						 bValue
+				 The updated BOOL value;
+ 
+	 return:	 TRUE if succeeded.
+ 
+ **********************************************************************/
+BOOL MgtFrameRateLimit_SetParamBoolValue(ANSC_HANDLE hInsContext, char *ParamName, BOOL bValue)
+{
+    wifi_global_config_t *global_wifi_config = get_dml_cache_global_wifi_config();
+
+    UNREFERENCED_PARAMETER(hInsContext);
+
+    if (global_wifi_config == NULL) {
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Failed to get global config\n", __func__, __LINE__);
+        return FALSE;
+    }
+
+    if (AnscEqualString(ParamName, "Enable", TRUE)) {
+        if (global_wifi_config->global_parameters.mgt_frame_rate_limit_enable == bValue) {
+            return TRUE;
+        }
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d: RateLimit Enable: %d\n", __func__, __LINE__,
+            bValue);
+        global_wifi_config->global_parameters.mgt_frame_rate_limit_enable = bValue;
+
+        if (push_global_config_dml_cache_to_one_wifidb() != RETURN_OK) {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d: Failed to push RateLimit Enable value to onewifi db\n", __func__, __LINE__);
+        }
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        MgtFrameRateLimit_GetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG*                      pULong
+            );
+
+    description:
+
+        This function is called to retrieve ULONG parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+               ULONG*                       pULong
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+
+BOOL MgtFrameRateLimit_GetParamUlongValue(ANSC_HANDLE hInsContext, char *ParamName, ULONG *pULong)
+{
+    wifi_global_param_t *pcfg = get_dml_wifi_global_param();
+
+    UNREFERENCED_PARAMETER(hInsContext);
+
+    if (pcfg == NULL) {
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Failed to get global config\n", __func__, __LINE__);
+        return FALSE;
+    }
+
+    if (AnscEqualString(ParamName, "RateLimit", TRUE)) {
+        *pULong = pcfg->mgt_frame_rate_limit;
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d RateLimit: %d\n", __func__, __LINE__, *pULong);
+        return TRUE;
+    }
+
+    if (AnscEqualString(ParamName, "WindowSize", TRUE)) {
+        *pULong = pcfg->mgt_frame_rate_limit_window_size;
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Window size: %d\n", __func__, __LINE__, *pULong);
+        return TRUE;
+    }
+
+    if (AnscEqualString(ParamName, "CooldownTime", TRUE)) {
+        *pULong = pcfg->mgt_frame_rate_limit_cooldown_time;
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Cooldown time: %d\n", __func__, __LINE__, *pULong);
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        MgtFrameRateLimit_SetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG                       iValue
+            );
+
+    description:
+
+        This function is called to set ULONG parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                ULONG                       iValue
+                The updated value;
+
+    return:     TRUE if succeeded.
+**********************************************************************/
+
+BOOL MgtFrameRateLimit_SetParamUlongValue(ANSC_HANDLE hInsContext, char *ParamName, ULONG iValue)
+{
+    wifi_global_config_t *global_wifi_config = get_dml_cache_global_wifi_config();
+
+    UNREFERENCED_PARAMETER(hInsContext);
+
+    if (global_wifi_config == NULL) {
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Failed to get global config\n", __func__, __LINE__);
+        return FALSE;
+    }
+
+    if (AnscEqualString(ParamName, "RateLimit", TRUE)) {
+        if ((ULONG)global_wifi_config->global_parameters.mgt_frame_rate_limit == iValue) {
+            return TRUE;
+        }
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Rate Limit: %d\n", __func__, __LINE__, iValue);
+        global_wifi_config->global_parameters.mgt_frame_rate_limit = iValue;
+
+        if (push_global_config_dml_cache_to_one_wifidb() != RETURN_OK) {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d: Failed to push RateLimit value to onewifi db\n", __func__, __LINE__);
+        }
+
+        return TRUE;
+    }
+
+    if (AnscEqualString(ParamName, "WindowSize", TRUE)) {
+        if ((ULONG)global_wifi_config->global_parameters.mgt_frame_rate_limit_window_size ==
+            iValue) {
+            return TRUE;
+        }
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Rate Limit Window Size: %d\n", __func__, __LINE__,
+            iValue);
+        global_wifi_config->global_parameters.mgt_frame_rate_limit_window_size = iValue;
+
+        if (push_global_config_dml_cache_to_one_wifidb() != RETURN_OK) {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d: Failed to push RateLimit WindowSize value to onewifi db\n", __func__,
+                __LINE__);
+        }
+
+        return TRUE;
+    }
+
+    if (AnscEqualString(ParamName, "CooldownTime", TRUE)) {
+        if ((ULONG)global_wifi_config->global_parameters.mgt_frame_rate_limit_cooldown_time ==
+            iValue) {
+            return TRUE;
+        }
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Rate Limit CooldownTime: %d\n", __func__, __LINE__,
+            iValue);
+        global_wifi_config->global_parameters.mgt_frame_rate_limit_cooldown_time = iValue;
+
+        if (push_global_config_dml_cache_to_one_wifidb() != RETURN_OK) {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d: Failed to push RateLimit CooldownTime value to onewifi db\n", __func__,
+                __LINE__);
+        }
+
+        return TRUE;
+    }
+
+    return FALSE;
+}

--- a/source/utils/wifi_validator.c
+++ b/source/utils/wifi_validator.c
@@ -1784,6 +1784,22 @@ int validate_wifi_global_config(const cJSON *global_cfg, wifi_global_param_t *gl
     validate_param_string(global_cfg, "TxRxRatetList", param);
     copy_string(global_info->txrx_rate_list, param->valuestring);
 
+    // MgtFrameRateLimitEnable
+    validate_param_bool(global_cfg, "MgtFrameRateLimitEnable", param);
+    global_info->mgt_frame_rate_limit_enable = (param->type & cJSON_True) ? true : false;
+
+    // MgtFrameRateLimit
+    validate_param_integer(global_cfg, "MgtFrameRateLimit", param);
+    global_info->mgt_frame_rate_limit = param->valuedouble;
+
+    // MgtFrameRateLimitWindowSize
+    validate_param_integer(global_cfg, "MgtFrameRateLimitWindowSize", param);
+    global_info->mgt_frame_rate_limit_window_size = param->valuedouble;
+
+    // MgtFrameRateLimitCooldownTime
+    validate_param_integer(global_cfg, "MgtFrameRateLimitCooldownTime", param);
+    global_info->mgt_frame_rate_limit_cooldown_time = param->valuedouble;
+
     wifi_util_dbg_print(WIFI_PASSPOINT,"wifi global Parameters validate successfully\n");
     return RETURN_OK;
 }

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -2247,6 +2247,22 @@ webconfig_error_t decode_wifi_global_config(const cJSON *global_cfg, wifi_global
     decode_param_integer(global_cfg, "FixedWmmParams", param);
     global_info->fixed_wmm_params = param->valuedouble;
 
+    // MgtFrameRateLimitEnable
+    decode_param_bool(global_cfg, "MgtFrameRateLimitEnable", param);
+    global_info->mgt_frame_rate_limit_enable = (param->type & cJSON_True) ? true : false;
+
+    // MgtFrameRateLimit
+    decode_param_integer(global_cfg, "MgtFrameRateLimit", param);
+    global_info->mgt_frame_rate_limit = param->valuedouble;
+
+    // MgtFrameRateLimitWindowSize
+    decode_param_integer(global_cfg, "MgtFrameRateLimitWindowSize", param);
+    global_info->mgt_frame_rate_limit_window_size = param->valuedouble;
+
+    // MgtFrameRateLimitCooldownTime
+    decode_param_integer(global_cfg, "MgtFrameRateLimitCooldownTime", param);
+    global_info->mgt_frame_rate_limit_cooldown_time = param->valuedouble;
+
     //WifiRegionCode
     decode_param_string(global_cfg, "WifiRegionCode", param);
     strcpy(global_info->wifi_region_code, param->valuestring);

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -745,6 +745,21 @@ webconfig_error_t encode_wifi_global_config(const wifi_global_param_t *global_in
     //TxRxRateList
     cJSON_AddStringToObject(global_obj, "TxRxRateList", global_info->txrx_rate_list);
 
+    // MgtFrameRateLimitEnable
+    cJSON_AddBoolToObject(global_obj, "MgtFrameRateLimitEnable",
+        global_info->mgt_frame_rate_limit_enable);
+
+    // MgtFrameRateLimit
+    cJSON_AddNumberToObject(global_obj, "MgtFrameRateLimit", global_info->mgt_frame_rate_limit);
+
+    // MgtFrameRateLimitWindowSize
+    cJSON_AddNumberToObject(global_obj, "MgtFrameRateLimitWindowSize",
+        global_info->mgt_frame_rate_limit_window_size);
+
+    // MgtFrameRateLimitCooldownTime
+    cJSON_AddNumberToObject(global_obj, "MgtFrameRateLimitCooldownTime",
+        global_info->mgt_frame_rate_limit_cooldown_time);
+
     return webconfig_error_none;
 }
 


### PR DESCRIPTION
Reason for change:
  Implement rate limit to block high number of auth requests

Test Procedure:
- Configure rate limit dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.Enable bool true dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.RateLimit uint 6 dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.WindowSize uint 1 dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.CooldownTime uint 30

- Send 10 auth auth requests per second
- Check client is blocked

cat /tmp/wifiHal | grep "rate limit"

Risks: Low
Priority: P1