### PR TITLE
RDKB-60516: Onewifi restarts post upgrade to 8.2p1s1.

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4427,7 +4427,7 @@ static void wifidb_global_config_upgrade()
             RSS_MEM_THRESHOLD2_DEFAULT;
     }
 
-    if ((g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low) == 0 &&
+    if ((g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low) == 0 ||
         (g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high) == 0) {
         g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low =
             RSS_MEM_THRESHOLD1_DEFAULT;


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: Threshold variable names were different in 8.2p1s1, so
the values were fetched as zero.

Test Procedure:
1. Load CGM4331COM_8.1p7s1_DEV_sey image
2. CDL to CGM4331COM_8.2p1s1_DEV_sey and
3. Check for both the threshold values are proper and for onewifi restart due to selfheal script.

Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com