### PR TITLE
RDKB-60405 Added scheduler timeout and updated channel scan params

### DIFF
--- a/source/stats/wifi_monitor.h
+++ b/source/stats/wifi_monitor.h
@@ -156,6 +156,8 @@ typedef struct {
     int scan_status[MAX_NUM_RADIOS];
     int scan_results_retries[MAX_NUM_RADIOS];
     int scan_trigger_retries[MAX_NUM_RADIOS];
+    struct timespec last_scan_time[MAX_NUM_RADIOS];
+    bool scan_failed[MAX_NUM_RADIOS];
     unsigned int        upload_period;
     unsigned int        current_poll_iter;
     instant_msmt_t      inst_msmt;

--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -32,7 +32,7 @@
 #define RADIO_SCAN_RESULT_INTERVAL 200 //200 ms
 #define RADIO_SCAN_MAX_RESULTS_RETRIES_FULL_SCAN 150 //30 seconds
 #define RADIO_SCAN_MAX_RESULTS_RETRIES_ON_AND_OFF_SCAN 35 //7 seconds
-#define NEIGHBOR_SCAN_RETRY_INTERVAL 45 //45ms
+#define NEIGHBOR_SCAN_RETRY_INTERVAL 100 //100ms
 #define NEIGHBOR_SCAN_MAX_RETRY 10
 
 int validate_radio_channel_args(wifi_mon_stats_args_t *args)
@@ -569,6 +569,7 @@ int retrigger_neighbor_scan(void *arg)
         ret = execute_radio_channel_api(c_elem, mon_data, c_elem->collector_task_interval_ms);
         if (ret != RETURN_OK) {
             mon_data->scan_trigger_retries[args->radio_index]++;
+            mon_data->scan_failed[args->radio_index] = true;
             scheduler_add_timer_task(mon_data->sched, FALSE, &id, retrigger_neighbor_scan, c_elem,
                 NEIGHBOR_SCAN_RETRY_INTERVAL, 1, FALSE);
             c_elem->u.radio_channel_neighbor_data.scan_trigger_task_id = id;
@@ -583,6 +584,16 @@ int retrigger_neighbor_scan(void *arg)
 
     mon_data->scan_status[args->radio_index] = 0;
     mon_data->scan_trigger_retries[args->radio_index] = 0;
+    if (mon_data->scan_failed[args->radio_index] == true) {
+        wifi_util_info_print(WIFI_MON,
+            "%s:%d  Previous scan failed. Updating Timeout Scan timeout for Radio %d \n", __func__,
+            __LINE__, args->radio_index);
+
+        scheduler_update_timeout(mon_data->sched, c_elem->collector_task_sched_id,
+            mon_data->last_scan_time[args->radio_index]);
+        mon_data->scan_failed[args->radio_index] = false;
+    }
+
     wifi_util_error_print(WIFI_MON,
         "%s:%d Failed to trigger scan for scan mode %d radio index %d\n", __func__, __LINE__,
         args->scan_mode, args->radio_index);
@@ -629,6 +640,7 @@ int check_scan_complete_read_results(void *arg)
         } else {
             if (mon_data->scan_trigger_retries[args->radio_index] < NEIGHBOR_SCAN_MAX_RETRY) {
                 mon_data->scan_trigger_retries[args->radio_index]++;
+                mon_data->scan_failed[args->radio_index] = true;
                 scheduler_add_timer_task(mon_data->sched, FALSE, &id, retrigger_neighbor_scan,
                     c_elem, NEIGHBOR_SCAN_RETRY_INTERVAL, 1, FALSE);
                 c_elem->u.radio_channel_neighbor_data.scan_trigger_task_id = id;
@@ -641,6 +653,16 @@ int check_scan_complete_read_results(void *arg)
         }
         mon_data->scan_trigger_retries[args->radio_index] = 0;
         mon_data->scan_status[args->radio_index] = 0;
+        if(mon_data->scan_failed[args->radio_index] == true) {
+            wifi_util_info_print(WIFI_MON,
+                "%s:%d  Previous scan failed. Updating Timeout Scan timeout for Radio %d \n", __func__,
+                __LINE__, args->radio_index);
+
+            scheduler_update_timeout(mon_data->sched, c_elem->collector_task_sched_id,
+                mon_data->last_scan_time[args->radio_index]);
+            mon_data->scan_failed[args->radio_index] = false;
+        }
+
         wifi_util_error_print(WIFI_MON,
             "%s : %d  Failed to get Neighbor wifi status for scan mode %d radio index %d\n",
             __func__, __LINE__, args->scan_mode, args->radio_index);
@@ -651,6 +673,15 @@ int check_scan_complete_read_results(void *arg)
         __LINE__, args->scan_mode, args->radio_index);
     mon_data->scan_status[args->radio_index] = 0;
     mon_data->scan_trigger_retries[args->radio_index] = 0;
+    if (mon_data->scan_failed[args->radio_index] == true) {
+        wifi_util_info_print(WIFI_MON,
+            "%s:%d  Previous scan failed. Updating Timeout Scan timeout for Radio %d \n", __func__,
+            __LINE__, args->radio_index);
+
+        scheduler_update_timeout(mon_data->sched, c_elem->collector_task_sched_id,
+            mon_data->last_scan_time[args->radio_index]);
+        mon_data->scan_failed[args->radio_index] = false;
+    }
 
     //Update Neighbour Cache
     pthread_mutex_lock(&mon_data->data_lock);
@@ -911,10 +942,12 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
     mon_data->scan_results_retries[args->radio_index] = 0;
     int private_vap_index = getPrivateApFromRadioIndex(args->radio_index);
     ret = wifi_startNeighborScan(private_vap_index, args->scan_mode, dwell_time, num_channels, (unsigned int *)channels);
+    clock_gettime(CLOCK_MONOTONIC, &(mon_data->last_scan_time[args->radio_index]));
     if (ret != RETURN_OK) {
         mon_data->scan_trigger_retries[args->radio_index]++;
+        mon_data->scan_failed[args->radio_index] = true;
         scheduler_add_timer_task(mon_data->sched, FALSE, &id, retrigger_neighbor_scan, c_elem,
-            NEIGHBOR_SCAN_RETRY_INTERVAL, 1, FALSE);
+            NEIGHBOR_SCAN_RETRY_INTERVAL, 1, TRUE);
         c_elem->u.radio_channel_neighbor_data.scan_trigger_task_id = id;
         wifi_util_dbg_print(WIFI_MON,
             "%s:%d  Retry (%d) to trigger scan for scan mode %d radio index %d\n", __func__,
@@ -922,6 +955,7 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
             args->radio_index);
         return RETURN_OK;
     }
