### PR TITLE
LTE-2690 No client connectivity with HostapMgmtFrameCtrl enabled

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -475,7 +475,9 @@ int start_radios(rdk_dev_mode_type_t mode)
         }
 
         //In case of reboot/FR, Non DFS channel will be selected and radio will switch to DFS Channel after 1 min.
-        if( (wifi_radio_oper_param->band == WIFI_FREQUENCY_5_BAND ) || ( wifi_radio_oper_param->band == WIFI_FREQUENCY_5L_BAND ) || ( wifi_radio_oper_param->band == WIFI_FREQUENCY_5H_BAND)) {
+        if ((wifi_radio_oper_param->band == WIFI_FREQUENCY_5_BAND) ||
+            (wifi_radio_oper_param->band == WIFI_FREQUENCY_5L_BAND) ||
+            (wifi_radio_oper_param->band == WIFI_FREQUENCY_5H_BAND)) {
             if (wifi_radio_oper_param->channel >= 52 && wifi_radio_oper_param->channel <= 144) {
                 if (mode == rdk_dev_mode_type_gw) {
                     dfs_channel_data_t *dfs_channel_data = (dfs_channel_data_t *)malloc(
@@ -483,9 +485,15 @@ int start_radios(rdk_dev_mode_type_t mode)
                     memset(dfs_channel_data, 0, sizeof(dfs_channel_data_t));
                     dfs_channel_data->radio_index = index;
                     dfs_channel_data->dfs_channel = wifi_radio_oper_param->channel;
-                    wifi_radio_oper_param->channel = 44;
-                    if ((is_wifi_channel_valid(wifi_prop, wifi_radio_oper_param->band, wifi_radio_oper_param->channel)) != RETURN_OK) {
-                        wifi_radio_oper_param->channel = dfs_fallback_channel(wifi_prop, wifi_radio_oper_param->band);
+                    if (wifi_radio_oper_param->band == WIFI_FREQUENCY_5H_BAND) {
+                        wifi_radio_oper_param->channel = 149;
+                    } else {
+                        wifi_radio_oper_param->channel = 44;
+                    }
+                    if ((is_wifi_channel_valid(wifi_prop, wifi_radio_oper_param->band,
+                            wifi_radio_oper_param->channel)) != RETURN_OK) {
+                        wifi_radio_oper_param->channel = dfs_fallback_channel(wifi_prop,
+                            wifi_radio_oper_param->band);
                     }
                     wifi_radio_oper_param->operatingClass = 1;
                     wifi_util_info_print(WIFI_CTRL,
@@ -494,17 +502,26 @@ int start_radios(rdk_dev_mode_type_t mode)
                     scheduler_add_timer_task(ctrl->sched, TRUE, NULL, switch_dfs_channel,
                         dfs_channel_data, (60 * 1000), 1, FALSE);
                 } else {
-                    wifi_radio_oper_param->channel = 36;
-                    if ((is_wifi_channel_valid(wifi_prop, wifi_radio_oper_param->band, wifi_radio_oper_param->channel)) != RETURN_OK) {
-                        wifi_radio_oper_param->channel = dfs_fallback_channel(wifi_prop, wifi_radio_oper_param->band);
+                    if (wifi_radio_oper_param->band == WIFI_FREQUENCY_5H_BAND) {
+                        wifi_radio_oper_param->channel = 149;
+                    } else {
+                        wifi_radio_oper_param->channel = 36;
+                    }
+                    if ((is_wifi_channel_valid(wifi_prop, wifi_radio_oper_param->band,
+                            wifi_radio_oper_param->channel)) != RETURN_OK) {
+                        wifi_radio_oper_param->channel = dfs_fallback_channel(wifi_prop,
+                            wifi_radio_oper_param->band);
                     }
                     wifi_radio_oper_param->operatingClass = 1;
                 }
             }
 
             if (strcmp(wifi_radio_oper_param->radarDetected, " ")) {
-                wifi_util_info_print(WIFI_CTRL,"%s:%d Triggering dfs_nop_start_timer for radar:%s \n",__func__, __LINE__, wifi_radio_oper_param->radarDetected);
-                scheduler_add_timer_task(ctrl->sched, FALSE, NULL, dfs_nop_start_timer, NULL, (60 * 1000), 1, FALSE);
+                wifi_util_info_print(WIFI_CTRL,
+                    "%s:%d Triggering dfs_nop_start_timer for radar:%s \n", __func__, __LINE__,
+                    wifi_radio_oper_param->radarDetected);
+                scheduler_add_timer_task(ctrl->sched, FALSE, NULL, dfs_nop_start_timer, NULL,
+                    (60 * 1000), 1, FALSE);
             }
         }
 


### PR DESCRIPTION
Impacted Platforms:
XLE

Reason for change: Issue with mesh backhaul and client conenctivity.

Test Procedure: Verify mesh backhaul and client connectivity.

Risks: Low

Priority: P1