### PR TITLE
RDKB-0 : Max-Queue value increased 

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1186,8 +1186,11 @@ int mgmt_wifi_frame_recv(int ap_index, mac_address_t sta_mac, uint8_t *frame, ui
                 break;
         }
     }
-
+    if (evt_subtype != ctrl_event_hal_unknown_frame) {
     push_event_to_ctrl_queue((frame_data_t *)&mgmt_frame, sizeof(mgmt_frame), wifi_event_type_hal_ind, evt_subtype, NULL);
+    } else {
+        wifi_util_dbg_print(WIFI_CTRL,"%s:%d: Unknown frame type received! skipped push_event_to_ctrl_queue, ap_index:%d, type:%d\n", __func__, __LINE__, ap_index, type);
+    }
     return RETURN_OK;
 }
 #endif

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -116,7 +116,7 @@ extern "C" {
 
 #define BUS_DML_CONFIG_FILE "bus_dml_config.json"
 
-#define CTRL_QUEUE_SIZE_MAX 500
+#define CTRL_QUEUE_SIZE_MAX (700 * getNumberRadios())
 
 typedef enum {
     ctrl_webconfig_state_none = 0,

--- a/source/core/wifi_events.c
+++ b/source/core/wifi_events.c
@@ -191,7 +191,31 @@ const char *wifi_event_subtype_to_string(wifi_event_subtype_t type)
 
     return "unknown event";
 }
-
+bool is_important_event(wifi_event_subtype_t sub_type)
+{
+    switch (sub_type) {
+    case wifi_event_type_notify_monitor_done:
+    case wifi_event_type_command_factory_reset:
+    case wifi_event_type_command_wps:
+    case wifi_event_type_command_wps_cancel:
+    case wifi_event_type_eth_bh_status:
+    case wifi_event_type_xfinity_enable:
+    case wifi_event_type_prefer_private_rfc:
+    case wifi_event_webconfig_br_report:
+    case wifi_event_radius_eap_failure:
+    case wifi_event_monitor_connect:
+    case wifi_event_monitor_disconnect:
+    case wifi_event_monitor_deauthenticate:
+    case wifi_event_monitor_auth_req:
+    case wifi_event_monitor_assoc_req:
+    case wifi_event_exec_start:
+    case wifi_event_exec_stop:
+    case wifi_event_exec_timeout:
+        return true;
+    default:
+        return false;
+    }
+}
 void free_cloned_event(wifi_event_t *clone)
 {
     destroy_wifi_event(clone);
@@ -699,7 +723,7 @@ int push_monitor_response_event_to_ctrl_queue(const void *msg, unsigned int len,
 
         pthread_mutex_lock(&ctrl->queue_lock);
         is_limit_reached = queue_count(ctrl->queue) >= CTRL_QUEUE_SIZE_MAX;
-        if (!is_limit_reached) {
+        if (!is_limit_reached || is_important_event(sub_type)) {
             queue_push(ctrl->queue, event);
             pthread_cond_signal(&ctrl->cond);
         }
@@ -707,7 +731,7 @@ int push_monitor_response_event_to_ctrl_queue(const void *msg, unsigned int len,
 
         if (is_limit_reached) {
             wifi_util_error_print(WIFI_CTRL,
-                "%s:%d max queue size reached, drop message type: %s subtype: %s\n", __FUNCTION__,
+                "%s:%d MAX-QUEUE size reached, DROP message type: %s subtype: %s\n", __FUNCTION__,
                 __LINE__, wifi_event_type_to_string(type), wifi_event_subtype_to_string(sub_type));
             destroy_wifi_event(event);
             return RETURN_ERR;
@@ -755,7 +779,7 @@ int push_event_to_ctrl_queue(const void *msg, unsigned int len, wifi_event_type_
 
     pthread_mutex_lock(&ctrl->queue_lock);
     is_limit_reached = queue_count(ctrl->queue) >= CTRL_QUEUE_SIZE_MAX;
-    if (!is_limit_reached) {
+    if (!is_limit_reached || is_important_event(sub_type)) {
         queue_push(ctrl->queue, event);
         pthread_cond_signal(&ctrl->cond);
     }
@@ -763,7 +787,7 @@ int push_event_to_ctrl_queue(const void *msg, unsigned int len, wifi_event_type_
 
     if (is_limit_reached) {
         wifi_util_error_print(WIFI_CTRL,
-            "%s:%d max queue size reached, drop message type: %s subtype: %s\n", __FUNCTION__,
+            "%s:%d MAX-QUEUE size reached, DROP message type: %s subtype: %s\n", __FUNCTION__,
             __LINE__, wifi_event_type_to_string(type), wifi_event_subtype_to_string(sub_type));
         destroy_wifi_event(event);
         return RETURN_ERR;
@@ -807,14 +831,14 @@ int push_event_to_monitor_queue(wifi_monitor_data_t *mon_data, wifi_event_subtyp
 
     pthread_mutex_lock(&monitor_param->queue_lock);
     is_limit_reached = queue_count(monitor_param->queue) >= MONITOR_QUEUE_SIZE_MAX;
-    if (!is_limit_reached) {
+    if (!is_limit_reached || is_important_event(sub_type)) {
         queue_push(monitor_param->queue, event);
         pthread_cond_signal(&monitor_param->cond);
     }
     pthread_mutex_unlock(&monitor_param->queue_lock);
 
     if (is_limit_reached) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d max queue size reached, drop message subtype: %s\n",
+        wifi_util_error_print(WIFI_CTRL, "%s:%d MAX-QUEUE size reached, DROP message subtype: %s\n",
             __FUNCTION__, __LINE__, wifi_event_subtype_to_string(sub_type));
         destroy_wifi_event(event);
         return RETURN_ERR;

--- a/source/core/wifi_events.c
+++ b/source/core/wifi_events.c
@@ -191,23 +191,15 @@ const char *wifi_event_subtype_to_string(wifi_event_subtype_t type)
 
     return "unknown event";
 }
-bool is_important_event(wifi_event_subtype_t sub_type)
+bool is_high_priority_event(wifi_event_subtype_t sub_type)
 {
     switch (sub_type) {
     case wifi_event_type_notify_monitor_done:
     case wifi_event_type_command_factory_reset:
-    case wifi_event_type_command_wps:
-    case wifi_event_type_command_wps_cancel:
     case wifi_event_type_eth_bh_status:
     case wifi_event_type_xfinity_enable:
     case wifi_event_type_prefer_private_rfc:
     case wifi_event_webconfig_br_report:
-    case wifi_event_radius_eap_failure:
-    case wifi_event_monitor_connect:
-    case wifi_event_monitor_disconnect:
-    case wifi_event_monitor_deauthenticate:
-    case wifi_event_monitor_auth_req:
-    case wifi_event_monitor_assoc_req:
     case wifi_event_exec_start:
     case wifi_event_exec_stop:
     case wifi_event_exec_timeout:
@@ -723,7 +715,7 @@ int push_monitor_response_event_to_ctrl_queue(const void *msg, unsigned int len,
 
         pthread_mutex_lock(&ctrl->queue_lock);
         is_limit_reached = queue_count(ctrl->queue) >= CTRL_QUEUE_SIZE_MAX;
-        if (!is_limit_reached || is_important_event(sub_type)) {
+        if (!is_limit_reached || is_high_priority_event(sub_type)) {
             queue_push(ctrl->queue, event);
             pthread_cond_signal(&ctrl->cond);
         }
@@ -779,7 +771,7 @@ int push_event_to_ctrl_queue(const void *msg, unsigned int len, wifi_event_type_
 
     pthread_mutex_lock(&ctrl->queue_lock);
     is_limit_reached = queue_count(ctrl->queue) >= CTRL_QUEUE_SIZE_MAX;
-    if (!is_limit_reached || is_important_event(sub_type)) {
+    if (!is_limit_reached || is_high_priority_event(sub_type)) {
         queue_push(ctrl->queue, event);
         pthread_cond_signal(&ctrl->cond);
     }
@@ -831,7 +823,7 @@ int push_event_to_monitor_queue(wifi_monitor_data_t *mon_data, wifi_event_subtyp
 
     pthread_mutex_lock(&monitor_param->queue_lock);
     is_limit_reached = queue_count(monitor_param->queue) >= MONITOR_QUEUE_SIZE_MAX;
-    if (!is_limit_reached || is_important_event(sub_type)) {
+    if (!is_limit_reached || is_high_priority_event(sub_type)) {
         queue_push(monitor_param->queue, event);
         pthread_cond_signal(&monitor_param->cond);
     }

--- a/source/stats/wifi_monitor.h
+++ b/source/stats/wifi_monitor.h
@@ -30,7 +30,7 @@
 
 #define  ANSC_STATUS_SUCCESS                        0
 
-#define MONITOR_QUEUE_SIZE_MAX 500
+#define MONITOR_QUEUE_SIZE_MAX (700 * getNumberRadios())
 
 typedef struct {
     unsigned int        rapid_reconnect_threshold;


### PR DESCRIPTION
Impacted Platforms: All platforms

Reason for change: Increase Max-Queue values & avoid flooding in queues

Test Procedure:  check wifictrl.txt logs for max-queue drop msg

Priority: P1

Risks: Low