### PR TITLE
RDKB-60433: [Improved] Sample APP now saves CSI data in JSON format

### DIFF
--- a/source/sampleapps/wifievents_consumer_sample.c
+++ b/source/sampleapps/wifievents_consumer_sample.c
@@ -51,9 +51,14 @@
 typedef struct csi_data_json_obj {
     cJSON *main_json_obj;
     cJSON *json_csi_obj;
-    cJSON *json_csi_sta_mac;
+    cJSON *json_souding_devices;
+    hash_map_t *stalist_array_map;
     FILE *json_dump_fptr;
 } csi_data_json_obj_t;
+
+typedef struct stalist_map_info {
+    cJSON *sta_json_arr_obj;
+} stalist_map_info_t;
 
 csi_data_json_obj_t json_obj;
 
@@ -346,10 +351,12 @@ static void csiMacListHandler(rbusHandle_t handle, rbusEvent_t const *event,
     UNREFERENCED_PARAMETER(handle);
 }
 
-void json_add_wifi_csi_frame_info(cJSON *sta_obj, wifi_frame_info_t *frame_info)
+void json_add_wifi_csi_frame_info(cJSON *sta_obj, wifi_frame_info_t *frame_info,
+    char *str_sta_mac)
 {
     cJSON *obj_array, *number_item;
 
+    cJSON_AddStringToObject(sta_obj, "sta_mac", str_sta_mac);
     cJSON_AddNumberToObject(sta_obj, "bw_mode", frame_info->bw_mode);
     cJSON_AddNumberToObject(sta_obj, "mcs", frame_info->mcs);
     cJSON_AddNumberToObject(sta_obj, "Nr", frame_info->Nr);
@@ -408,28 +415,32 @@ void json_add_wifi_csi_matrix_info(cJSON *csi_matrix_obj_wrapper, wifi_csi_data_
                 cJSON *real_imag_pair_array = cJSON_CreateArray();
                 VERIFY_NULL_CHECK(real_imag_pair_array);
 
+                cJSON *real_imag_object = cJSON_CreateObject();
+                VERIFY_NULL_CHECK(real_imag_object);
+
                 int16_t real_data = (int16_t)((csi->csi_matrix[sc_idx][ant_idx][stream_idx] >> 16) &
                     0xFFFF);
                 int16_t imag_data = (int16_t)(csi->csi_matrix[sc_idx][ant_idx][stream_idx] &
                     0xFFFF);
 
-                cJSON_AddItemToArray(real_imag_pair_array, cJSON_CreateNumber(real_data));
-                cJSON_AddItemToArray(real_imag_pair_array, cJSON_CreateNumber(imag_data));
+                cJSON_AddNumberToObject(real_imag_object, "real", real_data);
+                cJSON_AddNumberToObject(real_imag_object, "img", imag_data);
 
-                cJSON_AddItemToArray(antenna_data_array, real_imag_pair_array);
+                cJSON_AddItemToArray(antenna_data_array, real_imag_object);
             }
         }
     }
 }
 
-void client_csi_data_json_elem_add(cJSON *sta_obj, wifi_csi_data_t *csi)
+void client_csi_data_json_elem_add(cJSON *sta_obj, wifi_csi_data_t *csi,
+    char *str_sta_mac)
 {
     cJSON *obj;
 
     obj = cJSON_CreateObject();
     VERIFY_NULL_CHECK(obj);
     cJSON_AddItemToObject(sta_obj, "frame_info", obj);
-    json_add_wifi_csi_frame_info(obj, &csi->frame_info);
+    json_add_wifi_csi_frame_info(obj, &csi->frame_info, str_sta_mac);
 
     obj = cJSON_CreateObject();
     VERIFY_NULL_CHECK(obj);
@@ -443,6 +454,7 @@ void csi_data_in_json_format(mac_address_t sta_mac, wifi_csi_data_t *csi)
         return;
     }
     mac_addr_str_t str_sta_mac = { 0 };
+    cJSON *obj;
 
     csi_data_json_obj_t *p_csi_json_obj = get_csi_json_obj();
     if (p_csi_json_obj->main_json_obj == NULL) {
@@ -456,25 +468,46 @@ void csi_data_in_json_format(mac_address_t sta_mac, wifi_csi_data_t *csi)
         cJSON_AddItemToObject(p_csi_json_obj->main_json_obj, "CSI", p_csi_json_obj->json_csi_obj);
     }
 