+
     scheduler_add_timer_task(mon_data->sched, FALSE, &id, check_scan_complete_read_results, c_elem,
             RADIO_SCAN_RESULT_INTERVAL/2, 1, FALSE);
     c_elem->u.radio_channel_neighbor_data.scan_complete_task_id = id;

--- a/source/utils/scheduler.c
+++ b/source/utils/scheduler.c
@@ -447,6 +447,28 @@ int scheduler_execute(struct scheduler *sched, struct timespec t_start, unsigned
     return 0;
 }
 
+int scheduler_update_timeout(struct scheduler *sched, int id, struct timespec new_time) {
+    unsigned int i;
+    struct timer_task *tt;
+
+    if (sched == NULL) {
+        return -1;
+    }
+    for (i = 0; i < sched->num_tasks; i++) {
+        tt = queue_peek(sched->timer_list, i);
+        if (tt != NULL && tt->id == id) {
+            timespecadd(&new_time, &(tt->interval), &(tt->timeout));
+        }
+    }
+    for (i = 0; i < sched->num_hp_tasks; i++) {
+        tt = queue_peek(sched->high_priority_timer_list, i);
+        if (tt != NULL && tt->id == id) {
+            timespecadd(&new_time, &(tt->interval), &(tt->timeout));
+        }
+    }
+    return 0;
+}
+
 static int scheduler_calculate_timeout(struct scheduler *sched, struct timespec t_now)
 {
     unsigned int i;

--- a/source/utils/scheduler.h
+++ b/source/utils/scheduler.h
@@ -148,6 +148,17 @@ int scheduler_execute(struct scheduler *sched, struct timespec t_start, unsigned
   */
 int scheduler_free_timer_task_arg(struct scheduler *sched, int id);
 
+/* Description:
+  *      This API is used to update timeout value, to delay the event
+  * Arguments:
+  *      sched - Pointer to the scheduler struct
+  *      id - unique identifier to denote the timer task
+  *      new_time - Time at which previous event was executed
+  * Returns:
+  *       Returns 0 on Success, -1 on Failure
+  */
+int scheduler_update_timeout(struct scheduler *sched, int id, struct timespec new_time);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Impacted Platforms:
Tech-XB7, TXB8, XB10, CBRv2

Reason for change: Added scheduler timeout function and updated Channel scan interval

Test Procedure: Set DFS Channel and check if on channel scan is failing Risks: Low
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com