### PR TITLE
RDKB-61233: Easymesh - WiFi 7 Integration

### DIFF
--- a/include/webconfig_external_proto_easymesh.h
+++ b/include/webconfig_external_proto_easymesh.h
@@ -43,6 +43,10 @@ typedef em_sta_info_t * (*ext_proto_get_sta_info_t)(void *data_model, mac_addres
 typedef void (*ext_proto_put_sta_info_t)(void *data_model, em_sta_info_t *sta_info, em_target_sta_map_t target);
 typedef em_bss_info_t * (*ext_proto_em_get_bss_info_with_mac_t)(void *data_model, mac_address_t mac);
 typedef void (*ext_proto_put_scan_results_t)(void *data_model, em_scan_result_t *scan_result);
+typedef void (*ext_proto_update_ap_mld_info_t)(void *data_model, em_ap_mld_info_t *ap_mld_info);
+typedef void (*ext_proto_update_bsta_mld_info_t)(void *data_model, em_bsta_mld_info_t *bsta_mld_info);
+typedef void (*ext_proto_update_assoc_sta_mld_info_t)(void *data_model, em_assoc_sta_mld_info_t *assoc_sta_mld_info);
+typedef em_ap_mld_info_t * (*ext_proto_get_ap_mld_frm_bssid_t)(void *data_model, mac_address_t bss_id);
 
 typedef struct {
     void *data_model; /* agent data model dm_easy_mesh_t */
@@ -68,6 +72,10 @@ typedef struct {
     ext_proto_put_sta_info_t   put_sta_info;
     ext_proto_em_get_bss_info_with_mac_t   get_bss_info_with_mac;
     ext_proto_put_scan_results_t put_scan_results;
+    ext_proto_update_ap_mld_info_t update_ap_mld_info;
+    ext_proto_update_bsta_mld_info_t update_bsta_mld_info;
+    ext_proto_update_assoc_sta_mld_info_t update_assoc_sta_mld_info;
+    ext_proto_get_ap_mld_frm_bssid_t get_ap_mld_frm_bssid; 
 } webconfig_external_easymesh_t;
 
 void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *data_model, void *m2ctrl_vapconfig, void *policy_config,
@@ -79,7 +87,9 @@ void webconfig_proto_easymesh_init(webconfig_external_easymesh_t *proto, void *d
         ext_proto_em_get_bss_info_t get_bss, ext_proto_em_get_op_class_info_t get_op_class,
         ext_proto_get_first_sta_info_t get_first_sta, ext_proto_get_next_sta_info_t get_next_sta,
         ext_proto_get_sta_info_t get_sta, ext_proto_put_sta_info_t put_sta, ext_proto_em_get_bss_info_with_mac_t get_bss_info_with_mac,
-        ext_proto_put_scan_results_t put_scan_results);
+        ext_proto_put_scan_results_t put_scan_results, ext_proto_update_ap_mld_info_t update_ap_mld_info,
+        ext_proto_update_bsta_mld_info_t update_bsta_mld_info, ext_proto_update_assoc_sta_mld_info_t update_assoc_sta_mld_info,
+        ext_proto_get_ap_mld_frm_bssid_t get_ap_mld_frm_bssid);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
RDKB-61233: Easymesh - WiFi 7 Integration

Reason for change: Add support for WiFi 7 SLO/MLO in Easymesh.
Test Procedure: Ensure basic easymesh configuration and client connectivity works for wifi7 clients.
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>