### PR TITLE
DTMESH-515 changes to allow station deletion

### DIFF
--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -318,6 +318,7 @@ wifi_ctrl_t *get_wifictrl_obj();
 void deinit_ctrl_monitor(wifi_ctrl_t *ctrl);
 bool is_db_consolidated();
 bool is_db_backup_required();
+bool is_devtype_pod();
 
 UINT getRadioIndexFromAp(UINT apIndex);
 UINT getPrivateApFromRadioIndex(UINT radioIndex);

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -821,8 +821,10 @@ int webconfig_hal_vap_apply_by_name(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_
         // Ignore exists flag change because STA interfaces always enabled in HAL. This allows to
         // avoid redundant reconfiguration with STA disconnection.
         // For pods, STA is just like any other AP interface, deletion is allowed.
-        if (ctrl->network_mode == rdk_dev_mode_type_ext && isVapSTAMesh(tgt_vap_index)) {
-            mgr_rdk_vap_info->exists = rdk_vap_info->exists;
+        if (ctrl->dev_type != dev_subtype_pod) {
+            if (ctrl->network_mode == rdk_dev_mode_type_ext && isVapSTAMesh(tgt_vap_index)) {
+                mgr_rdk_vap_info->exists = rdk_vap_info->exists;
+            }
         }
 
         wifi_util_dbg_print(WIFI_CTRL,"%s:%d: Comparing VAP [%s] with [%s]. \n",__func__, __LINE__,mgr_vap_info->vap_name,vap_info->vap_name);

--- a/source/core/wifi_mgr.c
+++ b/source/core/wifi_mgr.c
@@ -91,6 +91,11 @@ bool is_db_backup_required()
     return (g_wifi_mgr.ctrl.dev_type != dev_subtype_pod);
 }
 
+bool is_devtype_pod()
+{
+    return (g_wifi_mgr.ctrl.dev_type == dev_subtype_pod);
+}
+
 int init_wifi_hal()
 {
     int ret = RETURN_OK;


### PR DESCRIPTION
Reason for change:-
- changes to stop scanning if station is not present
- AP interface creation fails after successful backhaul connection in
Qualcomm device if a station interface is present not associated state.