### PR TITLE
RDKB-60367: OpenWRT related build changes for libalsap enablement

### DIFF
--- a/build/openwrt/MT7966.config
+++ b/build/openwrt/MT7966.config
@@ -431,9 +431,8 @@ CONFIG_IPV6=y
 # Stripping options
 #
 CONFIG_NO_STRIP=y
-#CONFIG_USE_STRIP=y
+# CONFIG_USE_STRIP is not set
 # CONFIG_USE_SSTRIP is not set
-#CONFIG_STRIP_ARGS="--strip-all"
 # CONFIG_STRIP_KERNEL_EXPORTS is not set
 # CONFIG_USE_MKLIBS is not set
 
@@ -1858,6 +1857,7 @@ CONFIG_PACKAGE_libiwinfo-data=y
 # CONFIG_PACKAGE_brcmfmac-firmware-usb is not set
 # CONFIG_PACKAGE_brcmsmac-firmware is not set
 # CONFIG_PACKAGE_carl9170-firmware is not set
+# CONFIG_PACKAGE_crypto-eip-inline-fw=y
 # CONFIG_PACKAGE_cypress-firmware-43012-sdio is not set
 # CONFIG_PACKAGE_cypress-firmware-43340-sdio is not set
 # CONFIG_PACKAGE_cypress-firmware-43362-sdio is not set
@@ -2509,7 +2509,7 @@ CONFIG_PACKAGE_kmod-slhc=y
 # CONFIG_PACKAGE_kmod-tcp-hybla is not set
 # CONFIG_PACKAGE_kmod-trelay is not set
 # CONFIG_PACKAGE_kmod-tun is not set
-# CONFIG_PACKAGE_kmod-veth is not set
+CONFIG_PACKAGE_kmod-veth=y
 # CONFIG_PACKAGE_kmod-vxlan is not set
 # CONFIG_PACKAGE_kmod-wireguard is not set
 # CONFIG_PACKAGE_kmod-xfrm-interface is not set
@@ -4690,6 +4690,26 @@ CONFIG_PACKAGE_switch=y
 # end of Applications
 
 #
+# Drivers
+#
+# CONFIG_PACKAGE_kmod-crypto-eip=y
+
+#
+# Crypto Offload Configuration
+#
+CONFIG_CRYPTO_OFFLOAD_INLINE=y
+CONFIG_CRYPTO_XFRM_OFFLOAD_MTK_PCE=y
+# end of Crypto Offload Configuration
+
+# CONFIG_PACKAGE_kmod-crypto-eip-ddk=y
+# CONFIG_PACKAGE_kmod-crypto-eip-ddk-ksupport=y
+# CONFIG_PACKAGE_kmod-crypto-eip-ddk-ctrl=y
+# CONFIG_PACKAGE_kmod-crypto-eip-ddk-ctrl-app=y
+# CONFIG_PACKAGE_kmod-crypto-eip-ddk-engine=y
+# CONFIG_PACKAGE_kmod-crypto-eip-inline is not set
+# end of Drivers
+
+#
 # Misc
 #
 # CONFIG_PACKAGE_mtk_factory_rw is not set
@@ -5785,7 +5805,8 @@ CONFIG_PACKAGE_ppp-mod-pppoe=y
 # CONFIG_PACKAGE_snowflake-probetest is not set
 # CONFIG_PACKAGE_snowflake-proxy is not set
 # CONFIG_PACKAGE_snowflake-server is not set
-# CONFIG_PACKAGE_socat is not set
+CONFIG_PACKAGE_socat=y
+# CONFIG_SOCAT_SSL is not set
 # CONFIG_PACKAGE_softflowd is not set
 # CONFIG_PACKAGE_soloscli is not set
 # CONFIG_PACKAGE_speedtest-netperf is not set
@@ -5823,6 +5844,7 @@ CONFIG_PACKAGE_uclient-fetch=y
 # CONFIG_PACKAGE_vxlan is not set
 # CONFIG_PACKAGE_wakeonlan is not set
 # CONFIG_PACKAGE_wg-installer-client is not set
+# CONFIG_PACKAGE_wg-installer-server is not set
 # CONFIG_PACKAGE_wpan-tools is not set
 # CONFIG_PACKAGE_wwan is not set
 # CONFIG_PACKAGE_xfrm is not set
@@ -6253,7 +6275,112 @@ CONFIG_PACKAGE_resize2fs=y
 # CONFIG_PACKAGE_conmon is not set
 # CONFIG_PACKAGE_containerd is not set
 # CONFIG_PACKAGE_coremark is not set
