### PR TITLE
RDKB-58210 : Incorrect wifi survey scan interval during OCS 

### DIFF
--- a/source/apps/sm/wifi_sm.c
+++ b/source/apps/sm/wifi_sm.c
@@ -666,6 +666,32 @@ int handle_sm_webconfig_event(wifi_app_t *app, wifi_event_t *event)
         new_stats_cfg = hash_map_get_next(new_ctrl_stats_cfg_map, new_stats_cfg);
     }
 
+    // update neigbour survey_interval to survey's interval if value is 0
+    new_stats_cfg = hash_map_get_first(new_ctrl_stats_cfg_map);
+    while (new_stats_cfg != NULL) {
+        if (new_stats_cfg->stats_type == stats_type_neighbor &&
+            new_stats_cfg->survey_interval == 0) {
+            // search survey configuration.
+            tmp_stats_cfg = hash_map_get_first(new_ctrl_stats_cfg_map);
+            while (tmp_stats_cfg != NULL) {
+                if (tmp_stats_cfg->stats_type == stats_type_survey &&
+                    tmp_stats_cfg->radio_type == new_stats_cfg->radio_type &&
+                    tmp_stats_cfg->survey_type == new_stats_cfg->survey_type &&
+                    tmp_stats_cfg->survey_interval != 0) {
+                    new_stats_cfg->survey_interval = tmp_stats_cfg->survey_interval;
+                    wifi_util_dbg_print(WIFI_SM,
+                        "%s %d update survey_interval for neighbor "
+                        "stats_type_neighbor(radio_type %d, survey_type %d) to %u\n",
+                        __func__, __LINE__, new_stats_cfg->radio_type, new_stats_cfg->survey_type,
+                        new_stats_cfg->survey_interval);
+                    break;
+                }
+                tmp_stats_cfg = hash_map_get_next(new_ctrl_stats_cfg_map, tmp_stats_cfg);
+            }
+        }
+        new_stats_cfg = hash_map_get_next(new_ctrl_stats_cfg_map, new_stats_cfg);
+    }
+
     // search for the deleted elements if any in new_ctrl_stats_cfg
     if (cur_app_stats_cfg_map != NULL) {
         cur_stats_cfg = hash_map_get_first(cur_app_stats_cfg_map);
@@ -728,7 +754,7 @@ int handle_sm_webconfig_event(wifi_app_t *app, wifi_event_t *event)
                     if (!off_scan_rfc && cur_stats_cfg->survey_type == survey_type_off_channel &&
                         (cur_stats_cfg->radio_type == WIFI_FREQUENCY_5_BAND ||
                             cur_stats_cfg->radio_type == WIFI_FREQUENCY_5L_BAND ||
-                            cur_stats_cfg->radio_type == WIFI_FREQUENCY_5H_BAND)) {
+                            cur_stats_cfg->radio_type == WIFI_FREQUENCY_5H_BAND)) { 
                         if (is_scan_scheduled(app, cur_stats_cfg)) {
                             push_sm_config_event_to_monitor_queue(app, mon_stats_request_state_stop,
                                 cur_stats_cfg);

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -3809,12 +3809,11 @@ int coordinator_update_task(wifi_mon_collector_element_t *collector_elem, wifi_m
         return RETURN_ERR;
     }
 
-    if (coordinator_calculate_clctr_interval(collector_elem, dup_provider_elem, &new_collector_interval) != RETURN_OK) {
+    if (coordinator_calculate_clctr_interval(collector_elem, dup_provider_elem,
+            &new_collector_interval) != RETURN_OK) {
         coordinator_free_provider_elem(&dup_provider_elem);
         return RETURN_ERR;
     }
-
-    collector_task_update(collector_elem, &new_collector_interval);
 
     wifi_mon_provider_element_t *provider_elem = (wifi_mon_provider_element_t *)hash_map_get(collector_elem->provider_list, dup_provider_elem->key);
     if (provider_elem == NULL) {
@@ -3845,6 +3844,7 @@ int coordinator_update_task(wifi_mon_collector_element_t *collector_elem, wifi_m
         coordinator_free_provider_elem(&dup_provider_elem);
     }
 
+    collector_task_update(collector_elem, &new_collector_interval);
     return RETURN_OK;
 }
 

--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -1072,6 +1072,7 @@ int update_radio_channels_collector_args(void *ce)
     int channels[64] = {0};
     unsigned int is_used[64] = {0};
     int i, j;
+    int new_dwell_time = 0;
     wifi_mon_provider_element_t *provider_elem = NULL;
     wifi_mon_collector_element_t *collector_elem = (wifi_mon_collector_element_t *) ce;
 
@@ -1079,6 +1080,16 @@ int update_radio_channels_collector_args(void *ce)
         wifi_util_error_print(WIFI_MON,"%s:%d NULL arguments \n", __func__, __LINE__);
         return RETURN_ERR;
     }
+
+    // Traverse through the providers
+    provider_elem = hash_map_get_first(collector_elem->provider_list);
+    while (provider_elem != NULL) {
+        if (provider_elem->mon_stats_config->args.dwell_time > new_dwell_time) {
+            new_dwell_time = provider_elem->mon_stats_config->args.dwell_time;
+        }
+        provider_elem = hash_map_get_next(collector_elem->provider_list, provider_elem);
+    }
+    collector_elem->args->dwell_time = new_dwell_time;
 
     if (collector_elem->args->scan_mode == WIFI_RADIO_SCAN_MODE_OFFCHAN) {
         return RETURN_OK;


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: Collector element structure is not being updated as it was already being created for other stats type.

Test Procedure:
Enable the mesh rfc
dmcli eRT getv Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.Mesh.Enable dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.Mesh.Enable bool true

check the wifi stats config table
ovsh s Wifi_Stats_Config -w radio_type==5G
ovsh s Wifi_Stats_Config -w radio_type==2.4G

Enable the SM App.

dmcli eRT getv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.SM_APP.Disable dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.SM_APP.Disable bool false

Enable the OCS RFC for SM.
dmcli eRT getv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.OffChannelScan.Enable dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.OffChannelScan.Enable bool true

And then check the logs in wifiMon and wifiSM in /tmp directory.

If the logs doesn't reflect the value as per the stats config table , then issue is reproduced.

Risks: Medium
Priority: P1
Signed-off-by:sanjayvenkatesan1902@gmail.com