### PR TITLE
RDKB-58832: [25Q1] WIFI_VAP_PERCENT_UP percentage is always 100 (radio down case)

### DIFF
--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -2025,6 +2025,7 @@ int capture_vapup_status()
         } else {
             vap_up_arr[vap_index] = 0;
         }
+    }
     vap_iteration++;
     return RETURN_OK;
 }

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -1969,31 +1969,6 @@ static BOOL erouterGetIpAddress()
 }
 #endif
 
-static unsigned char updateNasIpStatus (int apIndex)
-{
-#if defined (DUAL_CORE_XB3)
-
-    static unsigned char erouterIpInitialized = 0;
-    if(isVapHotspotSecure(apIndex)) {
-        if (!erouterIpInitialized) {
-            if (FALSE == erouterGetIpAddress()) {
-                return 0;
-            } else {
-                erouterIpInitialized = 1;
-                return wifi_pushSecureHotSpotNASIP(apIndex, erouterIpAddrStr);
-            }
-        } else {
-                return wifi_pushSecureHotSpotNASIP(apIndex, erouterIpAddrStr);
-        }
-    } else {
-        return 1;
-    }
-#else
-    UNREFERENCED_PARAMETER(apIndex);
-    return 1;
-#endif
-}
-
 int capture_vapup_status()
 {
     int i = 0, vap_status = 0;

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -63,7 +63,6 @@
     arg[5]
 #define AP_UNABLE_TO_HANDLE_ADDITIONAL_ASSOCIATIONS 17
 static unsigned int vap_up_arr[MAX_VAP]={0};
-static unsigned char vap_nas_status[MAX_VAP]={0};
 static unsigned int vap_iteration=0;
 static unsigned int curr_uptime_val = 0;
 static unsigned int prev_uptime_val = 0;

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -2015,16 +2015,21 @@ int capture_vapup_status()
                 __func__, __LINE__, vap_index);
             return RETURN_ERR;
         }
-        vap_status = vap_info->u.bss_info.enabled;
-        if (vap_status) {
-            vap_up_arr[vap_index] = vap_up_arr[vap_index] + 1;
-            if (!vap_nas_status[vap_index]) {
-                vap_nas_status[vap_index] = updateNasIpStatus(vap_index);
-            }
-        } else {
-            vap_nas_status[vap_index] = 0;
+        if (mgr->radio_config[vap_info->radio_index].oper.enable == TRUE &&
+    mgr->global_config.global_parameters.force_disable_radio_feature == FALSE) {
+    vap_status = vap_info->u.bss_info.enabled;
+    if (vap_status) {
+        vap_up_arr[vap_index] = vap_up_arr[vap_index] + 1;
+        if (!vap_nas_status[vap_index]) {
+            vap_nas_status[vap_index] = updateNasIpStatus(vap_index);
         }
+    } else {
+        vap_nas_status[vap_index] = 0;
     }
+} else {
+    vap_up_arr[vap_index] = 0;
+}
+}
     vap_iteration++;
     return RETURN_OK;
 }

--- a/source/apps/whix/wifi_whix.c
+++ b/source/apps/whix/wifi_whix.c
@@ -2016,20 +2016,16 @@ int capture_vapup_status()
             return RETURN_ERR;
         }
         if (mgr->radio_config[vap_info->radio_index].oper.enable == TRUE &&
-    mgr->global_config.global_parameters.force_disable_radio_feature == FALSE) {
-    vap_status = vap_info->u.bss_info.enabled;
-    if (vap_status) {
-        vap_up_arr[vap_index] = vap_up_arr[vap_index] + 1;
-        if (!vap_nas_status[vap_index]) {
-            vap_nas_status[vap_index] = updateNasIpStatus(vap_index);
+            mgr->global_config.global_parameters.force_disable_radio_feature == FALSE) {
+            vap_status = vap_info->u.bss_info.enabled;
+            if (vap_status) {
+                vap_up_arr[vap_index] = vap_up_arr[vap_index] + 1;
+                wifi_util_dbg_print(WIFI_APPS, "VAP %d is UP, count: %d\n", vap_index,
+                    vap_up_arr[vap_index]);
+            }
+        } else {
+            vap_up_arr[vap_index] = 0;
         }
-    } else {
-        vap_nas_status[vap_index] = 0;
-    }
-} else {
-    vap_up_arr[vap_index] = 0;
-}
-}
     vap_iteration++;
     return RETURN_OK;
 }


### PR DESCRIPTION
Reason for change: Even radio is down WIFI_VAP_PERCENT_UP percentage is 100
Test Procedure: Reduce the log_interval for 5mins and check the vap_up_percentage marker
at /rdklogs/logs/messages.txt
Priority: P2
Risks: Low
Signed-off-by: [mothishree_mallaiyanjothimani@comcast.com](mailto:mothishree_mallaiyanjothimani@comcast.com)