-# CONFIG_PACKAGE_coreutils is not set
+CONFIG_PACKAGE_coreutils=y
+# CONFIG_PACKAGE_coreutils-b2sum is not set
+# CONFIG_PACKAGE_coreutils-base32 is not set
+# CONFIG_PACKAGE_coreutils-base64 is not set
+# CONFIG_PACKAGE_coreutils-basename is not set
+# CONFIG_PACKAGE_coreutils-basenc is not set
+# CONFIG_PACKAGE_coreutils-cat is not set
+# CONFIG_PACKAGE_coreutils-chcon is not set
+# CONFIG_PACKAGE_coreutils-chgrp is not set
+# CONFIG_PACKAGE_coreutils-chmod is not set
+# CONFIG_PACKAGE_coreutils-chown is not set
+# CONFIG_PACKAGE_coreutils-chroot is not set
+# CONFIG_PACKAGE_coreutils-cksum is not set
+# CONFIG_PACKAGE_coreutils-comm is not set
+# CONFIG_PACKAGE_coreutils-cp is not set
+# CONFIG_PACKAGE_coreutils-csplit is not set
+# CONFIG_PACKAGE_coreutils-cut is not set
+# CONFIG_PACKAGE_coreutils-date is not set
+# CONFIG_PACKAGE_coreutils-dd is not set
+# CONFIG_PACKAGE_coreutils-df is not set
+# CONFIG_PACKAGE_coreutils-dir is not set
+# CONFIG_PACKAGE_coreutils-dircolors is not set
+# CONFIG_PACKAGE_coreutils-dirname is not set
+# CONFIG_PACKAGE_coreutils-du is not set
+# CONFIG_PACKAGE_coreutils-echo is not set
+# CONFIG_PACKAGE_coreutils-env is not set
+# CONFIG_PACKAGE_coreutils-expand is not set
+# CONFIG_PACKAGE_coreutils-expr is not set
+# CONFIG_PACKAGE_coreutils-factor is not set
+# CONFIG_PACKAGE_coreutils-false is not set
+# CONFIG_PACKAGE_coreutils-fmt is not set
+# CONFIG_PACKAGE_coreutils-fold is not set
+# CONFIG_PACKAGE_coreutils-groups is not set
+# CONFIG_PACKAGE_coreutils-head is not set
+# CONFIG_PACKAGE_coreutils-hostid is not set
+# CONFIG_PACKAGE_coreutils-id is not set
+# CONFIG_PACKAGE_coreutils-install is not set
+# CONFIG_PACKAGE_coreutils-join is not set
+# CONFIG_PACKAGE_coreutils-kill is not set
+# CONFIG_PACKAGE_coreutils-link is not set
+# CONFIG_PACKAGE_coreutils-ln is not set
+# CONFIG_PACKAGE_coreutils-logname is not set
+# CONFIG_PACKAGE_coreutils-ls is not set
+# CONFIG_PACKAGE_coreutils-md5sum is not set
+# CONFIG_PACKAGE_coreutils-mkdir is not set
+# CONFIG_PACKAGE_coreutils-mkfifo is not set
+# CONFIG_PACKAGE_coreutils-mknod is not set
+# CONFIG_PACKAGE_coreutils-mktemp is not set
+# CONFIG_PACKAGE_coreutils-mv is not set
+# CONFIG_PACKAGE_coreutils-nice is not set
+# CONFIG_PACKAGE_coreutils-nl is not set
+# CONFIG_PACKAGE_coreutils-nohup is not set
+# CONFIG_PACKAGE_coreutils-nproc is not set
+# CONFIG_PACKAGE_coreutils-numfmt is not set
+# CONFIG_PACKAGE_coreutils-od is not set
+# CONFIG_PACKAGE_coreutils-paste is not set
+# CONFIG_PACKAGE_coreutils-pathchk is not set
+# CONFIG_PACKAGE_coreutils-pinky is not set
+# CONFIG_PACKAGE_coreutils-pr is not set
+# CONFIG_PACKAGE_coreutils-printenv is not set
+# CONFIG_PACKAGE_coreutils-printf is not set
+# CONFIG_PACKAGE_coreutils-ptx is not set
+# CONFIG_PACKAGE_coreutils-pwd is not set
+# CONFIG_PACKAGE_coreutils-readlink is not set
+# CONFIG_PACKAGE_coreutils-realpath is not set
+# CONFIG_PACKAGE_coreutils-rm is not set
+# CONFIG_PACKAGE_coreutils-rmdir is not set
+# CONFIG_PACKAGE_coreutils-runcon is not set
+# CONFIG_PACKAGE_coreutils-seq is not set
+# CONFIG_PACKAGE_coreutils-sha1sum is not set
+# CONFIG_PACKAGE_coreutils-sha224sum is not set
+# CONFIG_PACKAGE_coreutils-sha256sum is not set
+# CONFIG_PACKAGE_coreutils-sha384sum is not set
+# CONFIG_PACKAGE_coreutils-sha512sum is not set
+# CONFIG_PACKAGE_coreutils-shred is not set
+# CONFIG_PACKAGE_coreutils-shuf is not set
+# CONFIG_PACKAGE_coreutils-sleep is not set
+# CONFIG_PACKAGE_coreutils-sort is not set
+# CONFIG_PACKAGE_coreutils-split is not set
+# CONFIG_PACKAGE_coreutils-stat is not set
+# CONFIG_PACKAGE_coreutils-stdbuf is not set
+# CONFIG_PACKAGE_coreutils-stty is not set
+# CONFIG_PACKAGE_coreutils-sum is not set
+# CONFIG_PACKAGE_coreutils-sync is not set
+# CONFIG_PACKAGE_coreutils-tac is not set
+# CONFIG_PACKAGE_coreutils-tail is not set
+# CONFIG_PACKAGE_coreutils-tee is not set
+# CONFIG_PACKAGE_coreutils-test is not set
+CONFIG_PACKAGE_coreutils-timeout=y
+# CONFIG_PACKAGE_coreutils-touch is not set
+# CONFIG_PACKAGE_coreutils-tr is not set
+# CONFIG_PACKAGE_coreutils-true is not set
+# CONFIG_PACKAGE_coreutils-truncate is not set
+# CONFIG_PACKAGE_coreutils-tsort is not set
+# CONFIG_PACKAGE_coreutils-tty is not set
+# CONFIG_PACKAGE_coreutils-uname is not set
+# CONFIG_PACKAGE_coreutils-unexpand is not set
+# CONFIG_PACKAGE_coreutils-uniq is not set
+# CONFIG_PACKAGE_coreutils-unlink is not set
+# CONFIG_PACKAGE_coreutils-uptime is not set
+# CONFIG_PACKAGE_coreutils-users is not set
+# CONFIG_PACKAGE_coreutils-vdir is not set
+# CONFIG_PACKAGE_coreutils-wc is not set
+# CONFIG_PACKAGE_coreutils-who is not set
+# CONFIG_PACKAGE_coreutils-whoami is not set
+# CONFIG_PACKAGE_coreutils-yes is not set
 # CONFIG_PACKAGE_crconf is not set
 # CONFIG_PACKAGE_crelay is not set
 # CONFIG_PACKAGE_crun is not set
