### PR TITLE
RDKCOM-5332: RDKBDEV-3192 drop duplicate declarations in WiFi HAL APIs

### DIFF
--- a/source/core/wifi_easy_connect.c
+++ b/source/core/wifi_easy_connect.c
@@ -32,7 +32,7 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include "collection.h"
-#include "wifi_hal.h"
+#include <wifi_hal.h>
 #include "wifi_easy_connect.h"
 #include "wifi_data_plane_types.h"
 #include <sys/socket.h>
@@ -45,8 +45,6 @@
 
 static const char *wifi_health_log = "/rdklogs/logs/wifihealth.txt";
 
-extern bool is_device_associated(int ap_index, char *mac);
-extern bool wifi_api_is_device_associated(int ap_index, char *mac);
 static wifi_easy_connect_t g_easy_connect = {0};
 
 PCOSA_DML_WIFI_DPP_STA_CFG find_dpp_sta_dml_wifi_ap(unsigned int ap_index, mac_address_t sta_mac);

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -76,7 +76,7 @@
 #include "ccsp_psm_helper.h"
 #include "cosa_dbus_api.h"
 #include "collection.h"
-#include "wifi_hal.h"
+#include <wifi_hal.h>
 #include "../../../stubs/wifi_stubs.h"
 #include "wifi_monitor.h"
 
@@ -114,7 +114,6 @@ extern unsigned int startTime[MAX_NUM_RADIOS];
 uint8_t g_radio_instance_num = 0;
 extern void* g_pDslhDmlAgent;
 extern int gChannelSwitchingCount;
-extern bool wifi_api_is_device_associated(int ap_index, char *mac);
 
 /***********************************************************************
  IMPORTANT NOTE:


### PR DESCRIPTION
Reason for change:
drop duplicate declarations of wifi_api_is_device_associated() WiFi HAL APIs Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy [amccurdy@libertyglobal.com](mailto:amccurdy@libertyglobal.com)
(cherry picked from commit 18d22cd9e46a1dd5db29180ebddd2079f739ea8e)