### PR TITLE
RDKB-60183: fixed queue size and memory issues

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -382,7 +382,6 @@ typedef struct {
         instant_msmt_t      imsmt;
         active_msmt_t       amsmt;
         associated_devs_t   devs;
-        wifi_csi_dev_t      csi;
         csi_mon_t           csi_mon;
         wifi_mon_stats_config_t mon_stats_config;
         frame_data_t msg;

--- a/source/apps/levl/wifi_levl.c
+++ b/source/apps/levl/wifi_levl.c
@@ -1323,7 +1323,7 @@ bus_error_t levl_get_handler(char *event_name, raw_data_t *p_data, bus_user_data
     }
 
     wifi_util_dbg_print(WIFI_CTRL, "%s(): %s\n", __FUNCTION__, name);
-    sscanf(name, "Device.WiFi.X_RDK_CSI_LEVL.%200s", parameter);
+    sscanf(name, "Device.WiFi.X_RDK_CSI_LEVL.%199s", parameter);
 
     if (strcmp(parameter, "clientMac") == 0) {
         char mac_string[18];
@@ -1436,7 +1436,7 @@ bus_error_t levl_set_handler(char *event_name, raw_data_t *p_data, bus_user_data
 
     wifi_util_dbg_print(WIFI_CTRL, "%s(): %s\n", __FUNCTION__, name);
 
-    sscanf(name, "Device.WiFi.X_RDK_CSI_LEVL.%200s", parameter);
+    sscanf(name, "Device.WiFi.X_RDK_CSI_LEVL.%199s", parameter);
 
     if (strcmp(parameter, "clientMac") == 0) {
         if (p_data->data_type != bus_data_type_string) {

--- a/source/apps/motion/wifi_motion.c
+++ b/source/apps/motion/wifi_motion.c
@@ -770,7 +770,7 @@ bus_error_t csi_set_handler(char *event_name, raw_data_t *p_data, bus_user_data_
         return bus_error_general;
     }
 
-    ret = sscanf(name, "Device.WiFi.X_RDK_CSI.%4d.%200s", &idx, parameter);
+    ret = sscanf(name, "Device.WiFi.X_RDK_CSI.%4d.%199s", &idx, parameter);
     if (ret==2) {
         qcount = queue_count(local_csi_queue);
         for (itr=0; itr<qcount; itr++) {
@@ -965,7 +965,7 @@ bus_error_t csi_get_handler(char *event_name, raw_data_t *p_data, bus_user_data_
         return status;
     }
 
-    ret = sscanf(name, "Device.WiFi.X_RDK_CSI.%4d.%200s", &idx, parameter);
+    ret = sscanf(name, "Device.WiFi.X_RDK_CSI.%4d.%199s", &idx, parameter);
     if (ret==2) {
         qcount = queue_count(csi_data_queue);
         for (itr=0; itr<qcount; itr++) {

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -1006,16 +1006,14 @@ static void get_device_flag(char flag[], int size, char *list_name)
             }
         }
 
-        for(i = 0; i < MAX_VAP && i < size; i ++)
-        {
-            if(buf_int[i] < size && buf_int[i] >= 0)
-            {
-                flag[(buf_int[i] - 1)] = 1;
-            }
-            else
-            {
-                wifi_util_error_print(WIFI_APPS, "%s():%d for vap(%u) failed.\n",
-                        __func__, __LINE__, buf_int[i]);
+        for (i = 0; i < MAX_VAP && buf_int[i] > 0; i++) {
+            if (buf_int[i] - 1 < size) {
+                flag[buf_int[i] - 1] = 1;
+            } else {
+                wifi_util_error_print(WIFI_APPS,
+                    "%s:%d failed to set flag, vap index %d is more than size %d\n", __func__,
+                    __LINE__, buf_int[i], size);
+                return;
             }
         }
     } else {

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -116,7 +116,7 @@ extern "C" {
 
 #define BUS_DML_CONFIG_FILE "bus_dml_config.json"
 
-#define CTRL_QUEUE_SIZE_MAX 500
+#define CTRL_QUEUE_SIZE_MAX (700 * getNumberRadios())
 
 typedef enum {
     ctrl_webconfig_state_none = 0,

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3585,6 +3585,7 @@ void handle_webconfig_event(wifi_ctrl_t *ctrl, const char *raw, unsigned int len
     webconfig_subdoc_type_t subdoc_type;
     wifi_vap_name_t vap_names[MAX_NUM_RADIOS * MAX_NUM_VAP_PER_RADIO];
     unsigned int num_ssid = 0;
+    cJSON *json = NULL;
 
     switch (subtype) {
     case wifi_event_webconfig_set_data:
@@ -3600,7 +3601,9 @@ void handle_webconfig_event(wifi_ctrl_t *ctrl, const char *raw, unsigned int len
             return;
         }
 
-        subdoc_type = find_subdoc_type(config, cJSON_Parse(raw));
+        json = cJSON_Parse(raw);
+        subdoc_type = find_subdoc_type(config, json);
+        cJSON_Delete(json);
         switch (subdoc_type) {
         case webconfig_subdoc_type_private:
             num_ssid += get_list_of_private_ssid(&mgr->hal_cap.wifi_prop, MAX_NUM_RADIOS,

--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -379,6 +379,9 @@ void existing_assoc_list_update(webconfig_subdoc_decoded_data_t *params)
                     }
                     free(temp_assoc_dev_data);
                 }
+                hash_map_destroy(associated_devices_map);
+                params->radios[r_index].vaps.rdk_vap_array[v_index].associated_devices_diff_map =
+                    NULL;
             }
         }
     }

--- a/source/stats/wifi_monitor.h
+++ b/source/stats/wifi_monitor.h
@@ -30,7 +30,7 @@
 
 #define  ANSC_STATUS_SUCCESS                        0
 
-#define MONITOR_QUEUE_SIZE_MAX 500
+#define MONITOR_QUEUE_SIZE_MAX (700 * getNumberRadios())
 
 typedef struct {
     unsigned int        rapid_reconnect_threshold;

--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -531,6 +531,7 @@ int execute_radio_channel_stats_api(wifi_mon_collector_element_t *c_elem, wifi_m
         push_monitor_response_event_to_ctrl_queue(collect_stats, sizeof(wifi_provider_response_t), wifi_event_type_monitor, wifi_event_type_collect_stats, NULL);
         free(collect_stats);
         free(chan_stats);
+        free(chan_data);
         return RETURN_OK;
     }
 

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -840,7 +840,9 @@ webconfig_error_t encode_anqp_object(const char *vap_name, cJSON *inter,const un
     if(cJSON_HasObjectItem(p_root, "ANQP") == true) {
         wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d  anqp element already exsistingin json\n", __func__, __LINE__);
         anqpElement = cJSON_GetObjectItem(p_root, (const char * const)"ANQP");
+        cJSON_DetachItemViaPointer(p_root, anqpElement);
         cJSON_AddItemToObject(inter, "ANQP", anqpElement);
+        cJSON_Delete(p_root);
     } else {
         wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d  Add anqp element to json\n", __func__, __LINE__);
         cJSON_AddItemToObject(inter, "ANQP", p_root);
@@ -865,7 +867,9 @@ webconfig_error_t encode_passpoint_object(const char *vap_name, cJSON *inter,con
       if(cJSON_HasObjectItem(p_root, "Passpoint") == true) {
         wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d  Passpoint element already exsisting in json\n", __func__, __LINE__);
         pass = cJSON_GetObjectItem(p_root,  (const char * const) "Passpoint");
+        cJSON_DetachItemViaPointer(p_root, pass);
         cJSON_AddItemToObject(inter, "Passpoint", pass);
+        cJSON_Delete(p_root);
     } else {
         wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d  Add Passpoint element to json\n", __func__, __LINE__);
         cJSON_AddItemToObject(inter, "Passpoint", p_root);


### PR DESCRIPTION
Reason for change:
  - increased control and monitor queue size to avoid events drops
  - stack-buffer-overflow in levl_get_handler sscanf
  - stack-buffer-overflow in get_device_config_list for Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.TxRxRateList is 1,2,17
  - memory leak in channel stats
  - memory leak in encode_anqp_object
  - memory leak in encode_passpoint_object
  - memory leak in decoded associated devices map
  - memory leak in handle_webconfig_event
  - removed unused wifi_csi_dev_t csi from wifi_monitor_data_t to reduce event size Test Procedure:
Risks: Low
Priority: P1