### PR TITLE
RDKB-60336: To sync build scripts used for RPI and BPI devices

### DIFF
--- a/build/linux/rpi/setup.sh
+++ b/build/linux/rpi/setup.sh
@@ -39,6 +39,7 @@ patch_filenames="hostap-patches/0001-OneWifi-related-hostap-patch-for-2.10-based
 	hostap-patches/0003-mbssid_support_2.10.patch \
         hostap-patches/wpa3_compatibility_hostap_2_10.patch \
         hostap-patches/0005-RDKB-58414-Dynamically-update-NAS_2_10.patch \
+        hostap-patches/0006-RDKB-59523-connectivity-via-supplicant.patch \
 	hostap-patches/mdu_radius_psk_auth_2_10.patch"
 echo "Applying patches ..."
 git am $patch_filenames

--- a/build/openwrt/setup.sh
+++ b/build/openwrt/setup.sh
@@ -38,7 +38,8 @@ patch_filenames="hostap-patches/0001-OneWifi-related-hostap-patch-for-2.10-based
 	hostap-patches/0003-mbssid_support_2.10.patch \
         hostap-patches/wpa3_compatibility_hostap_2_10.patch \
         hostap-patches/0005-RDKB-58414-Dynamically-update-NAS_2_10.patch \
-        hostap-patches/0006-RDKB-59523-connectivity-via-supplicant.patch"
+        hostap-patches/0006-RDKB-59523-connectivity-via-supplicant.patch \
+        hostap-patches/mdu_radius_psk_auth_2_10.patch"
 echo "Applying patches ..."
 git am $patch_filenames
 


### PR DESCRIPTION
RDKB-60336: To sync build scripts used for RPI and BPI devices

Reason for change: To sync build scripts used for RPI and BPI devices
Test Procedure: Ensure onewifi build is successful for both RPI and BPI OpenWRT and Linux builds.
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>