@@ -6289,6 +6416,7 @@ CONFIG_PACKAGE_resize2fs=y
 # CONFIG_PACKAGE_flashrom-pci is not set
 # CONFIG_PACKAGE_flashrom-spi is not set
 # CONFIG_PACKAGE_flashrom-usb is not set
+# CONFIG_PACKAGE_flent-tools is not set
 # CONFIG_PACKAGE_flock is not set
 # CONFIG_PACKAGE_fritz-caldata is not set
 # CONFIG_PACKAGE_fritz-tffs is not set

--- a/build/openwrt/Makefile_package
+++ b/build/openwrt/Makefile_package
@@ -38,6 +38,11 @@ define Build/Compile
 	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/OneWifi/build/openwrt/  \
 		$(TARGET_CONFIGURE_OPTS)
 
+	echo "Compiling libalsap..."
+	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS) $(TARGET_LDFLAGS)" \
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/unified-wifi-mesh/build/openwrt/libalsap/  \
+		$(TARGET_CONFIGURE_OPTS)
+
 	echo "Compiling Easymesh AGENT..."
 	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS) $(TARGET_LDFLAGS) $(STAGING_DIR)" \
 	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/unified-wifi-mesh/build/openwrt/agent/  \
@@ -55,6 +60,16 @@ define Package/easymesh/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/bin/onewifi_em_agent $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/bin/onewifi_em_ctrl $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/OneWifi/install/bin/OneWifi $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/banana-pi
+	$(INSTALL_DIR) $(1)/nvram
+	$(CP) $(PKG_BUILD_DIR)/OneWifi/config/openwrt/banana-pi/* $(1)/banana-pi/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/OneWifi/config/openwrt/banana-pi/etc/init.d/* $(1)/etc/init.d/
+	$(CP) $(PKG_BUILD_DIR)/unified-wifi-mesh/config/openwrt/banana-pi/* $(1)/banana-pi/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/unified-wifi-mesh/config/openwrt/banana-pi/etc/init.d/* $(1)/etc/init.d/
+	#Copy certificate file needed for ssh connection to nvram folder
+	$(CP) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/config/test_cert.crt $(1)/nvram/
+	$(CP) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/config/test_cert.key $(1)/nvram/
 endef
 
 $(eval $(call BuildPackage,easymesh))

--- a/config/openwrt/banana-pi/etc/init.d/onewifi
+++ b/config/openwrt/banana-pi/etc/init.d/onewifi
@@ -1,15 +1,31 @@
 #!/bin/sh /etc/rc.common
 
-START=99  # Service startup order
-STOP=01  # Service stop order
 USE_PROCD=1
+#Commenting start to ensure that service is started manually
+#START=97  # Service startup order
+STOP=97  # Service stop order
 Name=OneWifi
 
+#Helper function for logging with timestamp
+log_message() {
+    # Get current uptime in seconds and hundredths (e.g., "12345.67")
+    UPTIME_SECONDS_DECIMAL=$(cut -d' ' -f1 /proc/uptime)
+    # Extract integer seconds and fractional part
+    UPTIME_SECONDS=${UPTIME_SECONDS_DECIMAL%.*}
+    UPTIME_FRACTION=${UPTIME_SECONDS_DECIMAL#*.}
+
+    # Convert fraction to milliseconds (take first 3 digits, pad with zeros if needed)
+    # This assumes UPTIME_FRACTION is at least 2 digits.
+    # For robust padding if it's less than 3 digits:
+    MILLISECONDS=$(printf "%-3.3s" "$UPTIME_FRACTION" | sed 's/ /0/g')
+    echo "$(date "+%Y-%m-%d %H:%M:%S").${MILLISECONDS} - $@" >> /tmp/onewifi_log.txt
+}
+
 start_service() {
-    echo "Starting onewifi service..." >> /tmp/onewifi_log.txt
+    log_message "Starting onewifi service..."
     # Run wifi_interface_up.sh only once after boot
     if [ ! -f /tmp/onewifi_bootup_completed ]; then
-        echo "Running wifi_interface_up.sh..." >> /tmp/onewifi_log.txt
+        log_message "Running wifi_interface_up.sh..."
         cd /banana-pi
         ./wifi_interface_up.sh >> /tmp/onewifi_log.txt
         cd -
@@ -26,14 +42,10 @@ start_service() {
     procd_set_param stderr 1 # same for stderr
     procd_set_param pidfile /tmp/onewifi.pid
     procd_close_instance
-
-    # Start the main process for onewifi
-    #/usr/bin/OneWifi -c &   # Replace this with your process path or command
-    #echo $! > /tmp/onewifi.pid   # Save the PID of the process
 }
 
 stop_service() {
-    echo "Stopping onewifi service..." >> /tmp/onewifi_log.txt
+    log_message "Stopping onewifi service..."
     # Stop the main process if it is running
     if [ -f /tmp/onewifi.pid ]; then
         kill -9 "$(cat /tmp/onewifi.pid)"  # Kill the process
@@ -48,19 +60,19 @@ stop_service() {
 }
 
 restart_service() {
-    echo "Restart triggered for onewifi service..."
+    log_message "Restart triggered for onewifi service..."
     stop
     start
 }
 
 reload_service() {
-    echo "Reload triggered for onewifi service..."
+    log_message "Reload triggered for onewifi service..."
     stop
     start
 }
 
 service_triggers() {
-    echo "Setting up respawn trigger for onewifi service..."
+    log_message "Setting up respawn trigger for onewifi service..."
     procd_add_reload_trigger "/nvram/EasymeshCfg.json" "/nvram/InterfaceMap.json"
 }
 


### PR DESCRIPTION
Reason for change: OpenWRT config related change to enable virtual ethernet package in kernel. Makefile change to build libalsap and install necessary components in right path. onewifi procd script change for considering colocated_mode before overwriting the EasymeshCfg.json file.

Risks: Low
Priority: P1