### PR TITLE
Csi analytics app

### DIFF
--- a/source/apps/csi/wifi_csi_analytics.c
+++ b/source/apps/csi/wifi_csi_analytics.c
@@ -255,7 +255,7 @@ static int webconfig_hal_csi_data_apply(wifi_app_t *apps, webconfig_subdoc_decod
                 for (s_index = 0; s_index < new_csi_data->csi_client_count; s_index++) {
                     memset(mac_str, 0, MAX_MAC_STR_SIZE);
                     to_mac_str(new_csi_data->csi_client_list[s_index], mac_str);
-                    if (add_str_mac_addr(total_str_mac, mac_str) == RETURN_OK) {
+                    if (add_str_mac_addr(total_str_mac, mac_str) != RETURN_OK) {
                         break;
                     }
                 }


### PR DESCRIPTION
RDKB-60529:[OneWifi] Improvement of CSI Analytics APP
Reason for change: CSI Analytics App support has been implemented
                   for sniffing other motion subscriber data.

Test Procedure:1) Load the OneWifi build.
2) Check Wi-Fi CSI Analytics APP is enabled or not ?
    dmcli eRT getv Device.WiFi.CsiAnalytics
3) If it's not enabled then enable it.
    dmcli eRT setv Device.WiFi.CsiAnalytics bool true
4) Connect client device with private_vap.
5) Start Motion CSI Sounding with this client device.
6) This CSI Analytics APP sniff those CSI data packets.
7) CSI Analytics APP log message will be generated if a
   subcarrier mismatch is detected in the CSI data.

Priority: P0
Risks: Low

Signed-off-by: aniketnarsinhbhai_Patel@comcast.com