### PR TITLE
DTMESH-520 OVSM crash during OneWifi initialization

### DIFF
--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -587,18 +587,13 @@ bus_error_t webconfig_init_data_get_subdoc(char *event_name, raw_data_t *p_data,
         memset(&data, 0, sizeof(webconfig_subdoc_data_t));
         memcpy((unsigned char *)&data.u.decoded.radios, (unsigned char *)&mgr->radio_config,
             num_of_radios * sizeof(rdk_wifi_radio_t));
+	memcpy((unsigned char *)&data.u.decoded.config, (unsigned char *)&mgr->global_config,
+			sizeof(wifi_global_config_t));
         memcpy((unsigned char *)&data.u.decoded.hal_cap, (unsigned char *)&mgr->hal_cap,
             sizeof(wifi_hal_capability_t));
         data.u.decoded.num_radios = num_of_radios;
         // tell webconfig to encode
-	if (ctrl->dev_type != dev_subtype_pod) {
-                memcpy((unsigned char *)&data.u.decoded.config, (unsigned char *)&mgr->global_config,
-                                sizeof(wifi_global_config_t));
-		webconfig_encode(&ctrl->webconfig, &data, webconfig_subdoc_type_dml);
-	}
-	else {
-		webconfig_encode(&ctrl->webconfig, &data, webconfig_subdoc_type_mesh_sta);
-	}
+	webconfig_encode(&ctrl->webconfig, &data, webconfig_subdoc_type_dml);
 
         uint32_t str_size = (strlen(data.u.encoded.raw) + 1);
         p_data->data_type = bus_data_type_string;
@@ -620,13 +615,17 @@ bus_error_t webconfig_init_data_get_subdoc(char *event_name, raw_data_t *p_data,
         memset(&data, 0, sizeof(webconfig_subdoc_data_t));
         memcpy((unsigned char *)&data.u.decoded.radios, (unsigned char *)&mgr->radio_config,
             num_of_radios * sizeof(rdk_wifi_radio_t));
-        memcpy((unsigned char *)&data.u.decoded.config, (unsigned char *)&mgr->global_config,
-            sizeof(wifi_global_config_t));
         memcpy((unsigned char *)&data.u.decoded.hal_cap, (unsigned char *)&mgr->hal_cap,
             sizeof(wifi_hal_capability_t));
         data.u.decoded.num_radios = num_of_radios;
         // tell webconfig to encode
-        webconfig_encode(&ctrl->webconfig, &data, webconfig_subdoc_type_dml);
+	if (ctrl->dev_type != dev_subtype_pod) {
+		memcpy((unsigned char *)&data.u.decoded.config, (unsigned char *)&mgr->global_config,
+				sizeof(wifi_global_config_t));
+		webconfig_encode(&ctrl->webconfig, &data, webconfig_subdoc_type_dml);
+	} else {
+		webconfig_encode(&ctrl->webconfig, &data, webconfig_subdoc_type_mesh_sta);
+	}
 
         uint32_t str_size = (strlen(data.u.encoded.raw) + 1);
         p_data->data_type = bus_data_type_string;


### PR DESCRIPTION
Reason for change: Crash seen with OVSM due to webconfig exchange during init with dml subdoc for pod platforms

Test Procedure: No crash should be seen with ovsm