### PR TITLE
TCXB8-3614 Observing empty value while fetching the mac entry using dmcli command

### DIFF
--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -396,6 +396,7 @@ wifi_platform_property_t *get_wifi_hal_cap_prop(void);
 wifi_vap_security_t * Get_wifi_object_bss_security_parameter(uint8_t vapIndex);
 wifi_vap_security_t * Get_wifi_object_sta_security_parameter(uint8_t vapIndex);
 char *get_assoc_devices_blob();
+char *get_acl_devices_blob();
 void get_subdoc_name_from_vap_index(uint8_t vap_index, int* subdoc);
 int dfs_nop_start_timer(void *args);
 int webconfig_send_full_associate_status(wifi_ctrl_t *ctrl);

--- a/source/dml/dml_webconfig/dml_onewifi_api.h
+++ b/source/dml/dml_webconfig/dml_onewifi_api.h
@@ -124,6 +124,7 @@ UINT get_total_num_vap_dml();
 void get_associated_devices_data(unsigned int radio_index);
 unsigned long get_associated_devices_count(wifi_vap_info_t *vap_info);
 hash_map_t* get_associated_devices_hash_map(unsigned int vap_index);
+int get_acl_data_from_ctrl(unsigned int radio_index);
 queue_t** get_acl_new_entry_queue(wifi_vap_info_t *vap_info);
 hash_map_t** get_acl_hash_map(wifi_vap_info_t *vap_info);
 wifi_global_config_t *get_dml_cache_global_wifi_config();

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -17666,6 +17666,13 @@ MacFiltTab_Synchronize
     )
 {
     wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Inside Synchronize \n",__func__, __LINE__);
+    wifi_vap_info_t *vap_info = (wifi_vap_info_t *)hInsContext;
+    if (vap_info == NULL ) {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d NULL Pointer\n", __func__, __LINE__);
+        return -1;
+    }
+
+    get_acl_data_from_ctrl(vap_info->radio_index);
 
     return ANSC_STATUS_SUCCESS;
 }


### PR DESCRIPTION
TCXB8-3614 Observing empty value while fetching the mac entry using dmcli command

Reason for change: dml cache did not sync up with wifi management object at wifictrl
Test Procedure:
1. Push the hotspot configuration blob.
2. Disable the RadiusGreyList.
3. Enable the prefer private.
4. Connect the client with private ssid.
5. Check the hotspot mac filter entry.

Priority: P1
Risks: No
Signed-off-by: Dao Vu Tuan <DaoVu_Tuan2@comcast.com>