### PR TITLE
RDKB-60475 Need to correct to typo in Heapwalkcheckrss.sh script

### DIFF
--- a/scripts/Heapwalkcheckrss.sh
+++ b/scripts/Heapwalkcheckrss.sh
@@ -86,7 +86,7 @@ while true; do
     echo "$(date '+%Y-%m-%d %H:%M:%S') Current RSS : $current_vmrss" >> "$log_file"
     rss_diff=$((current_vmrss - initial_vmrss))
     echo "$(date '+%Y-%m-%d %H:%M:%S') RSS Diff: $rss_diff" >> "$log_file"
-    if [ "$rss_diff" -gt "$RSShreshold" ] || [ "$current_vmrss" -gt "$RSSMaxLimit" ]; then
+    if [ "$rss_diff" -gt "$RSSThreshold" ] || [ "$current_vmrss" -gt "$RSSMaxLimit" ]; then
         heapwalk_pid=$(ps | grep -i "HeapwalkField" | grep -v grep |  awk '{print $1}')
         echo "$(date '+%Y-%m-%d %H:%M:%S') HeapwalkField.sh pid : $heapwalk_pid" >> "$log_file"
         if [ -z "$heapwalk_pid" ]; then


### PR DESCRIPTION
Reason for change: To correct parameter name in Heapwalkcheckrss.sh script
Test Procedure:
   1. Load the image in the device.
   2. Set the RFC param to true
            dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MemwrapTool.Enable bool true
   3. Make sure parameters to run the tool are as expected with below provided DMCLI commands
            dmcli eRT getv Device.WiFi.MemwrapTool.RssCheckInterval
            dmcli eRT getv Device.WiFi.MemwrapTool.RssThreshold
            dmcli eRT getv Device.WiFi.MemwrapTool.HeapwalkDuration
            dmcli eRT getv Device.WiFi.MemwrapTool.HeapwalkInterval
    4. Enable the tool by executing the below command
            dmcli eRT setv Device.WiFi.MemwrapTool.Enable bool true
Priority: P1
Risks: Low
Signed-off-by: Samyuktha Karthikeyan <samyuktha_karthikeyan@comcast.com>