### PR TITLE
RDKB-60494: EM Translator: Access bss_info structure only in vap ap mode.

### DIFF
--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -492,9 +492,16 @@ webconfig_error_t translate_vap_info_to_em_common(const wifi_vap_info_t *vap, co
     radio_interface_mapping_t *radio_iface_map;
 
     if ((vap_row == NULL) || (vap == NULL)) {
-        wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: input argument is NULL\n", __func__, __LINE__);
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: input argument is NULL\n", __func__,
+            __LINE__);
         return webconfig_error_translate_to_easymesh;
     }
+    if (vap->vap_mode != wifi_vap_mode_ap) {
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: vap_mode:%d is not wifi_vap_mode_ap.\n",
+            __func__, __LINE__, vap->vap_mode);
+        return webconfig_error_translate_to_easymesh;
+    }
+
     vap_row->enabled = vap->u.bss_info.enabled;
     strncpy(vap_row->ssid, vap->u.bss_info.ssid, sizeof(vap_row->ssid));
 
@@ -509,7 +516,7 @@ webconfig_error_t translate_vap_info_to_em_common(const wifi_vap_info_t *vap, co
             vap->u.bss_info.bssid[4], vap->u.bss_info.bssid[5]);
     str_to_mac_bytes(mac_str,vap_row->bssid.mac);
     strncpy(vap_row->bssid.name, iface_map->interface_name,sizeof(vap_row->bssid.name));
-	convert_vap_name_to_hault_type(&vap_row->id.haul_type, vap->vap_name);
+	convert_vap_name_to_hault_type(&vap_row->id.haul_type, (char *)vap->vap_name);
 
     default_em_bss_info(vap_row);
     radio_iface_map = NULL;
