### PR TITLE
RDKB-60531: SelfHeal constantly restarts OneWifi process after FR

### DIFF
--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -204,7 +204,9 @@ onewifi_mem_restart() {
     now=$(date +%s)
     time_since_last_restart=$((now - onewifi_last_restart))
 
-    if [ -z "$vmrss" -o -z "$threshold2" -o -z "$threshold1" ]; then
+    # Added check for threshold1 and threshold2 if any of them are zero or empty, then skip the OneWifi restart.
+    if [ -z "$vmrss" ] || [ -z "$threshold2" ] || [ -z "$threshold1" ] || \
+        [ "$vmrss" -eq 0 ] || [ "$threshold2" -eq 0 ] || [ "$threshold1" -eq 0 ]; then
         echo_t "Invalid vmrss=$vmrss, threshold1=$threshold1, threshold2=$threshold2" >> $LOG_FILE
         return
     fi

--- a/source/core/wifi_mgr.c
+++ b/source/core/wifi_mgr.c
@@ -224,7 +224,10 @@ bool is_device_type_vbvxer5(void)
 {
     return is_supported_gateway_device("VTER11QEL");
 }
-
+bool is_device_type_xle(void)
+{
+    return is_supported_gateway_device("WNXL11BWL");
+}
 
 int init_wifimgr()
 {

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -8734,7 +8734,8 @@ int get_all_param_from_psm_and_set_into_db(void)
     if (is_device_type_xb7() == true || is_device_type_xb8() == true ||
         is_device_type_vbvxb10() == true || is_device_type_sercommxb10() == true ||
         is_device_type_scxer10() == true || is_device_type_sr213() == true ||
-        is_device_type_cmxb7() == true || is_device_type_cbr2() == true || is_device_type_vbvxer5() == true) {
+        is_device_type_cmxb7() == true || is_device_type_cbr2() == true ||
+        is_device_type_vbvxer5() == true || is_device_type_xle() == true) {
         bool wifi_psm_db_enabled = false;
         char last_reboot_reason[32];
         raw_data_t data;
@@ -8742,7 +8743,7 @@ int get_all_param_from_psm_and_set_into_db(void)
         memset(&data, 0, sizeof(raw_data_t));
         memset(last_reboot_reason, 0, sizeof(last_reboot_reason));
 
-        bus_handle_t handle = {0};
+        bus_handle_t handle = { 0 };
         if (wifi_mgr_bus_subsription(&handle) == RETURN_OK) {
             if (get_bus_descriptor()->bus_data_get_fn(&handle, WIFI_PSM_DB_NAMESPACE, &data) ==
                 bus_error_success) {
@@ -8788,7 +8789,7 @@ int get_all_param_from_psm_and_set_into_db(void)
                 return 0;
             }
             strncpy(inactive_firmware, (char *)data.raw_data.bytes,
-                   (sizeof(inactive_firmware) - 1));
+                (sizeof(inactive_firmware) - 1));
             if (access(ONEWIFI_DB_CONSOLIDATED_FLAG, F_OK) != 0) {
                 if (((strncmp(last_reboot_reason, "Software_upgrade", strlen("Software_upgrade")) ==
                          0) ||
@@ -8800,7 +8801,6 @@ int get_all_param_from_psm_and_set_into_db(void)
                 }
             }
             get_bus_descriptor()->bus_data_free_fn(&data);
-
         }
 
         if ((access(ONEWIFI_MIGRATION_FLAG, F_OK) == 0)) {


### PR DESCRIPTION
RDKB-60531: SelfHeal constantly restarts OneWifi process after FR

Impacted Platforms: XLE only.

Reason for change: FR flag is not created for XLE ,so the global values are
 zeroed instead of setting default values.

Test Procedure:
1. Do a Factory Reset.
2. Check OneWifi process

3. If process is getting restarted constantly, then issue is reproduced.

Risks: Low
Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com