### PR TITLE
RDKB-60777: OneWifi sends ACK immediately instead of sending it after enabling it.

### DIFF
--- a/include/wifi_webconfig.h
+++ b/include/wifi_webconfig.h
@@ -97,13 +97,6 @@ typedef struct {
 } webconfig_error_map_t;
 
 typedef enum {
-    webconfig_hotspot_blob,
-    webconfig_managed_wifi_blob,
-    webconfig_private_blob,
-    webconfig_home_blob
-} webconfig_blob_type_t;
-
-typedef enum {
     webconfig_subdoc_type_unknown,
     webconfig_subdoc_type_private,
     webconfig_subdoc_type_null,

--- a/include/wifi_webconfig.h
+++ b/include/wifi_webconfig.h
@@ -97,6 +97,13 @@ typedef struct {
 } webconfig_error_map_t;
 
 typedef enum {
+    webconfig_hotspot_blob,
+    webconfig_managed_wifi_blob,
+    webconfig_private_blob,
+    webconfig_home_blob
+} webconfig_blob_type_t;
+
+typedef enum {
     webconfig_subdoc_type_unknown,
     webconfig_subdoc_type_private,
     webconfig_subdoc_type_null,

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -2032,12 +2032,12 @@ void managed_wifi_cfg_sem_signal(bool status)
     wifi_sem_param_signal(&ctrl->managed_wifi_sem_param, status);
 }
 
-bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec, webconfig_blob_type_t blob_type)
+bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_type_t subdoc_type)
 {
     wifi_ctrl_t *ctrl = get_wifictrl_obj();
 
-    if (blob_type != webconfig_managed_wifi_blob) {
-        wifi_util_info_print(WIFI_CTRL,"%s:%d - blob_type:%d not supported\n", __func__, __LINE__, blob_type);
+    if (subdoc_type != webconfig_subdoc_type_lnf) {
+        wifi_util_info_print(WIFI_CTRL,"%s:%d - subdoc_type:%d not supported\n", __func__, __LINE__, subdoc_type);
         return true;
     }
 

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -2035,14 +2035,14 @@ bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec)
     return status;
 }
 
-bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_type_t subdoc_type)
+bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec, webconfig_blob_type_t blob_type)
 {
     struct timespec ts;
     int ret;
     bool status = false;
 
-    if (subdoc_type != webconfig_subdoc_type_lnf) {
-        wifi_util_info_print(WIFI_CTRL,"%s:%d - subdoc_type:%d not supported\n", __func__, __LINE__, subdoc_type);
+    if (blob_type != webconfig_managed_wifi_blob) {
+        wifi_util_info_print(WIFI_CTRL,"%s:%d - blob_type:%d not supported\n", __func__, __LINE__, blob_type);
         return true;
     }
 

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1975,7 +1975,7 @@ void start_wifi_sched_timer(unsigned int index, wifi_ctrl_t *l_ctrl, wifi_schedu
 
 static void wifi_sem_param_init(wifi_sem_param_t *sem_param)
 {
-    if (!sem_param->is_init) {
+    if (sem_param && !sem_param->is_init) {
         pthread_condattr_t cond_attr;
         pthread_condattr_init(&cond_attr);
         pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
@@ -1989,7 +1989,7 @@ static void wifi_sem_param_init(wifi_sem_param_t *sem_param)
 
 static void wifi_sem_param_destroy(wifi_sem_param_t *sem_param)
 {
-    if (sem_param->is_init) {
+    if (sem_param && sem_param->is_init) {
         pthread_mutex_destroy(&sem_param->lock);
         pthread_cond_destroy(&sem_param->cond);
         sem_param->is_init = false;
@@ -2021,7 +2021,7 @@ static bool wifi_sem_param_wait(wifi_sem_param_t *sem_param, uint32_t time_in_se
 
 static void wifi_sem_param_signal(wifi_sem_param_t *sem_param, bool status)
 {
-    if (sem_param->is_init) {
+    if (sem_param && sem_param->is_init) {
         pthread_mutex_lock(&sem_param->lock);
         sem_param->cfg_status = status;
         pthread_cond_signal(&sem_param->cond);
@@ -2036,15 +2036,9 @@ void managed_wifi_cfg_sem_signal(bool status)
     wifi_sem_param_signal(&ctrl->managed_wifi_sem_param, status);
 }
 
-bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_type_t subdoc_type)
+bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec)
 {
     wifi_ctrl_t *ctrl = get_wifictrl_obj();
-
-    if (subdoc_type != webconfig_subdoc_type_lnf) {
-        wifi_util_info_print(WIFI_CTRL,"%s:%d - subdoc_type:%d not supported\n", __func__, __LINE__, subdoc_type);
-        return true;
-    }
-
     wifi_util_info_print(WIFI_CTRL, "%s:%d - time_in_sec:%d\n", __func__, __LINE__, time_in_sec);
     return wifi_sem_param_wait(&ctrl->managed_wifi_sem_param, time_in_sec);
 }

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -2031,11 +2031,16 @@ bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec)
     return status;
 }
 
-bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec)
+bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_type_t subdoc_type)
 {
     struct timespec ts;
     int ret;
     bool status = false;
+
+    if (subdoc_type != webconfig_subdoc_type_lnf) {
+        wifi_util_info_print(WIFI_CTRL,"%s:%d - subdoc_type:%d not supported\n", __func__, __LINE__, subdoc_type);
+        return true;
+    }
 
     wifi_ctrl_t *ctrl = NULL;
     wifi_util_info_print(WIFI_CTRL, "%s:%d Inside the function\n", __func__, __LINE__);

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1969,115 +1969,92 @@ void start_wifi_sched_timer(unsigned int index, wifi_ctrl_t *l_ctrl, wifi_schedu
     }
 }
 
-void hotspot_cfg_sem_signal(bool status)
+static void wifi_sem_param_init(wifi_sem_param_t *sem_param)
 {
-    wifi_ctrl_t *ctrl = NULL;
+    if (!sem_param->is_init) {
+        pthread_condattr_t cond_attr;
+        pthread_condattr_init(&cond_attr);
+        pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
+        pthread_cond_init(&sem_param->cond, &cond_attr);
+        pthread_condattr_destroy(&cond_attr);
+        pthread_mutex_init(&sem_param->lock, NULL);
+        sem_param->is_init = true;
+        sem_param->cfg_status = false;
+    }
+}
 
-    ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
+static void wifi_sem_param_destroy(wifi_sem_param_t *sem_param)
+{
+    if (sem_param->is_init) {
+        pthread_mutex_destroy(&sem_param->lock);
+        pthread_cond_destroy(&sem_param->cond);
+        sem_param->is_init = false;
+    }
+}
 
-    if (ctrl->hotspot_sem_param.is_init == true) {
-        pthread_mutex_lock(&ctrl->hotspot_sem_param.lock);
-        ctrl->hotspot_sem_param.cfg_status = status;
-        pthread_cond_signal(&ctrl->hotspot_sem_param.cond);
-        pthread_mutex_unlock(&ctrl->hotspot_sem_param.lock);
+static bool wifi_sem_param_wait(wifi_sem_param_t *sem_param, uint32_t time_in_sec)
+{
+    struct timespec ts;
+    int ret;
+    bool status = false;
+
+    wifi_sem_param_init(sem_param);
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    ts.tv_sec += time_in_sec;
+
+    pthread_mutex_lock(&sem_param->lock);
+    ret = pthread_cond_timedwait(&sem_param->cond, &sem_param->lock, &ts);
+    if (ret == 0) {
+        status = sem_param->cfg_status;
+    }
+    pthread_mutex_unlock(&sem_param->lock);
+
+    wifi_sem_param_destroy(sem_param);
+
+    return status;
+}
+
+static void wifi_sem_param_signal(wifi_sem_param_t *sem_param, bool status)
+{
+    if (sem_param->is_init) {
+        pthread_mutex_lock(&sem_param->lock);
+        sem_param->cfg_status = status;
+        pthread_cond_signal(&sem_param->cond);
+        pthread_mutex_unlock(&sem_param->lock);
     }
 }
 
 void managed_wifi_cfg_sem_signal(bool status)
 {
+    wifi_ctrl_t *ctrl = get_wifictrl_obj();
     wifi_util_info_print(WIFI_CTRL, "%s:%d - status:%d\n", __func__, __LINE__, status);
-    wifi_ctrl_t *ctrl = NULL;
-    ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
-    if (ctrl->managed_wifi_sem_param.is_init == true) {
-        pthread_mutex_lock(&ctrl->managed_wifi_sem_param.lock);
-        ctrl->managed_wifi_sem_param.cfg_status = status;
-        wifi_util_info_print(WIFI_CTRL, "%s:%d - status:%d and returning the conditional signal\n", __func__, __LINE__, ctrl->managed_wifi_sem_param.cfg_status);
-        pthread_cond_signal(&ctrl->managed_wifi_sem_param.cond);
-        pthread_mutex_unlock(&ctrl->managed_wifi_sem_param.lock);
-    }
-}
-
-bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec)
-{
-    struct timespec ts;
-    int ret;
-    bool status = false;
-
-    wifi_ctrl_t *ctrl = NULL;
-
-    ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
-    if (ctrl->hotspot_sem_param.is_init == false) {
-        pthread_condattr_t  cond_attr;
-        pthread_condattr_init(&cond_attr);
-        pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
-        pthread_cond_init(&ctrl->hotspot_sem_param.cond, &cond_attr);
-        pthread_condattr_destroy(&cond_attr);
-        pthread_mutex_init(&ctrl->hotspot_sem_param.lock, NULL);
-        ctrl->hotspot_sem_param.is_init = true;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-
-    /* Add wait duration*/
-    ts.tv_sec += time_in_sec;
-
-    pthread_mutex_lock(&ctrl->hotspot_sem_param.lock);
-    ret = pthread_cond_timedwait(&ctrl->hotspot_sem_param.cond, &ctrl->hotspot_sem_param.lock, &ts);
-    if (ret == 0) {
-        status = ctrl->hotspot_sem_param.cfg_status;
-    }
-
-    pthread_mutex_unlock(&ctrl->hotspot_sem_param.lock);
-
-    ctrl->hotspot_sem_param.is_init = false;
-    pthread_mutex_destroy(&ctrl->hotspot_sem_param.lock);
-    pthread_cond_destroy(&ctrl->hotspot_sem_param.cond);
-
-    return status;
+    wifi_sem_param_signal(&ctrl->managed_wifi_sem_param, status);
 }
 
 bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec, webconfig_blob_type_t blob_type)
 {
-    struct timespec ts;
-    int ret;
-    bool status = false;
+    wifi_ctrl_t *ctrl = get_wifictrl_obj();
 
     if (blob_type != webconfig_managed_wifi_blob) {
         wifi_util_info_print(WIFI_CTRL,"%s:%d - blob_type:%d not supported\n", __func__, __LINE__, blob_type);
         return true;
     }
 
-    wifi_ctrl_t *ctrl = NULL;
-    wifi_util_info_print(WIFI_CTRL, "%s:%d Inside the function\n", __func__, __LINE__);
-    ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
-    if (ctrl->managed_wifi_sem_param.is_init == false) {
-        pthread_condattr_t cond_attr;
-        pthread_condattr_init(&cond_attr);
-        pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
-        pthread_cond_init(&ctrl->managed_wifi_sem_param.cond, &cond_attr);
-        pthread_condattr_destroy(&cond_attr);
-        pthread_mutex_init(&ctrl->managed_wifi_sem_param.lock, NULL);
-        ctrl->managed_wifi_sem_param.is_init = true;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    ts.tv_sec += time_in_sec;
-    wifi_util_info_print(WIFI_CTRL, "%s:%d - time_in_sec:%d\r\n", __func__, __LINE__, time_in_sec);
-    pthread_mutex_lock(&ctrl->managed_wifi_sem_param.lock);
-    ret = pthread_cond_timedwait(
-        &ctrl->managed_wifi_sem_param.cond,
-        &ctrl->managed_wifi_sem_param.lock,
-        &ts
-    );
-    if (ret == 0) {
-        wifi_util_info_print(WIFI_CTRL, "%s:%d - ret:%d and status:%d\n", __func__, __LINE__, ret, ctrl->managed_wifi_sem_param.cfg_status);
-        status = ctrl->managed_wifi_sem_param.cfg_status;
-    }
-    pthread_mutex_unlock(&ctrl->managed_wifi_sem_param.lock);
-    wifi_util_info_print(WIFI_CTRL, "%s:%d - status:%d\n", __func__, __LINE__, status);
-    ctrl->managed_wifi_sem_param.is_init = false;
-    pthread_mutex_destroy(&ctrl->managed_wifi_sem_param.lock);
-    pthread_cond_destroy(&ctrl->managed_wifi_sem_param.cond);
+    wifi_util_info_print(WIFI_CTRL, "%s:%d - time_in_sec:%d\n", __func__, __LINE__, time_in_sec);
+    return wifi_sem_param_wait(&ctrl->managed_wifi_sem_param, time_in_sec);
+}
 
-    return status;
+bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec)
+{
+    wifi_ctrl_t *ctrl = get_wifictrl_obj();
+    return wifi_sem_param_wait(&ctrl->hotspot_sem_param, time_in_sec);
+}
+
+void hotspot_cfg_sem_signal(bool status)
+{
+    wifi_ctrl_t *ctrl = get_wifictrl_obj();
+    wifi_sem_param_signal(&ctrl->hotspot_sem_param, status);
 }
 
 void stop_wifi_sched_timer(unsigned int index, wifi_ctrl_t *l_ctrl, wifi_scheduler_type_t type)

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -2037,7 +2037,8 @@ bool managed_wifi_cfg_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_t
     wifi_ctrl_t *ctrl = get_wifictrl_obj();
 
     if (subdoc_type != webconfig_subdoc_type_lnf) {
-        wifi_util_info_print(WIFI_CTRL,"%s:%d - subdoc_type:%d not supported\n", __func__, __LINE__, subdoc_type);
+        wifi_util_info_print(WIFI_CTRL, "%s:%d - subdoc_type:%d not supported\n", __func__,
+            __LINE__, subdoc_type);
         return true;
     }
 

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -218,13 +218,6 @@ typedef struct hotspot_cfg_sem_param {
     bool cfg_status;
 } hotspot_cfg_sem_param_t;
 
-typedef struct hotspot_cfg_sem_param {
-    bool is_init;
-    pthread_mutex_t lock;
-    pthread_cond_t cond;
-    bool cfg_status;
-} managed_wifi_cfg_sem_param_t;
-
 typedef struct wifi_ctrl {
     bool                exit_ctrl;
     queue_t             *queue;

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -211,12 +211,12 @@ typedef struct {
     pthread_mutex_t      events_bus_lock;
 } events_bus_data_t;
 
-typedef struct hotspot_cfg_sem_param {
+typedef struct {
     bool is_init;
     pthread_mutex_t lock;
     pthread_cond_t cond;
     bool cfg_status;
-} hotspot_cfg_sem_param_t;
+} wifi_sem_param_t;
 
 typedef struct wifi_ctrl {
     bool                exit_ctrl;
@@ -264,10 +264,9 @@ typedef struct wifi_ctrl {
     int                 speed_test_timeout;
     int                 speed_test_running;
     events_bus_data_t   events_bus_data;
-    hotspot_cfg_sem_param_t hotspot_sem_param;
-    hotspot_cfg_sem_param_t managed_wifi_sem_param;
+    wifi_sem_param_t    hotspot_sem_param;
+    wifi_sem_param_t    managed_wifi_sem_param;
 } wifi_ctrl_t;
-
 
 typedef struct {
     mac_address_t sta_mac;

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -403,7 +403,7 @@ int webconfig_send_full_associate_status(wifi_ctrl_t *ctrl);
 
 bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec);
 void hotspot_cfg_sem_signal(bool status);
-bool managed_wifi_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_type_t subdoc_type);
+bool managed_wifi_sem_wait_duration(uint32_t time_in_sec);
 void managed_wifi_sem_signal(bool status);
 
 #ifdef __cplusplus

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -404,7 +404,7 @@ int webconfig_send_full_associate_status(wifi_ctrl_t *ctrl);
 
 bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec);
 void hotspot_cfg_sem_signal(bool status);
-bool managed_wifi_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_type_t subdoc_type);
+bool managed_wifi_sem_wait_duration(uint32_t time_in_sec, webconfig_blob_type_t blob_type);
 void managed_wifi_sem_signal(bool status);
 
 #ifdef __cplusplus

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -403,7 +403,7 @@ int webconfig_send_full_associate_status(wifi_ctrl_t *ctrl);
 
 bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec);
 void hotspot_cfg_sem_signal(bool status);
-bool managed_wifi_sem_wait_duration(uint32_t time_in_sec, webconfig_blob_type_t blob_type);
+bool managed_wifi_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_type_t subdoc_type);
 void managed_wifi_sem_signal(bool status);
 
 #ifdef __cplusplus

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -95,6 +95,7 @@ extern "C" {
 
 #define MAX_HOTSPOT_BLOB_SET_TIMEOUT             100
 #define MAX_WEBCONFIG_HOTSPOT_BLOB_SET_TIMEOUT   120
+#define MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT        30
 #define MAX_VAP_RE_CFG_APPLY_RETRY     2
 
 //This is a dummy string if the value is not passed.
@@ -217,6 +218,13 @@ typedef struct hotspot_cfg_sem_param {
     bool cfg_status;
 } hotspot_cfg_sem_param_t;
 
+typedef struct hotspot_cfg_sem_param {
+    bool is_init;
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    bool cfg_status;
+} managed_wifi_cfg_sem_param_t;
+
 typedef struct wifi_ctrl {
     bool                exit_ctrl;
     queue_t             *queue;
@@ -264,6 +272,7 @@ typedef struct wifi_ctrl {
     int                 speed_test_running;
     events_bus_data_t   events_bus_data;
     hotspot_cfg_sem_param_t hotspot_sem_param;
+    hotspot_cfg_sem_param_t managed_wifi_sem_param;
 } wifi_ctrl_t;
 
 

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -404,6 +404,8 @@ int webconfig_send_full_associate_status(wifi_ctrl_t *ctrl);
 
 bool hotspot_cfg_sem_wait_duration(uint32_t time_in_sec);
 void hotspot_cfg_sem_signal(bool status);
+bool managed_wifi_sem_wait_duration(uint32_t time_in_sec, webconfig_subdoc_type_t subdoc_type);
+void managed_wifi_sem_signal(bool status);
 
 #ifdef __cplusplus
 }

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -2372,6 +2372,9 @@ webconfig_error_t webconfig_ctrl_apply(webconfig_subdoc_t *doc, webconfig_subdoc
                     ctrl->webconfig_state |= ctrl_webconfig_state_vap_lnf_cfg_rsp_pending;
                     webconfig_analytic_event_data_to_hal_apply(data);
                     ret = webconfig_hal_lnf_vap_apply(ctrl, &data->u.decoded);
+                    bool status = ((ret == RETURN_OK) ? true : false);
+                    wifi_util_info_print(WIFI_CTRL,":%s:%d lnf blob cfg status:%d\n", __func__, __LINE__, ret);
+                    managed_wifi_cfg_sem_signal(status);
                 }
             }
         break;

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -2373,7 +2373,8 @@ webconfig_error_t webconfig_ctrl_apply(webconfig_subdoc_t *doc, webconfig_subdoc
                     webconfig_analytic_event_data_to_hal_apply(data);
                     ret = webconfig_hal_lnf_vap_apply(ctrl, &data->u.decoded);
                     bool status = ((ret == RETURN_OK) ? true : false);
-                    wifi_util_info_print(WIFI_CTRL,":%s:%d lnf blob cfg status:%d\n", __func__, __LINE__, ret);
+                    wifi_util_info_print(WIFI_CTRL, "%s:%d lnf blob cfg status:%d\n", __func__,
+                        __LINE__, ret);
                     managed_wifi_cfg_sem_signal(status);
                 }
             }

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -49,7 +49,7 @@ size_t wifi_vap_cfg_timeout_handler()
 
 size_t webconf_managed_wifi_timeout_handler()
 {
-    wifi_util_info_print(WIFI_CTRL, "%s: Enter max blob timeout value:%d\n", __func__, MAX_WEBCONFIG_MANAGED_WIFI_BLOB_SET_TIMEOUT);
+    wifi_util_info_print(WIFI_CTRL, "%s: Enter max blob timeout value:%d\n", __func__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
     return MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT;
 }
 

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -81,7 +81,7 @@ static int update_vap_info(void *data, wifi_vap_info_t *vap_info, pErr execRetVa
 static int update_vap_info_managed_guest(void *data, void *amenities_blob, wifi_vap_info_t *vap_info, int radio_index,bool connected_building_enabled, pErr execRetVal);
 static int update_vap_info_managed_xfinity(void *data, wifi_vap_info_t *vap_info,pErr execRetVal);
 static int update_vap_info_with_blob_info(void *blob, void *amenities_blob, webconfig_subdoc_data_t *data, const char *vap_prefix, bool managed_wifi, pErr execRetVal);
-static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t subdoc_type, webconfig_blob_type_t blob_type);
+static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t subdoc_type);
 static pErr create_execRetVal(void);
 static pErr private_home_exec_common_handler(void *blob, const char *vap_prefix, webconfig_subdoc_type_t subdoc_type);
 static int validate_private_home_ssid_param(char *str, pErr execRetVal);
@@ -683,7 +683,7 @@ static int update_vap_info_with_blob_info(void *blob, void *amenities_blob, webc
 
     return status;
 }
-static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t subdoc_type, webconfig_blob_type_t blob_type)
+static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t subdoc_type)
 {
     char *str;
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
@@ -697,7 +697,7 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d:SREESH Encoded blob:\n%s\n", __func__, __LINE__, str);
     push_event_to_ctrl_queue(str, strlen(str), wifi_event_type_webconfig, wifi_event_webconfig_set_data_webconfig, NULL);
     wifi_util_info_print(WIFI_CTRL, "%s:%d:SREESH Doing a thread wait for the managed wifi blob for %d seconds\n", __func__, __LINE__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
-    ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT, blob_type);
+    ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT, subdoc_type);
     if (ret == false)
     {
         wifi_util_info_print(WIFI_CTRL,"%s:%d WebConfig blob is applied failure\n", __func__, __LINE__);
@@ -712,7 +712,6 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
 static pErr private_home_exec_common_handler(void *blob, const char *vap_prefix, webconfig_subdoc_type_t subdoc_type)
 {
     pErr execRetVal = NULL;
-    webconfig_blob_type_t blob_type;
     webconfig_subdoc_data_t *data = NULL;
     if (blob == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s: Null blob\n", __func__);
@@ -739,9 +738,8 @@ static pErr private_home_exec_common_handler(void *blob, const char *vap_prefix,
         execRetVal->ErrorCode = VALIDATION_FALIED;
         goto done;
     }
-    blob_type = (subdoc_type == webconfig_subdoc_type_private) ? webconfig_private_blob : webconfig_home_blob;
 
-    if (push_blob_data(data, subdoc_type, blob_type) != RETURN_OK) {
+    if (push_blob_data(data, subdoc_type) != RETURN_OK) {
         execRetVal->ErrorCode = WIFI_HAL_FAILURE;
         strncpy(execRetVal->ErrorMsg, "push_blob_to_ctrl_queue failed", sizeof(execRetVal->ErrorMsg)-1);
         wifi_util_error_print(WIFI_CTRL, "%s: failed to encode %s subdoc\n", \

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -1478,8 +1478,7 @@ static int connected_subdoc_handler(void *blob, void *amenities_blob, char *vap_
         wifi_util_error_print(WIFI_CTRL, "%s: failed to encode %s subdoc\n", \
                               __func__, (subdoc_type == webconfig_subdoc_type_lnf) ? "lnf_psk" : "xfinity");
         goto done;
-    }
-    else if(ret == RETURN_TIMEDOUT) {
+    } else if(ret == RETURN_TIMEDOUT) {
         execRetVal->ErrorCode = BLOB_EXECUTION_TIMEDOUT;
         strncpy(execRetVal->ErrorMsg, "subdoc apply is failed", sizeof(execRetVal->ErrorMsg)-1);
         wifi_util_error_print(WIFI_CTRL, "%s:%d WebConfig blob apply is failed:%s\n", __func__,

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -783,7 +783,7 @@ static int connected_subdoc_handler(void *blob, void *amenities_blob, char *vap_
         execRetVal->ErrorCode = VALIDATION_FALIED;
         goto done;
     }
-    ret = push_blob_data(data, subdoc_type, webconfig_managed_wifi_blob);
+    ret = push_blob_data(data, subdoc_type);
     if (ret == RETURN_ERR) {
         execRetVal->ErrorCode = WIFI_HAL_FAILURE;
         strncpy(execRetVal->ErrorMsg, "push_blob_to_ctrl_queue failed", sizeof(execRetVal->ErrorMsg)-1);

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -1380,12 +1380,12 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
             webconfig_data_free(data);
             return RETURN_TIMEDOUT;
         }
-    } else {
+    } else if(subdoc_type == webconfig_subdoc_type_xfinity) {
         wifi_util_dbg_print(WIFI_CTRL, "%s:%d Not managed wifi, proceeding with hotspot wait\n",
             __func__, __LINE__);
 
-        bool ret_value = hotspot_cfg_sem_wait_duration(MAX_HOTSPOT_BLOB_SET_TIMEOUT);
-        if (ret_value == false) {
+        ret = hotspot_cfg_sem_wait_duration(MAX_HOTSPOT_BLOB_SET_TIMEOUT);
+        if (ret == false) {
             wifi_util_error_print(WIFI_CTRL, "%s:%d Hotspot blob apply failed\n", __func__,
                 __LINE__);
             webconfig_data_free(data);
@@ -1394,6 +1394,7 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
         webconfig_data_free(data);
         return RETURN_OK;
     }
+    return RETURN_OK;
 }
 
 static pErr private_home_exec_common_handler(void *blob, const char *vap_prefix, webconfig_subdoc_type_t subdoc_type)

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -47,9 +47,10 @@ size_t wifi_vap_cfg_timeout_handler()
     return MAX_WEBCONFIG_HOTSPOT_BLOB_SET_TIMEOUT;
 }
 
-size_t webconf_managed_wifi_timeout_handler()
+static size_t webconf_managed_wifi_timeout_handler()
 {
-    wifi_util_info_print(WIFI_CTRL, "%s: Enter max blob timeout value:%d\n", __func__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
+    wifi_util_info_print(WIFI_CTRL, "%s: Enter max blob timeout value:%d\n", __func__, 
+            MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
     return MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT;
 }
 
@@ -688,19 +689,18 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
     char *str;
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     bool ret = true;
+
     if (webconfig_encode(&ctrl->webconfig, data, subdoc_type) != webconfig_error_none) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d - Failed webconfig_encode for subdoc type %d\n", __FUNCTION__, __LINE__, subdoc_type);
         return RETURN_ERR;
     }
 
     str = data->u.encoded.raw;
-    wifi_util_dbg_print(WIFI_CTRL, "%s:%d:SREESH Encoded blob:\n%s\n", __func__, __LINE__, str);
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d:Encoded blob:\n%s\n", __func__, __LINE__, str);
     push_event_to_ctrl_queue(str, strlen(str), wifi_event_type_webconfig, wifi_event_webconfig_set_data_webconfig, NULL);
-    wifi_util_info_print(WIFI_CTRL, "%s:%d:SREESH Doing a thread wait for the managed wifi blob for %d seconds\n", __func__, __LINE__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
     ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT, subdoc_type);
-    if (ret == false)
-    {
-        wifi_util_info_print(WIFI_CTRL,"%s:%d WebConfig blob is applied failure\n", __func__, __LINE__);
+    if (ret == false) {
+        wifi_util_info_print(WIFI_CTRL, "%s:%d WebConfig blob apply failure\n", __func__, __LINE__);
         webconfig_data_free(data);
         return RETURN_TIMEDOUT;
     }

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -81,7 +81,7 @@ static int update_vap_info(void *data, wifi_vap_info_t *vap_info, pErr execRetVa
 static int update_vap_info_managed_guest(void *data, void *amenities_blob, wifi_vap_info_t *vap_info, int radio_index,bool connected_building_enabled, pErr execRetVal);
 static int update_vap_info_managed_xfinity(void *data, wifi_vap_info_t *vap_info,pErr execRetVal);
 static int update_vap_info_with_blob_info(void *blob, void *amenities_blob, webconfig_subdoc_data_t *data, const char *vap_prefix, bool managed_wifi, pErr execRetVal);
-static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t subdoc_type);
+static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t subdoc_type, webconfig_blob_type_t blob_type);
 static pErr create_execRetVal(void);
 static pErr private_home_exec_common_handler(void *blob, const char *vap_prefix, webconfig_subdoc_type_t subdoc_type);
 static int validate_private_home_ssid_param(char *str, pErr execRetVal);
@@ -683,7 +683,7 @@ static int update_vap_info_with_blob_info(void *blob, void *amenities_blob, webc
 
     return status;
 }
-static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t subdoc_type)
+static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t subdoc_type, webconfig_blob_type_t blob_type)
 {
     char *str;
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
@@ -697,7 +697,7 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d:SREESH Encoded blob:\n%s\n", __func__, __LINE__, str);
     push_event_to_ctrl_queue(str, strlen(str), wifi_event_type_webconfig, wifi_event_webconfig_set_data_webconfig, NULL);
     wifi_util_info_print(WIFI_CTRL, "%s:%d:SREESH Doing a thread wait for the managed wifi blob for %d seconds\n", __func__, __LINE__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
-    ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT, subdoc_type);
+    ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT, blob_type);
     if (ret == false)
     {
         wifi_util_info_print(WIFI_CTRL,"%s:%d WebConfig blob is applied failure\n", __func__, __LINE__);
@@ -712,6 +712,7 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
 static pErr private_home_exec_common_handler(void *blob, const char *vap_prefix, webconfig_subdoc_type_t subdoc_type)
 {
     pErr execRetVal = NULL;
+    webconfig_blob_type_t blob_type;
     webconfig_subdoc_data_t *data = NULL;
     if (blob == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s: Null blob\n", __func__);
@@ -738,8 +739,9 @@ static pErr private_home_exec_common_handler(void *blob, const char *vap_prefix,
         execRetVal->ErrorCode = VALIDATION_FALIED;
         goto done;
     }
+    blob_type = (subdoc_type == webconfig_subdoc_type_private) ? webconfig_private_blob : webconfig_home_blob;
 
-    if (push_blob_data(data, subdoc_type) != RETURN_OK) {
+    if (push_blob_data(data, subdoc_type, blob_type) != RETURN_OK) {
         execRetVal->ErrorCode = WIFI_HAL_FAILURE;
         strncpy(execRetVal->ErrorMsg, "push_blob_to_ctrl_queue failed", sizeof(execRetVal->ErrorMsg)-1);
         wifi_util_error_print(WIFI_CTRL, "%s: failed to encode %s subdoc\n", \
@@ -783,7 +785,7 @@ static int connected_subdoc_handler(void *blob, void *amenities_blob, char *vap_
         execRetVal->ErrorCode = VALIDATION_FALIED;
         goto done;
     }
-    ret = push_blob_data(data, subdoc_type);
+    ret = push_blob_data(data, subdoc_type, webconfig_managed_wifi_blob);
     if (ret == RETURN_ERR) {
         execRetVal->ErrorCode = WIFI_HAL_FAILURE;
         strncpy(execRetVal->ErrorMsg, "push_blob_to_ctrl_queue failed", sizeof(execRetVal->ErrorMsg)-1);

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -1359,13 +1359,13 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
     }
 
     str = data->u.encoded.raw;
-    wifi_util_dbg_print(WIFI_CTRL, "%s:%d:SREESH Encoded blob:\n%s\n", __func__, __LINE__, str);
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d:Encoded blob:\n%s\n", __func__, __LINE__, str);
     push_event_to_ctrl_queue(str, strlen(str), wifi_event_type_webconfig,
         wifi_event_webconfig_set_data_webconfig, NULL);
 
     if (subdoc_type == webconfig_subdoc_type_lnf) {
         wifi_util_info_print(WIFI_CTRL,
-            "%s:%d:SREESH Doing a thread wait for the managed wifi blob for %d seconds\n", __func__,
+            "%s:%d: Doing a thread wait for the managed wifi blob for %d seconds\n", __func__,
             __LINE__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
         ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
 
@@ -1380,7 +1380,7 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
             webconfig_data_free(data);
             return RETURN_TIMEDOUT;
         }
-    } else if(subdoc_type == webconfig_subdoc_type_xfinity) {
+    } else if (subdoc_type == webconfig_subdoc_type_xfinity) {
         wifi_util_dbg_print(WIFI_CTRL, "%s:%d Not managed wifi, proceeding with hotspot wait\n",
             __func__, __LINE__);
 
@@ -1394,6 +1394,7 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
         webconfig_data_free(data);
         return RETURN_OK;
     }
+    webconfig_data_free(data);
     return RETURN_OK;
 }
 

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -696,10 +696,8 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
     str = data->u.encoded.raw;
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d:SREESH Encoded blob:\n%s\n", __func__, __LINE__, str);
     push_event_to_ctrl_queue(str, strlen(str), wifi_event_type_webconfig, wifi_event_webconfig_set_data_webconfig, NULL);
-    if (subdoc_type == webconfig_subdoc_type_lnf){
-        wifi_util_info_print(WIFI_CTRL, "%s:%d:SREESH Doing a thread wait for the managed wifi blob for %d seconds\n", __func__, __LINE__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
-        ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
-    }
+    wifi_util_info_print(WIFI_CTRL, "%s:%d:SREESH Doing a thread wait for the managed wifi blob for %d seconds\n", __func__, __LINE__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
+    ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT, subdoc_type);
     if (ret == false)
     {
         wifi_util_info_print(WIFI_CTRL,"%s:%d WebConfig blob is applied failure\n", __func__, __LINE__);

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -700,7 +700,7 @@ static int push_blob_data(webconfig_subdoc_data_t *data, webconfig_subdoc_type_t
         wifi_util_info_print(WIFI_CTRL, "%s:%d:SREESH Doing a thread wait for the managed wifi blob for %d seconds\n", __func__, __LINE__, MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
         ret = managed_wifi_cfg_sem_wait_duration(MAX_MANAGED_WIFI_BLOB_SET_TIMEOUT);
     }
-    if (ret_value == false)
+    if (ret == false)
     {
         wifi_util_info_print(WIFI_CTRL,"%s:%d WebConfig blob is applied failure\n", __func__, __LINE__);
         webconfig_data_free(data);


### PR DESCRIPTION
Make the WebConfig Amenity thread wait and signal it only after appropriately enabling LnF VAPs.