### PR TITLE
RDKB-59710 Resolve Sync issue for WPA3-PCM

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -42,7 +42,7 @@ extern "C" {
 #define WIFI_WAN_FAILOVER_TEST              "Device.WiFi.WanFailoverTest"
 #define WIFI_LMLITE_NOTIFY                  "Device.Hosts.X_RDKCENTRAL-COM_LMHost_Sync_From_WiFi"
 #define WIFI_HOTSPOT_NOTIFY                 "Device.X_COMCAST-COM_GRE.Hotspot.ClientChange"
-#define WIFI_NOTIFY_ASSOCIATED_ENTRIES      "Device.NotifyComponent.SetNotifi_ParamName"
+#define WIFI_NOTIFY_SYNC_COMPONENT      "Device.NotifyComponent.SetNotifi_ParamName"
 #define WIFI_NOTIFY_FORCE_DISASSOCIATION    "Device.WiFi.ConnectionControl.ClientForceDisassociation"
 #define WIFI_NOTIFY_DENY_ASSOCIATION        "Device.WiFi.ConnectionControl.ClientDenyAssociation"
 #define MESH_STATUS                         "Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.Mesh.Enable"

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -52,6 +52,51 @@ typedef enum {
     hotspot_vap_param_update
 } wifi_hotspot_action_t;
 
+#define SEC_MODE_STR_MAX 32
+
+int convert_sec_mode_enable_int_str(int sec_mode_enable, char *secModeStr) {
+
+    switch(sec_mode_enable) {
+        case wifi_security_mode_wpa_personal:
+            strncpy(secModeStr, "WPA-Personal", SEC_MODE_STR_MAX);
+            break;
+
+        case wifi_security_mode_wpa2_personal:
+            strncpy(secModeStr, "WPA2-Personal", SEC_MODE_STR_MAX);
+            break;
+
+        case wifi_security_mode_wpa3_personal:
+            strncpy(secModeStr, "WPA3-Personal", SEC_MODE_STR_MAX);
+            break;
+
+        case wifi_security_mode_wpa_enterprise:
+            strncpy(secModeStr, "WPA-Enterprise", SEC_MODE_STR_MAX);
+            break;
+
+        case wifi_security_mode_wpa2_enterprise:
+            strncpy(secModeStr, "WPA2-Enterprise", SEC_MODE_STR_MAX);
+            break;
+
+        case wifi_security_mode_wpa3_enterprise:
+            strncpy(secModeStr, "WPA3-Enterprise", SEC_MODE_STR_MAX);
+            break;
+
+        case wifi_security_mode_wpa3_transition:
+            strncpy(secModeStr, "WPA3-Personal-Transition", SEC_MODE_STR_MAX);
+            break;
+
+        case wifi_security_mode_wpa3_compatibility:
+            strncpy(secModeStr, "WPA3-Personal-Compatibility", SEC_MODE_STR_MAX);
+            break;
+
+        default:
+            wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Invalid security mode %d\n", __func__, __LINE__, sec_mode_enable);
+            return RETURN_ERR;
+    }
+
+    return RETURN_OK;
+}
+
 void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_nop_start_reboot, unsigned int dfs_timer_secs);
 
 void process_scan_results_event(scan_results_t *results, unsigned int len)
@@ -3090,7 +3135,7 @@ void process_rsn_override_rfc(bool type)
     UINT apIndex = 0, ret;
     rdk_wifi_vap_info_t *rdk_vap_info;
     wifi_vap_info_t *vapInfo = NULL;
-    char update_status[128];
+    char update_status[128], old_sec_mode[32], new_sec_mode[32];
 
     rfc_param->wpa3_compatibility_enable = type;
     get_wifidb_obj()->desc.update_rfc_config_fn(0, rfc_param);
@@ -3108,6 +3153,13 @@ void process_rsn_override_rfc(bool type)
         if (radio_params->band == WIFI_FREQUENCY_6_BAND) {
             wifi_util_info_print(WIFI_CTRL,"%s: %d 6GHz radio supports only WPA3 personal mode. WPA3-RFC: %d\n",__FUNCTION__,__LINE__,type);
             continue;
+        }
+
+        memset(old_sec_mode, 0, sizeof(old_sec_mode));
+        memset(new_sec_mode, 0, sizeof(new_sec_mode));
+        ret = convert_sec_mode_enable_int_str(vapInfo->u.bss_info.security.mode, old_sec_mode);
+        if(ret != RETURN_OK) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d: Error converting security mode to string old_mode:%d new_mode\n", __func__, __LINE__);
         }
 
         if(type) {
@@ -3134,6 +3186,11 @@ void process_rsn_override_rfc(bool type)
                 vapInfo->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
             }
         }
