### PR TITLE
RDKB-60901: Xfinitywifi clients are unable to connect onewi…

### DIFF
--- a/source/apps/cac/wifi_cac.c
+++ b/source/apps/cac/wifi_cac.c
@@ -284,7 +284,7 @@ int cac_event_exec_timeout(wifi_app_t *apps, void *arg)
     int chan_util = 0;
     cac_status_t status = status_ok;
     assoc_dev_data_t *assoc_dev_data = NULL;
-    int itr, itrj;
+    unsigned int itr, itrj;
     wifi_mgr_t *mgr = (wifi_mgr_t *)get_wifimgr_obj();
     bool found = false;
     char *str;
@@ -381,17 +381,29 @@ int cac_event_exec_timeout(wifi_app_t *apps, void *arg)
             get_radio_data(radio_index, &chan_stats);
 
             if (client->sampling_interval == 0 && client->sampling_count != 0) {
-                for (itr=0; itr<MAX_NUM_RADIOS; itr++) {
-                    for (itrj=0; itrj<MAX_NUM_VAP_PER_RADIO; itrj++) {
+                for (itr = 0; itr < getNumberRadios(); itr++) {
+                    for (itrj = 0; itrj < getMaxNumberVAPsPerRadio(itr); itrj++) {
+                        if (mgr->radio_config[itr]
+                                .vaps.rdk_vap_array[itrj]
+                                .associated_devices_lock == NULL) {
+                            continue;
+                        }
                         pthread_mutex_lock(mgr->radio_config[itr]
-                                               .vaps.rdk_vap_array[itrj]
-                                               .associated_devices_lock);
-                        if (mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map != NULL && !found) {
-                            assoc_dev_data = hash_map_get_first(mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map);
+                                .vaps.rdk_vap_array[itrj]
+                                .associated_devices_lock);
+                        if (mgr->radio_config[itr]
+                                    .vaps.rdk_vap_array[itrj]
+                                    .associated_devices_map != NULL &&
+                            !found) {
+                            assoc_dev_data = hash_map_get_first(mgr->radio_config[itr]
+                                    .vaps.rdk_vap_array[itrj]
+                                    .associated_devices_map);
                             while (assoc_dev_data != NULL) {
                                 get_sta_stats_info(assoc_dev_data);
                                 if (((unsigned int)assoc_dev_data->ap_index == client->ap_index) &&
-                                    (memcmp(client->sta_mac,assoc_dev_data->dev_stats.cli_MACAddress,sizeof(mac_address_t))== 0 )) {
+                                    (memcmp(client->sta_mac,
+                                         assoc_dev_data->dev_stats.cli_MACAddress,
+                                         sizeof(mac_address_t)) == 0)) {
                                     found = true;
 
                                     if (assoc_dev_data != NULL) {
@@ -412,12 +424,15 @@ int cac_event_exec_timeout(wifi_app_t *apps, void *arg)
                                     }
                                     break;
                                 }
-                                assoc_dev_data = hash_map_get_next(mgr->radio_config[itr].vaps.rdk_vap_array[itrj].associated_devices_map, assoc_dev_data);
+                                assoc_dev_data = hash_map_get_next(mgr->radio_config[itr]
+                                                                       .vaps.rdk_vap_array[itrj]
+                                                                       .associated_devices_map,
+                                    assoc_dev_data);
                             }
                         }
                         pthread_mutex_unlock(mgr->radio_config[itr]
-                                                 .vaps.rdk_vap_array[itrj]
-                                                 .associated_devices_lock);
+                                .vaps.rdk_vap_array[itrj]
+                                .associated_devices_lock);
                     }
                 }
 


### PR DESCRIPTION
…fi crash

Reason for change: Remove access to not initialized variables.
Test Procedure: onewifi crash shouldn't happen while connecting xfinitywifi clients
Risks: Low
Priority: P1