### PR TITLE
XER10-1792, XB10-1863: Observed after FR 2.4G default radio operating mode is coming up with "g,n,ax,be"

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6727,9 +6727,6 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
 #if defined (NEWPLATFORM_PORT) || defined (_GREXT02ACTS_PRODUCT_REQ_)
             cfg.variant |= WIFI_80211_VARIANT_AX;
 #endif /* NEWPLATFORM_PORT */
-#if defined(CONFIG_IEEE80211BE)
-            cfg.variant |= WIFI_80211_VARIANT_BE;
-#endif /* CONFIG_IEEE80211BE */
 #if defined (_PP203X_PRODUCT_REQ_) || defined (_GREXT02ACTS_PRODUCT_REQ_)
             cfg.beaconInterval = 200;
 #endif


### PR DESCRIPTION
XER10-1792, XB10-1863: Observed after FR 2.4G default radio operating mode is coming up with "g,n,ax,be"

Reason for change: RDKBACCL-718 revert changes enabled BE mode by default for 2.4GHz radio in XER10 and XB10.
Test Procedure: Ensure after FR 2.4G default radio is not coming up with "g,n,ax,be".
Risks: Medium
Priority: P1