### PR TITLE
TCXB8-3614 Observing empty value while fetching the mac entry using dmcli command

### DIFF
--- a/source/core/services/vap_svc_public.c
+++ b/source/core/services/vap_svc_public.c
@@ -134,6 +134,8 @@ void process_prefer_private_mac_filter(mac_address_t prefer_private_mac)
             wifi_util_dbg_print(WIFI_CTRL,"add %s mac to %s\n",new_mac_str,rdk_vap_info->vap_name);
         }
     }
+
+    get_wifictrl_obj()->webconfig_state |= ctrl_webconfig_state_macfilter_cfg_rsp_pending;
 }
 
 int update_managementFramePower(void *arg) {

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -193,6 +193,9 @@ int remove_xfinity_acl_entries(bool remove_all_greylist_entry,bool prefer_privat
             }
        }
     }
+
+    get_wifictrl_obj()->webconfig_state |= ctrl_webconfig_state_macfilter_cfg_rsp_pending;
+
     return RETURN_OK;
 }
 void process_unknown_frame_event(frame_data_t *msg, uint32_t msg_length)
@@ -1538,6 +1541,9 @@ void process_greylist_mac_filter(void *data)
             greylist_client_added = true;
         }
     }
+
+    get_wifictrl_obj()->webconfig_state |= ctrl_webconfig_state_macfilter_cfg_rsp_pending;
+
     //Add time and Mac address to wifihealth.txt
     if (greylist_client_added) {
         time(&now);

--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -208,6 +208,20 @@ void mac_filter_dml_vap_cache_update(int radio_index, int vap_array_index)
     }
 }
 
+void update_dml_macfilter_list(webconfig_subdoc_data_t *data)
+{
+    unsigned int radio_idx = 0, vap_idx = 0;
+
+    for (radio_idx = 0; radio_idx < get_num_radio_dml(); radio_idx++) {
+        for (vap_idx = 0; vap_idx < MAX_NUM_VAP_PER_RADIO; vap_idx++) {
+            hash_map_t **acl_dev_map = get_dml_acl_hash_map(radio_idx, vap_idx);
+
+            mac_filter_dml_vap_cache_update(radio_idx, vap_idx);
+            *acl_dev_map = data->u.decoded.radios[radio_idx].vaps.rdk_vap_array[vap_idx].acl_map;
+        }
+    }
+}
+
 void update_dml_subdoc_vap_data(webconfig_subdoc_data_t *data)
 {
     webconfig_subdoc_decoded_data_t *params;
@@ -435,6 +449,7 @@ void dml_cache_update(webconfig_subdoc_data_t *data)
         case webconfig_subdoc_type_mac_filter:
             wifi_util_info_print(WIFI_DMCLI,"%s:%d subdoc parse and update macfilter entries:%d\n", __func__,
                 __LINE__, data->type);
+            update_dml_macfilter_list(data);
 #ifndef ONEWIFI_DML_SUPPORT
             sync_dml_macfilter_table_entries();
 #endif


### PR DESCRIPTION
TCXB8-3614 Observing empty value while fetching the mac entry using dmcli command

Reason for change: dml cache did not sync up with wifi management object at wifictrl

Test Procedure:
Push the hotspot configuration blob.
Disable the RadiusGreyList.
Enable the prefer private.
Connect the client with private ssid.
Check the hotspot mac filter entry.

Priority: P1
Risks: No
Signed-off-by: Dao Vu Tuan DaoVu_Tuan2@comcast.com