### PR TITLE
RDKB-61031: ignore exists flag change for GW STA interface

### DIFF
--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -821,7 +821,7 @@ int webconfig_hal_vap_apply_by_name(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_
         // Ignore exists flag change because STA interfaces always enabled in HAL. This allows to
         // avoid redundant reconfiguration with STA disconnection.
         // For pods, STA is just like any other AP interface, deletion is allowed.
-        if (ctrl->network_mode == rdk_dev_mode_type_ext && isVapSTAMesh(tgt_vap_index)) {
+        if (isVapSTAMesh(tgt_vap_index)) {
             mgr_rdk_vap_info->exists = rdk_vap_info->exists;
         }
 


### PR DESCRIPTION
Reason for change: mesh cloud pushes delete of radio/STA interfaces.
    Delete will set exists flag to false and trigger radio
    reconfiguration. Reconfiguration disconnects all clients.
    We can ignore exists flag change because radio/STA interfaces
    should be always enabled and flag is only required for
    Wifi_VIF_Config and Wifi_VIF_State sync.
Test Procedure:
Risks: Low
Priority: P1