### PR TITLE
RDKB-60397 Client Max Limit in XB10 devices are seen as 100

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -191,6 +191,7 @@ typedef void *wifi_analytics_data_t;
 #define BSS_MAX_NUM_STA_XB8      100     /**< Max supported stations for TCHX8 specific platform */
 #define BSS_MAX_NUM_STATIONS     100     /**< Max supported stations by RDK-B firmware which would varies based on platform */
 #define BSS_MAX_NUM_STA_HOTSPOT_CBRV2    15      /**< Max supported stations for hotspot vaps in CBR2 platform */
+#define BSS_MAX_NUM_STA_HOTSPOT_XB      5      /**< Max supported stations for hotspot vaps in XB platform */
 
 #define STA_MAX_BSS_ASSOCIATIONS  1
 

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -7147,20 +7147,17 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
 #endif //_SR213_PRODUCT_REQ_
 
 #else
-#ifdef NEWPLATFORM_PORT
-        cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
-#else
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
-            wifi_util_info_print(WIFI_DB, "%s:%d  vap_index:%d maxassoc:%d", __func__, __LINE__, vap_index, cfg.u.bss_info.bssMaxSta);
-        } else if (is_device_type_cbr2() && (isVapHotspotOpen5g(vap_index) || isVapHotspotSecure5g(vap_index))) {
+        } else if (is_device_type_cbr2() && isVapHotspot(vap_index)) {
             cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_HOTSPOT_CBRV2;
-            wifi_util_info_print(WIFI_DB, "%s:%d vap_index:%d maxassoc:%d", __func__, __LINE__, vap_index, cfg.u.bss_info.bssMaxSta);
+        } else if (isVapHotspot(vap_index)) {
+            cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_HOTSPOT_XB;
         } else {
-            cfg.u.bss_info.bssMaxSta =  BSS_MAX_NUM_STA_COMMON;
-            wifi_util_info_print(WIFI_DB,"%s:%d  maxassoc:%d", __func__,__LINE__, cfg.u.bss_info.bssMaxSta);
+            cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_COMMON;
         }
-#endif // NEWPLATFORM_PORT
+        wifi_util_dbg_print(WIFI_DB, "%s:%d vap_index:%d bssMaxSta:%d\n", __func__, __LINE__,
+            vap_index, cfg.u.bss_info.bssMaxSta);
 #endif //_SKY_HUB_COMMON_PRODUCT_REQ_
 
 #if defined(_XB7_PRODUCT_REQ_) || defined(_XB8_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) || \


### PR DESCRIPTION
Impacted Platforms:
All RDKB OneWiFi Platforms

Reason for change: Incorrect BssMax for XB hotspot VAPs

Test Procedure: Default BssMax for hotspot VAPs should be 5 for XBs.

Risks: Low

Priority: P1