### PR TITLE
RDKB-60228: Update self_heal script to run force reset for private vap

### DIFF
--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -402,13 +402,15 @@ do
         onewifi_restart_wifi
     fi
 
-    if [ $force_reset_subdoc -le  2 ]; then
+    if [ $force_reset_subdoc -le  5 ]; then
         if [ -f  $SW_UPGRADE_DEFAULT_FILE ]; then
-            webcfg_rfc_enabled=`dmcli eRT getv Device.X_RDK_WebConfig.RfcEnable | grep "value" | cut -d ':' -f3-5`
+            webcfg_rfc_enabled=$(dmcli eRT retv Device.X_RDK_WebConfig.RfcEnable)
             echo_t "webcfg_rfc status is $webcfg_rfc_enabled" >>  /rdklogs/logs/wifi_selfheal.txt
-            dmcli eRT setv Device.X_RDK_WebConfig.webcfgSubdocForceReset string privatessid
-            echo_t "Selfheal execution to force_reset on private vaps passed from WebConfig" >> /rdklogs/logs/wifi_selfheal.txt
-            rm -f $SW_UPGRADE_DEFAULT_FILE
+            if [ "$webcfg_rfc_enabled" = "true" ]; then
+                dmcli eRT setv Device.X_RDK_WebConfig.webcfgSubdocForceReset string privatessid
+                echo_t "Selfheal execution to force_reset on private vaps passed from WebConfig" >> /rdklogs/logs/wifi_selfheal.txt
+                rm -f $SW_UPGRADE_DEFAULT_FILE
+            fi
         fi
         ((force_reset_subdoc++))
     fi


### PR DESCRIPTION
Impacted Platforms:
XB7, XB8, XB10

Reason for change: Update self_heal script to run force reset private vap

Test Procedure: Private vap should be force reset within 5-10 mins after
webconfig is up if default SSID is set

Risks: Low
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com