### PR TITLE
RDKCOM-5333: RDKBDEV-3193 drop obsolete reference

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,39 +147,6 @@ AM_CONDITIONAL([FEATURE_OFF_CHANNEL_SCAN_5G], [test x$FEATURE_OFF_CHANNEL_SCAN_5
 AM_CONDITIONAL([USE_DML_SOURCES], [test x$DEVICE_EXTENDER != xtrue])
 AM_CONDITIONAL([USE_EXTENDER_MISC], [test x$DEVICE_EXTENDER = xtrue])
 
-# Specify ccsp cpu arch
-
-AC_ARG_WITH([ccsp-arch],
-[AC_HELP_STRING([--with-ccsp-arch={arm,atom,pc,mips}],
-                [specify the ccsp board CPU platform])],
-[case x"$withval" in
-   xarm)
-     CCSP_ARCH=arm
-     ;;
-   xatom)
-     CCSP_ARCH=atom
-     ;;
-   xpc)
-     CCSP_ARCH=pc
-     ;;
-   xmips)
-     CCSP_ARCH=mips
-     ;;
-   *)
-     AC_MSG_ERROR([$withval is an invalid option to --with-ccsp-arch])
-     ;;
- esac],
-[CCSP_ARCH=''])
-if test x"${CCSP_ARCH}" != x; then
-  AC_DEFINE_UNQUOTED(CCSP_ARCH, "$CCSP_ARCH",
-                     [The board CPU architecture])
-fi
-
-AM_CONDITIONAL(CCSP_ARCH_ARM, test "x$CCSP_ARCH" = xarm)
-AM_CONDITIONAL(CCSP_ARCH_ATOM, test "x$CCSP_ARCH" = xatom)
-AM_CONDITIONAL(CCSP_ARCH_PC, test "x$CCSP_ARCH" = xpc)
-AM_CONDITIONAL(CCSP_ARCH_MIPS, test "x$CCSP_ARCH" = xmips)
-
 AC_ARG_ENABLE([libwebconfig],
              [  --enable-libwebconfig    Turn on building libwebconfig, otherwise link against sysroot],
              [case "${enableval}" in
@@ -201,30 +168,6 @@ AC_ARG_ENABLE([rdk-wifi-libhostap],
 [CCSP_HOSTAP_AUTH=''])
 if test x"${CCSP_HOSTAP_AUTH}" != x; then
   AC_DEFINE_UNQUOTED(CCSP_HOSTAP_AUTH, "$CCSP_HOSTAP_AUTH",
-                     [The CCSP platform device])
-fi
-# Specify ccsp platform (device)
-
-AC_ARG_WITH([ccsp-platform],
-[AC_HELP_STRING([--with-ccsp-platform={intel_usg,pc,bcm}],
-                [specify the ccsp platform])],
-[case x"$withval" in
-   xintel_usg)
-     CCSP_PLATFORM=intel_usg
-     ;;
-   xpc)
-     CCSP_PLATFORM=pc
-     ;;
-   xbcm)
-     CCSP_PLATFORM=bcm
-     ;;
-   *)
-     AC_MSG_ERROR([$withval is an invalid option to --with-ccsp-platform])
-     ;;
- esac],
-[CCSP_PLATFORM=''])
-if test x"${CCSP_PLATFORM}" != x; then
-  AC_DEFINE_UNQUOTED(CCSP_PLATFORM, "$CCSP_PLATFORM",
                      [The CCSP platform device])
 fi
 


### PR DESCRIPTION
Reason for change:
drop obsolete --with-ccsp-arch= / --with-ccsp-platform= configure options Test Procedure: Build and Sanity test.
Risks: None.
Signed-off-by: Andre McCurdy [amccurdy@libertyglobal.com](mailto:amccurdy@libertyglobal.com)
(cherry picked from commit 35f2ebd965bb4b1e0649e8241293f7d0b3bd9690)