### PR TITLE
RDKB-58922: [XHS] - After FR - 2.4Ghz XHS SSID is enabled by default …

### DIFF
--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -442,9 +442,16 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         } else {
             cfg.u.bss_info.showSsid = false;
         }
-        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index)) {
-             cfg.u.bss_info.enabled = true;
+/*For XER5/XB10/XER10 2.4G XHS is disable by default*/
+#if defined(_XER5_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+        if (isVapLnf(vap_index) || isVapPrivate(vap_index)) {
+            cfg.u.bss_info.enabled = true;
         }
+#else
+        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index)) {
+            cfg.u.bss_info.enabled = true;
+        }
+#endif 
 
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6872,9 +6872,15 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         } else {
             cfg.u.bss_info.showSsid = false;
         }
+#if defined(_XER5_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+        if (isVapLnf(vap_index) || isVapPrivate(vap_index)) {
+             cfg.u.bss_info.enabled = true; 
+        }
+#else
         if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index)) {
              cfg.u.bss_info.enabled = true;
         }
+#endif
 #if defined(_SKY_HUB_COMMON_PRODUCT_REQ_)
 #ifndef _SCER11BEL_PRODUCT_REQ_
         if (isVapXhs(vap_index)) {


### PR DESCRIPTION
…(#294)

* Update wifi_db.c

RDKB-58922: [XHS] - After FR - 2.4Ghz XHS SSID is enabled by default

Reason for change:Change wifi db to default values set disable Test Procedure: upon FR xhs should be disabled
Risks: Low
Priority: P1
Signed-off-by:risheesharma@gmail.com

* Update wifi_db_apis.c

RDKB-58922: [XHS] - After FR - 2.4Ghz XHS SSID is enabled by default

Reason for change:Change wifi db to default values set disable Test Procedure: upon FR xhs should be disabled
Risks: Low
Priority: P1
Signed-off-by:risheesharma@gmail.com