@@ -602,7 +609,13 @@ webconfig_error_t translate_associated_clients_to_easymesh_sta_info(webconfig_su
                     printf("%s:%d: client_state: %d\n", __func__, __LINE__, assoc_dev_data->client_state);
 
                     memcpy(em_sta_dev_info->id, assoc_dev_data->dev_stats.cli_MACAddress, sizeof(mac_address_t));
-                    memcpy(em_sta_dev_info->bssid, vap->u.bss_info.bssid, sizeof(mac_address_t));
+                    if (vap->vap_mode == wifi_vap_mode_ap) {
+                        memcpy(em_sta_dev_info->bssid, vap->u.bss_info.bssid,
+                            sizeof(mac_address_t));
+                    } else if (vap->vap_mode == wifi_vap_mode_sta) {
+                        memcpy(em_sta_dev_info->bssid, vap->u.sta_info.bssid,
+                            sizeof(mac_address_t));
+                    }
                     memcpy(em_sta_dev_info->radiomac, radio_info->intf.mac, sizeof(mac_address_t));
                     em_sta_dev_info->last_ul_rate = assoc_dev_data->dev_stats.cli_LastDataUplinkRate;
                     em_sta_dev_info->last_dl_rate = assoc_dev_data->dev_stats.cli_LastDataDownlinkRate;
@@ -840,7 +853,7 @@ webconfig_error_t translate_ap_metrics_report_to_easy_mesh_bss_info(webconfig_su
         //Get the corresponding vap
         vap = &vap_map->vap_array[j];
         ap_metrics = &em_ap_report->vap_reports[j];
-        if (strncmp(ap_metrics->vap_metrics.bssid, vap->u.bss_info.bssid, sizeof(bssid_t)) != 0) {
+        if ((vap->vap_mode != wifi_vap_mode_ap) || (strncmp(ap_metrics->vap_metrics.bssid, vap->u.bss_info.bssid, sizeof(bssid_t)) != 0)) {
             continue;
         }
 
@@ -918,7 +931,7 @@ webconfig_error_t translate_sta_info_to_em_common(const wifi_vap_info_t *vap, co
     strncpy(vap_row->ssid, vap->u.sta_info.ssid, sizeof(vap->u.sta_info.ssid));
     memcpy(vap_row->bssid.mac, vap->u.sta_info.bssid, sizeof(mac_address_t));
     strncpy(vap_row->bssid.name,iface_map->interface_name,sizeof(vap_row->bssid.name));
-    convert_vap_name_to_hault_type(&vap_row->id.haul_type, vap->vap_name);
+    convert_vap_name_to_hault_type(&vap_row->id.haul_type, (char *)vap->vap_name);
 
     // Copy security info (mode/AKMs)
     enum_sec = vap->u.sta_info.security.mode;
@@ -1491,16 +1504,22 @@ webconfig_error_t translate_beacon_report_object_to_easymesh_sta_info(webconfig_
         }
     }
 
-    if (vap == NULL){
-        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: vap is NULL\n", __func__,
-            __LINE__);
+    if (vap == NULL) {
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: vap is NULL\n", __func__, __LINE__);
+        return webconfig_error_translate_to_easymesh;
+    }
+
+    if (vap->vap_mode != wifi_vap_mode_ap) {
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: vap_mode:%d is not wifi_vap_mode_ap\n",
+            __func__, __LINE__, vap->vap_mode);
+        return webconfig_error_translate_to_easymesh;
     }
 
     bss_info = proto->get_bss_info_with_mac(proto->data_model, vap->u.bss_info.bssid);
 
     if (bss_info == NULL) {
-        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: bss_info is NULL\n", __func__,
-            __LINE__);
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: bss_info is NULL\n", __func__, __LINE__);
+        return webconfig_error_translate_to_easymesh;
     }
 
     memcpy(em_sta_dev_info.id, params->sta_beacon_report.mac_addr, sizeof(mac_address_t));
@@ -1521,9 +1540,16 @@ webconfig_error_t translate_beacon_report_object_to_easymesh_sta_info(webconfig_
 webconfig_error_t translate_em_common_to_vap_info_common( wifi_vap_info_t *vap, const em_bss_info_t *vap_row)
 {
     if ((vap_row == NULL) || (vap == NULL)) {
-        wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: input argument is NULL\n", __func__, __LINE__);
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: input argument is NULL\n", __func__,
+            __LINE__);
         return webconfig_error_translate_from_easymesh;
     }
+    if (vap->vap_mode != wifi_vap_mode_ap) {
+        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: vap_mode:%d is not wifi_vap_mode_ap.\n",
+            __func__, __LINE__, vap->vap_mode);
+        return webconfig_error_translate_from_easymesh;
+    }
+
     vap->u.bss_info.enabled = vap_row->enabled ;
     strncpy(vap->u.bss_info.ssid,vap_row->ssid, sizeof(vap->u.bss_info.ssid));
 
@@ -1562,8 +1588,7 @@ webconfig_error_t translate_em_common_to_sta_info_common(wifi_vap_info_t *vap, c
     }
 
     vap->u.sta_info.security.mode = enum_sec;
-    
-    //Copy Passphrase
+    // Copy Passphrase
     strncpy(vap->u.sta_info.security.u.key.key, vap_row->mesh_sta_passphrase, sizeof(vap->u.sta_info.security.u.key.key));
     
     return webconfig_error_none;
@@ -1809,7 +1834,15 @@ webconfig_error_t translate_from_easymesh_bssinfo_to_vap_per_radio(webconfig_sub
     for (j = 0; j < radio->vaps.num_vaps; j++) {
         //Get the corresponding vap
         vap = &vap_map->vap_array[j];
-        vap_info_row = proto->get_bss_info_with_mac(proto->data_model, vap->u.bss_info.bssid);
+        if (vap->vap_mode == wifi_vap_mode_ap) {
+            vap_info_row = proto->get_bss_info_with_mac(proto->data_model, vap->u.bss_info.bssid);
+        } else if (vap->vap_mode == wifi_vap_mode_sta) {
+            vap_info_row = proto->get_bss_info_with_mac(proto->data_model, vap->u.sta_info.bssid);
+        } else {
+            wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: unhandled vap_mode:%d\n",
+                __func__, __LINE__, vap->vap_mode);
+            vap_info_row = NULL;
+        }
         if (vap_info_row == NULL) {
             wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: em_vap_info is NULL\n", __func__, __LINE__);
             continue;
@@ -1852,14 +1885,29 @@ webconfig_error_t translate_from_easymesh_bssinfo_to_vap_per_radio(webconfig_sub
 
         if (radio_config != NULL) {
             for(k = 0; k < radio_config->noofbssconfig; k++) {
-                convert_vap_name_to_hault_type(&haultype, vap->vap_name );
+                convert_vap_name_to_hault_type(&haultype, (char *)vap->vap_name);
                 if (radio_config->haultype[k] == haultype) {
-                    wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: ssid=%s sec_mode=%d password=%s", __func__, __LINE__,
-                    radio_config->ssid[k],radio_config->authtype[k],radio_config->password[k]);
-                    vap->u.bss_info.security.mode = radio_config->authtype[k];
-                    strncpy(vap->u.bss_info.ssid, radio_config->ssid[k], sizeof(vap->u.bss_info.ssid)-1);
-                    strncpy(vap->u.bss_info.security.u.key.key, radio_config->password[k], sizeof(vap->u.bss_info.security.u.key.key)-1);
-                    vap->u.bss_info.enabled = radio_config->enable[k];
+                    wifi_util_info_print(WIFI_WEBCONFIG,
+                        "%s:%d: vap_mode:%d ssid=%s sec_mode=%d\n", __func__, __LINE__,
+                        vap->vap_mode, radio_config->ssid[k], radio_config->authtype[k]);
+                    if (vap->vap_mode == wifi_vap_mode_ap) {
+                        vap->u.bss_info.security.mode = radio_config->authtype[k];
+                        strncpy(vap->u.bss_info.ssid, radio_config->ssid[k],
+                            sizeof(vap->u.bss_info.ssid) - 1);
+                        strncpy(vap->u.bss_info.security.u.key.key, radio_config->password[k],
+                            sizeof(vap->u.bss_info.security.u.key.key) - 1);
+                        vap->u.bss_info.enabled = radio_config->enable[k];
+                    } else if (vap->vap_mode == wifi_vap_mode_sta) {
+                        vap->u.sta_info.security.mode = radio_config->authtype[k];
+                        strncpy(vap->u.sta_info.ssid, radio_config->ssid[k],
+                            sizeof(vap->u.sta_info.ssid) - 1);
+                        strncpy(vap->u.sta_info.security.u.key.key, radio_config->password[k],
+                            sizeof(vap->u.sta_info.security.u.key.key) - 1);
+                        vap->u.sta_info.enabled = radio_config->enable[k];
+                    } else {
+                        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: unhandled vap_mode:%d\n",
+                            __func__, __LINE__, vap->vap_mode);
+                    }
                 }
             }
         }
@@ -2061,14 +2109,29 @@ webconfig_error_t translate_from_easymesh_bssinfo_to_vap_object(webconfig_subdoc
 
             if (radio_config != NULL) {
                 for(k = 0; k < radio_config->noofbssconfig; k++) {
-                    convert_vap_name_to_hault_type(&haultype, vap->vap_name );
+                    convert_vap_name_to_hault_type(&haultype, (char *)vap->vap_name );
                     if (radio_config->haultype[k] == haultype) {
-                        wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: ssid=%s sec_mode=%d password=%s", __func__, __LINE__,
-                        radio_config->ssid[k],radio_config->authtype[k],radio_config->password[k]);
-                        vap->u.bss_info.security.mode = radio_config->authtype[k];
-                        strncpy(vap->u.bss_info.ssid, radio_config->ssid[k], sizeof(vap->u.bss_info.ssid)-1);
-                        strncpy(vap->u.bss_info.security.u.key.key, radio_config->password[k], sizeof(vap->u.bss_info.security.u.key.key)-1);
-                        vap->u.bss_info.enabled = radio_config->enable[k];
+                        wifi_util_info_print(WIFI_WEBCONFIG,
+                            "%s:%d: vap_mode:%d ssid=%s sec_mode=%d\n", __func__, __LINE__,
+                            vap->vap_mode, radio_config->ssid[k], radio_config->authtype[k]);
+                        if (vap->vap_mode == wifi_vap_mode_ap) {
+                            vap->u.bss_info.security.mode = radio_config->authtype[k];
+                            strncpy(vap->u.bss_info.ssid, radio_config->ssid[k],
+                                sizeof(vap->u.bss_info.ssid) - 1);
+                            strncpy(vap->u.bss_info.security.u.key.key, radio_config->password[k],
+                                sizeof(vap->u.bss_info.security.u.key.key) - 1);
+                            vap->u.bss_info.enabled = radio_config->enable[k];
+                        } else if (vap->vap_mode == wifi_vap_mode_sta) {
+                            vap->u.sta_info.security.mode = radio_config->authtype[k];
+                            strncpy(vap->u.sta_info.ssid, radio_config->ssid[k],
+                                sizeof(vap->u.sta_info.ssid) - 1);
+                            strncpy(vap->u.sta_info.security.u.key.key, radio_config->password[k],
+                                sizeof(vap->u.sta_info.security.u.key.key) - 1);
+                            vap->u.sta_info.enabled = radio_config->enable[k];
+                        } else {
+                            wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: unhandled vap_mode:%d\n",
+                                __func__, __LINE__, vap->vap_mode);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Reason for change: vap_info structure has union of bss_info and sta_info structure. Based on the vap_mode access the union appropriately, otherwise fields will be accessed with wrong offset, causing undeterministic behavior.

Risks: Low
Priority: P1