### PR TITLE
RDKB-60516: Onewifi restarts post upgrade to 8.2p1s1. (#477)

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -1137,7 +1137,6 @@ void callback_Wifi_Global_Config(ovsdb_update_monitor_t *mon,
 
     wifi_util_dbg_print(WIFI_DB,"%s:%d\n", __func__, __LINE__);
 
-
     if (mon->mon_type == OVSDB_UPDATE_DEL)
     {
         wifi_util_dbg_print(WIFI_DB,"%s:%d:Delete\n", __func__, __LINE__);
@@ -3070,8 +3069,9 @@ int wifidb_update_wifi_global_config(wifi_global_param_t *config)
         "inst_wifi_client_def_reporting_period %d wifi_active_msmt_enabled %d "
         "wifi_active_msmt_pktsize %d wifi_active_msmt_num_samples %d "
         "wifi_active_msmt_sample_duration %d vlan_cfg_version %d wps_pin %s "
-        "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d assoc_gate_time "
-        "%d assoc_monitor_duration %d rapid_reconnect_enable %d vap_stats_feature %d "
+        "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d assoc_gate_time %d "
+        "rss_memory_restart_threshold_low %d rss_memory_restart_threshold_high %d "
+        "assoc_monitor_duration %d rapid_reconnect_enable %d vap_stats_feature %d "
         "mfp_config_feature %d force_disable_radio_feature %d force_disable_radio_status %d "
         "fixed_wmm_params %d wifi_region_code %s diagnostic_enable %d validate_ssid %d "
         "device_network_mode:%d normalized_rssi_list %s snr_list %s cli_stat_list %s "
@@ -3085,6 +3085,7 @@ int wifidb_update_wifi_global_config(wifi_global_param_t *config)
         config->wifi_active_msmt_num_samples, config->wifi_active_msmt_sample_duration,
         config->vlan_cfg_version, config->wps_pin, config->bandsteering_enable,
         config->good_rssi_threshold, config->assoc_count_threshold, config->assoc_gate_time,
+        config->rss_memory_restart_threshold_low, config->rss_memory_restart_threshold_high,
         config->assoc_monitor_duration, config->rapid_reconnect_enable, config->vap_stats_feature,
         config->mfp_config_feature, config->force_disable_radio_feature,
         config->force_disable_radio_status, config->fixed_wmm_params, config->wifi_region_code,
@@ -3196,7 +3197,9 @@ int wifidb_get_wifi_global_config(wifi_global_param_t *config)
             "wifi_active_msmt_pktsize %d wifi_active_msmt_num_samples %d "
             "wifi_active_msmt_sample_duration %d vlan_cfg_version %d wps_pin %s "
             "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d "
-            "assoc_gate_time %d assoc_monitor_duration %d rapid_reconnect_enable %d "
+            "assoc_gate_time %d rss_memory_restart_threshold_low %d "
+            "rss_memory_restart_threshold_high %d "
+            "assoc_monitor_duration %d rapid_reconnect_enable %d "
             "vap_stats_feature %d mfp_config_feature %d force_disable_radio_feature %d "
             "force_disable_radio_status %d fixed_wmm_params %d wifi_region_code %s "
             "diagnostic_enable %d validate_ssid %d device_network_mode:%d normalized_rssi_list %s "
@@ -3211,6 +3214,7 @@ int wifidb_get_wifi_global_config(wifi_global_param_t *config)
             config->wifi_active_msmt_num_samples, config->wifi_active_msmt_sample_duration,
             config->vlan_cfg_version, config->wps_pin, config->bandsteering_enable,
             config->good_rssi_threshold, config->assoc_count_threshold, config->assoc_gate_time,
+            config->rss_memory_restart_threshold_low, config->rss_memory_restart_threshold_high,
             config->assoc_monitor_duration, config->rapid_reconnect_enable,
             config->vap_stats_feature, config->mfp_config_feature,
             config->force_disable_radio_feature, config->force_disable_radio_status,
@@ -4448,6 +4452,14 @@ static void wifidb_global_config_upgrade()
     if (g_wifidb->db_version < ONEWIFI_DB_VERSION_RSS_MEMORY_THRESHOLD_FLAG) {
         wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade global config, old db version %d \n", __func__,
             __LINE__, g_wifidb->db_version);
+        g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low =
+            RSS_MEM_THRESHOLD1_DEFAULT;
+        g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high =
+            RSS_MEM_THRESHOLD2_DEFAULT;
+    }
+
+    if ((g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low) == 0 ||
+        (g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high) == 0) {
         g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low =
             RSS_MEM_THRESHOLD1_DEFAULT;
         g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high =
@@ -7387,10 +7399,9 @@ void init_wifidb_data()
         remove_onewifi_factory_reset_reboot_flag();
         create_onewifi_fr_wifidb_reset_done_flag();
         wifi_util_info_print(WIFI_DB,"%s:%d FactoryReset done. wifidb updated with default values.\n",__func__, __LINE__);
-    }
-    else {
-        if (wifidb_get_rfc_config(0,rfc_param) != 0) {
-            wifi_util_error_print(WIFI_DB,"%s:%d: Error getting RFC config\n",__func__, __LINE__);
+    } else {
+        if (wifidb_get_rfc_config(0, rfc_param) != 0) {
+            wifi_util_error_print(WIFI_DB, "%s:%d: Error getting RFC config\n", __func__, __LINE__);
         }
 #ifdef ALWAYS_ENABLE_AX_2G
         wifidb_update_rfc_config(0, rfc_param);


### PR DESCRIPTION
* RDKB-36610: OW RESTART FIX

Impacted Platforms: All RDKB platforms.

Reason for change:

Test Procedure:

Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com

* RDKB-36610: OW RESTART FIX

Impacted Platforms: All RDKB platforms.

Reason for change:

Test Procedure:

Risks: Low

Priority: P1

Signed-off-by: sanjay_venkatesan@comcast.com

* RDKB-36610: OW RESTART FIX

Impacted Platforms: All RDKB platforms.

Reason for change:

Test Procedure:

Risks: Low

Priority: P1

Signed-off-by: sanjay_venkatesan@comcast.com

* RDKB-60516: [8.2p1s1] [Internals] Onewifi restarts post upgrade to 8.2p1s1

Impacted Platforms: All RDKB platforms.

Reason for change: threshold variable name was different in 8.2p1s1, so the values were fetched as zero.

Test Procedure:
1. Load CGM4331COM_8.1p7s1_DEV_sey image
2. CDL to CGM4331COM_8.2p1s1_DEV_sey and
3. Check for both the threshold values are proper and for onewifi restart.

Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com

* RDKB-60516: [8.2p1s1] [Internals] Onewifi restarts post upgrade to 8.2p1s1

Impacted Platforms: All RDKB platforms.

Reason for change: threshold variable name was different in 8.2p1s1, so the values were fetched as zero.

Test Procedure:
1. Load CGM4331COM_8.1p7s1_DEV_sey image
2. CDL to CGM4331COM_8.2p1s1_DEV_sey and
3. Check for both the threshold values are proper and for onewifi restart.

Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com

* RDKB-60516: [8.2p1s1] [Internals] Onewifi restarts post upgrade to 8.2p1s1

Impacted Platforms: All RDKB platforms.

Reason for change: threshold variable name was different in 8.2p1s1, so the values were fetched as zero.

Test Procedure:
1. Load CGM4331COM_8.1p7s1_DEV_sey image
2. CDL to CGM4331COM_8.2p1s1_DEV_sey and
3. Check for both the threshold values are proper and for onewifi restart.

Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com

* RDKB-60516: [8.2p1s1] [Internals] Onewifi restarts post upgrade to 8.2p1s1

Impacted Platforms: All RDKB platforms.

Reason for change: threshold variable name was different in 8.2p1s1, so the values were fetched as zero.

Test Procedure:
1. Load CGM4331COM_8.1p7s1_DEV_sey image
2. CDL to CGM4331COM_8.2p1s1_DEV_sey and
3. Check for both the threshold values are proper and for onewifi restart.

Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com

* Update wifi_db_apis.c

* Update wifi_db_apis.c

* Update wifi_db_apis.c

---------

Signed-off-by: sanjayvenkatesan1902@gmail.com
Signed-off-by: sanjay_venkatesan@comcast.com