### PR TITLE
RDKBWIFI-40: Fixes HE-Bus stack overflow

### DIFF
--- a/source/platform/linux/he_bus/inc/he_bus_common.h
+++ b/source/platform/linux/he_bus/inc/he_bus_common.h
@@ -47,7 +47,7 @@ typedef struct _he_bus_handle *he_bus_handle_t;
 
 #define HE_BUS_MSG_IDENTIFICATION_NUM 0x12345678
 #define HE_BUS_RES_RECV_TIMEOUT_S 10
-#define HE_BUS_MAX_NAME_LENGTH 64
+#define HE_BUS_MAX_NAME_LENGTH 128
 
 #define HE_BUS_VERIFY_NULL(T) \
     if (NULL == T) {   \

--- a/source/platform/linux/he_bus/inc/he_bus_core.h
+++ b/source/platform/linux/he_bus/inc/he_bus_core.h
@@ -166,7 +166,7 @@ typedef struct data_model_prop {
 } data_model_prop_t;
 
 typedef struct element_node {
-    char name[32]; /* relative name of element */
+    char name[64]; /* relative name of element */
     he_bus_name_string_t full_name; /* full name/path of element */
     he_bus_element_type_t type; /**< Type of an element */
     he_bus_callback_table_t cb_table; /**< Element Handler table. A specific


### PR DESCRIPTION
Reason for change: OneWifi crashes when a bus connection (like a `unified-wifi-mesh` agent or controller) disconnects. This occurs because larger "full names" (such as `Device.WiFi.CollectStats.Radio.{i}.ScanMode.*`) are larger than the pre-allocated buffer. The same can occur for the "name".

Risks: Low
Priority: P1

Additional info:
Crash Backtrace: (continues for any more frames)
```gdb
#0  0x00000055555c2988 in hash_map_remove (map=0x2e65646f2e6964, key=0x7ff0001052 "EasyMesh_service")
    at /root/easymesh_project/OneWifi//source/utils/collection.c:221
#1  0x000000555562bddc in remove_client_existing_sub_info_cb (node=0x5556e0ab10, param=...)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:1267
#2  0x0000005555629924 in node_element_recurse_traversal (node=0x5556e0ab10, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:609
#3  0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a9e0, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#4  0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a8b0, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#5  0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a780, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#6  0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a650, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#7  0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a520, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#8  0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a3f0, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#9  0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a2c0, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#10 0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a190, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#11 0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a060, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#12 0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e08cf0, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#13 0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e08bc0, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#14 0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e08a90, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
#15 0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e01990, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
```

Stack overflow proof:
```gdb
#10 0x00000055556298c8 in node_element_recurse_traversal (node=0x5556e0a190, input_action=0x7ff74de588)
    at /root/easymesh_project/OneWifi//source/platform/linux/he_bus/src/he_bus_core.c:602
602	            node_element_recurse_traversal(tmp, input_action);
(gdb) p *tmp
$14 = {name = "ChannelStDevice.WiFi.CollectStat", full_name = "s.Radio.{i}.ScanMode.on_channel.ChannelStDevice.WiFi.CollectStat", type = 1632775795,
  cb_table = {get_handler = 0x6e6163532e7d697b, set_handler = 0x5f6e6f2e65646f4d, table_add_row_handler = 0x2e6c656e6e616863,
    table_remove_row_handler = 0x4d6e00746e696f70, event_sub_handler = 0x635f6e6f2e65646f, method_handler = 0x702e6c656e6e6168},
  subscriptions = 0x746e696f, parent = 0x5556e0a190, child = 0x5556e0a3f0, nextSibling = 0x5556e0e410, element_mutex = {__data = {__lock = 0,
      __count = 0, __owner = 0, __nusers = 0, __kind = 2, __spins = 0, __list = {__prev = 0x0, __next = 0x0}},
    __size = '\000' <repeats 16 times>, "\002", '\000' <repeats 30 times>, __align = 0}, bus_speed = 0 '\000', data_model_value = {data_format = 0,
    data_permission = false, min_data_range = 0, max_data_range = 0, num_of_str_validation = 0, str_validation = 0x0},
  reference_childs = actual_child_node}
```

which after many iterations, leads to this, leading to the crash (not the addresses in all of these):
```gdb
(gdb) p *node
$3 = {name = ".Radi..Radi.canMode.o.n_c.i}.Sca", full_name = "nMode.o.i.ode.._channel..i.CollectStats.Radi.ode.\000i..Radi.canMod",
  type = 779038309, cb_table = {get_handler = 0x4d6e6163532e7d69, set_handler = 0x2e692e6f2e65646f, table_add_row_handler = 0x68635f2e2e65646f,
    table_remove_row_handler = 0x692e2e6c656e6e61, event_sub_handler = 0x7463656c6c6f432e, method_handler = 0x61522e7374617453},
  subscriptions = 0x2e65646f2e6964, parent = 0x5556e0a9e0, child = 0x5556e0ac40, nextSibling = 0x0, element_mutex = {__data = {__lock = 1,
      __count = 0, __owner = 5231, __nusers = 1, __kind = 2, __spins = 0, __list = {__prev = 0x0, __next = 0x0}},
    __size = "\001\000\000\000\000\000\000\000o\024\000\000\001\000\000\000\002", '\000' <repeats 30 times>, __align = 1}, bus_speed = 0 '\000',
  data_model_value = {data_format = 0, data_permission = false, min_data_range = 0, max_data_range = 0, num_of_str_validation = 0,
    str_validation = 0x0}, reference_childs = actual_child_node}
```

@amarnathhullur 