### PR TITLE
RDKCOM-5333: RDKBDEV-3193 drop obsolete reference

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,30 +203,6 @@ if test x"${CCSP_HOSTAP_AUTH}" != x; then
   AC_DEFINE_UNQUOTED(CCSP_HOSTAP_AUTH, "$CCSP_HOSTAP_AUTH",
                      [The CCSP platform device])
 fi
-# Specify ccsp platform (device)
-
-AC_ARG_WITH([ccsp-platform],
-[AC_HELP_STRING([--with-ccsp-platform={intel_usg,pc,bcm}],
-                [specify the ccsp platform])],
-[case x"$withval" in
-   xintel_usg)
-     CCSP_PLATFORM=intel_usg
-     ;;
-   xpc)
-     CCSP_PLATFORM=pc
-     ;;
-   xbcm)
-     CCSP_PLATFORM=bcm
-     ;;
-   *)
-     AC_MSG_ERROR([$withval is an invalid option to --with-ccsp-platform])
-     ;;
- esac],
-[CCSP_PLATFORM=''])
-if test x"${CCSP_PLATFORM}" != x; then
-  AC_DEFINE_UNQUOTED(CCSP_PLATFORM, "$CCSP_PLATFORM",
-                     [The CCSP platform device])
-fi
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Reason for change:
drop obsolete --with-ccsp-arch= / --with-ccsp-platform= configure options Test Procedure: Build and Sanity test.
Risks: None.
Signed-off-by: qlei rlei@libertyglobal.com
(cherry picked from commit 35f2ebd965bb4b1e0649e8241293f7d0b3bd9690)