-    to_mac_str(sta_mac, str_sta_mac);
-    p_csi_json_obj->json_csi_sta_mac = cJSON_GetObjectItem(p_csi_json_obj->json_csi_obj,
-        str_sta_mac);
-    if (p_csi_json_obj->json_csi_sta_mac == NULL) {
-        p_csi_json_obj->json_csi_sta_mac = cJSON_CreateArray();
-        VERIFY_NULL_CHECK(p_csi_json_obj->json_csi_sta_mac);
-        cJSON_AddItemToObject(p_csi_json_obj->json_csi_obj, str_sta_mac,
-            p_csi_json_obj->json_csi_sta_mac);
+    if (p_csi_json_obj->json_souding_devices == NULL) {
+        p_csi_json_obj->json_souding_devices = cJSON_CreateArray();
+        VERIFY_NULL_CHECK(p_csi_json_obj->json_souding_devices);
+        cJSON_AddItemToObject(p_csi_json_obj->json_csi_obj, "SoundingDevices",
+            p_csi_json_obj->json_souding_devices);
     }
 
-    cJSON *obj = cJSON_CreateObject();
-    cJSON_AddItemToArray(p_csi_json_obj->json_csi_sta_mac, obj);
-    client_csi_data_json_elem_add(obj, csi);
+    if (p_csi_json_obj->stalist_array_map == NULL) {
+        p_csi_json_obj->stalist_array_map = hash_map_create();
+        VERIFY_NULL_CHECK(p_csi_json_obj->stalist_array_map);
+    }
+
+    to_mac_str(sta_mac, str_sta_mac);
+    stalist_map_info_t *ptr = hash_map_get(p_csi_json_obj->stalist_array_map,
+        str_sta_mac);
+    if (ptr == NULL) {
+        ptr = calloc(1, sizeof(stalist_map_info_t));
+        VERIFY_NULL_CHECK(ptr);
+        hash_map_put(p_csi_json_obj->stalist_array_map,
+            strdup(str_sta_mac), ptr);
+    }
+
+    if (ptr->sta_json_arr_obj == NULL) {
+        ptr->sta_json_arr_obj = cJSON_CreateArray();
+        VERIFY_NULL_CHECK(ptr->sta_json_arr_obj);
+        cJSON_AddItemToArray(p_csi_json_obj->json_souding_devices,
+            ptr->sta_json_arr_obj);
+    }
+
+    obj = cJSON_CreateObject();
+    cJSON_AddItemToArray(ptr->sta_json_arr_obj, obj);
+    client_csi_data_json_elem_add(obj, csi, str_sta_mac);
 }
 
 void save_json_data_to_file(void)
 {
     csi_data_json_obj_t *p_csi_json_obj = get_csi_json_obj();
     if (p_csi_json_obj->main_json_obj != NULL) {
+        hash_map_destroy(p_csi_json_obj->stalist_array_map);
+        p_csi_json_obj->stalist_array_map = NULL;
         char *json_string = cJSON_Print(p_csi_json_obj->main_json_obj);
         if (json_string == NULL) {
             cJSON_Delete(p_csi_json_obj->main_json_obj);


### PR DESCRIPTION
Reason for change: Improved sample APP csi data json file.

Test Procedure: 1. Load the OneWifi build.
2. Connect a station to gateway.
3. Execute the below command: $ wifi_events_consumer -e 7 -i 300 -n 20 &
-e 7 : subscribe to csi data
-i [csi data interval] : default 500ms min 100 max 30000 -n [num_of_samples to be written to a file]
4. check for the index by running the below data model command $ dmcli eRT getv Device.WiFi.X_RDK_CSI.
5. Provide input station mac address and enable CSI data collection by executing command, example as mentioned below $ dmcli eRT setv Device.WiFi.X_RDK_CSI.[index].ClientMaclist string F0:46:3B:5B:EF:D9 $ dmcli eRT setv Device.WiFi.X_RDK_CSI.[index].Enable bool true
6. As soon as the required samples are collected, wifi_events_consumer will be terminated.
7. The samples are saved to the file /tmp/csi_samples.json

Risks: Low
Priority: P1