+        ret = convert_sec_mode_enable_int_str(vapInfo->u.bss_info.security.mode, new_sec_mode);
+        if(ret != RETURN_OK) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d: Error converting security mode to string old_mode:%d new_mode\n", __func__, __LINE__);
+        }
+
         memset(&tgt_vap_map, 0, sizeof(wifi_vap_info_map_t));
         tgt_vap_map.num_vaps = 1;
         memcpy(&tgt_vap_map.vap_array[0], vapInfo, sizeof(wifi_vap_info_t));
@@ -3152,6 +3209,11 @@ void process_rsn_override_rfc(bool type)
             wifi_util_error_print(WIFI_CTRL,"%s:%d: Private vaps service update_fn failed \n",__func__, __LINE__);
         } else {
             wifi_util_dbg_print(WIFI_CTRL,"%s:%d: Updating security mode for apIndex %d secmode %d \n",__func__, __LINE__,apIndex,vapInfo->u.bss_info.security.mode);
+            wifi_util_info_print(WIFI_CTRL,"%s:%d: old_sec_mode %s new_sec_mode %s\n",
+                __func__, __LINE__, old_sec_mode, new_sec_mode);
+            if( (strcmp(old_sec_mode, new_sec_mode) != 0) && (new_sec_mode != NULL || old_sec_mode != NULL)) {
+                notify_wifi_sec_mode_enabled(ctrl, apIndex, old_sec_mode, new_sec_mode);
+            }
         }
     }
 }

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -242,7 +242,8 @@ int notify_associated_entries(wifi_ctrl_t *ctrl, int ap_index, ULONG new_count, 
     snprintf(str, sizeof(str),
         "Device.WiFi.AccessPoint.%d.AssociatedDeviceNumberOfEntries,%d,%lu,%lu,%d", ap_index + 1, 0,
         new_count, old_count, 2);
-    rc = get_bus_descriptor()->bus_set_string_fn(&ctrl->handle, WIFI_NOTIFY_ASSOCIATED_ENTRIES,
+    wifi_util_info_print(WIFI_CTRL, "%s:%d: Sending Notification for str:%s \n", __func__, __LINE__, str);
+    rc = get_bus_descriptor()->bus_set_string_fn(&ctrl->handle, WIFI_NOTIFY_SYNC_COMPONENT,
         str);
     if (rc != bus_error_success) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: bus: bus_set_string_fn Failed %d\n", __func__,
@@ -416,6 +417,28 @@ int tcm_notify_deny_association(wifi_ctrl_t *ctrl, int ap_index, mac_addr_str_t 
 
     rc = get_bus_descriptor()->bus_set_string_fn(&ctrl->handle, WIFI_NOTIFY_DENY_TCM_ASSOCIATION,
         str);
+    if (rc != bus_error_success) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: bus: bus_set_string_fn Failed %d\n", __func__,
+            __LINE__, rc);
+        return RETURN_ERR;
+    }
+    return RETURN_OK;
+}
+
+int notify_wifi_sec_mode_enabled(wifi_ctrl_t *ctrl, int ap_index, char *old_mode, char *new_mode) {
+    bus_error_t rc;
+    char str[2048];
+    memset(str, 0, sizeof(str));
+
+    if (ctrl == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: NULL Pointer \n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+
+    snprintf(str, sizeof(str),"Device.WiFi.AccessPoint.%d.Security.ModeEnabled,16,%s,%s,2",(ap_index + 1), new_mode, old_mode);
+
+    wifi_util_info_print(WIFI_CTRL, "%s:%d: sending str %s as notification to WIFI_NOTIFY_SYNC_COMPONENT\n", __func__, __LINE__, str);
+    rc = get_bus_descriptor()->bus_set_string_fn(&ctrl->handle, WIFI_NOTIFY_SYNC_COMPONENT, str);
     if (rc != bus_error_success) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: bus: bus_set_string_fn Failed %d\n", __func__,
             __LINE__, rc);


### PR DESCRIPTION
RDKB-59710 Resolve Sync issue for WPA3-PCM

Impacted Platforms:
XB7, XB8, XB10

Reason for change: Security Mode is not Synced with WEBPA when WPA3-PCM RFC is enabled

Test Procedure: Enable/Disable WPA3-PCM and check if notification is sent to webpa for security mode

Risks: Low
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com