### PR TITLE
RDKB-60904 Enable Force reset flag if SSID is defaulted

### DIFF
--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -33,7 +33,7 @@ force_reset_subdoc=0
 onewifi_last_restart=0
 webcfg_rfc_enabled=""
 
-SW_UPGRADE_DEFAULT_FILE="/nvram/sw_upgrade_private_defaults"
+SW_UPGRADE_DEFAULT_FILE="/tmp/sw_upgrade_private_defaults"
 wave_driver_restart_cnt=0
 bss_queue_full=0
 bss_queue_full_cnt=0

--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -33,7 +33,7 @@ force_reset_subdoc=0
 onewifi_last_restart=0
 webcfg_rfc_enabled=""
 
-SW_UPGRADE_DEFAULT_FILE="/tmp/sw_upgrade_private_defaults"
+SW_UPGRADE_DEFAULT_FILE="/nvram/sw_upgrade_private_defaults"
 wave_driver_restart_cnt=0
 bss_queue_full=0
 bss_queue_full_cnt=0

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -831,7 +831,7 @@ int start_wifi_services(void)
         start_radios(rdk_dev_mode_type_gw);
         start_gateway_vaps();
         captive_portal_check();
-#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_)
+#if !defined(_SR213_PRODUCT_REQ_)
         /* Function to check for default SSID and Passphrase for Private VAPS
         if they are default and last-reboot reason is SW get the previous config from Webconfig */
         validate_and_sync_private_vap_credentials();

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -834,6 +834,7 @@ int start_wifi_services(void)
 #if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_)
         /* Function to check for default SSID and Passphrase for Private VAPS
         if they are default and last-reboot reason is SW get the previous config from Webconfig */
+        wifi_util_info_print(WIFI_CTRL, "%s:%d calling validate_and_sync_private_vap_credentials \n",__func__, __LINE__);
         validate_and_sync_private_vap_credentials();
 #endif
 
@@ -1684,7 +1685,7 @@ int validate_and_sync_private_vap_credentials()
                     "[%s:%d] bus: bus_set_string_fn error in setting: %s\n", __func__, __LINE__,
                     SUBDOC_FORCE_RESET);
                 get_stubs_descriptor()->v_secure_system_fn(
-                    "touch /tmp/sw_upgrade_private_defaults");
+                    "touch /nvram/sw_upgrade_private_defaults");
                 get_bus_descriptor()->bus_data_free_fn(&data);
                 return RETURN_ERR;
             }

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -834,7 +834,6 @@ int start_wifi_services(void)
 #if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_)
         /* Function to check for default SSID and Passphrase for Private VAPS
         if they are default and last-reboot reason is SW get the previous config from Webconfig */
-        wifi_util_info_print(WIFI_CTRL, "%s:%d calling validate_and_sync_private_vap_credentials \n",__func__, __LINE__);
         validate_and_sync_private_vap_credentials();
 #endif
 
@@ -1685,7 +1684,7 @@ int validate_and_sync_private_vap_credentials()
                     "[%s:%d] bus: bus_set_string_fn error in setting: %s\n", __func__, __LINE__,
                     SUBDOC_FORCE_RESET);
                 get_stubs_descriptor()->v_secure_system_fn(
-                    "touch /nvram/sw_upgrade_private_defaults");
+                    "touch /tmp/sw_upgrade_private_defaults");
                 get_bus_descriptor()->bus_data_free_fn(&data);
                 return RETURN_ERR;
             }

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -831,7 +831,7 @@ int start_wifi_services(void)
         start_radios(rdk_dev_mode_type_gw);
         start_gateway_vaps();
         captive_portal_check();
-#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_) &&
+#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_) && \
         (defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_))
         /* Function to check for default SSID and Passphrase for Private VAPS
         if they are default and last-reboot reason is SW get the previous config from Webconfig */

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -831,7 +831,8 @@ int start_wifi_services(void)
         start_radios(rdk_dev_mode_type_gw);
         start_gateway_vaps();
         captive_portal_check();
-#if !defined(_SR213_PRODUCT_REQ_)
+#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_) &&
+        (defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_))
         /* Function to check for default SSID and Passphrase for Private VAPS
         if they are default and last-reboot reason is SW get the previous config from Webconfig */
         validate_and_sync_private_vap_credentials();

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1684,7 +1684,7 @@ int validate_and_sync_private_vap_credentials()
                     "[%s:%d] bus: bus_set_string_fn error in setting: %s\n", __func__, __LINE__,
                     SUBDOC_FORCE_RESET);
                 get_stubs_descriptor()->v_secure_system_fn(
-                    "touch /tmp/sw_upgrade_private_defaults");
+                    "touch /nvram/sw_upgrade_private_defaults");
                 get_bus_descriptor()->bus_data_free_fn(&data);
                 return RETURN_ERR;
             }

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1684,7 +1684,7 @@ int validate_and_sync_private_vap_credentials()
                     "[%s:%d] bus: bus_set_string_fn error in setting: %s\n", __func__, __LINE__,
                     SUBDOC_FORCE_RESET);
                 get_stubs_descriptor()->v_secure_system_fn(
-                    "touch /nvram/sw_upgrade_private_defaults");
+                    "touch /tmp/sw_upgrade_private_defaults");
                 get_bus_descriptor()->bus_data_free_fn(&data);
                 return RETURN_ERR;
             }


### PR DESCRIPTION
Impacted Platforms:
XB7, XB8, XB10

Reason for change: If SSID is defaulted, Force reset flag should be enabled to push private subdoc to the GW.

Test Procedure: Check if force reset flag in tmp dir exists in if SSID is default during bootup

Risks: Low
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com