### PR TITLE
RDKBWIFI44-45: Translate read-only vap_mode and vap_index to easymesh and allow passwordless station encoding/decoding

### DIFF
--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -1246,7 +1246,7 @@ webconfig_error_t decode_open_radius_object(const cJSON *radius, wifi_radius_set
 }
 
 webconfig_error_t decode_security_object(const cJSON *security, wifi_vap_security_t *security_info,
-    int band)
+    int band, wifi_vap_mode_t vap_mode)
 {
     const cJSON *param, *object;
 
@@ -1430,14 +1430,17 @@ webconfig_error_t decode_security_object(const cJSON *security, wifi_vap_securit
         return webconfig_error_none;
     }
 
-    decode_param_string(security, "Passphrase", param);
+    decode_param_allow_empty_string(security, "Passphrase", param);
 
-    if (security_info->mode != wifi_security_mode_none &&
-        (strlen(param->valuestring) < MIN_PWD_LEN || strlen(param->valuestring) > MAX_PWD_LEN)) {
-        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d invalid password length: %d\n", __func__,
-            __LINE__, strlen(param->valuestring));
-        return webconfig_error_decode;
+    if (vap_mode != wifi_vap_mode_sta) {
+        if (security_info->mode != wifi_security_mode_none &&
+            (strlen(param->valuestring) < MIN_PWD_LEN || strlen(param->valuestring) > MAX_PWD_LEN)) {
+            wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d invalid password length: %d\n", __func__,
+                __LINE__, strlen(param->valuestring));
+            return webconfig_error_decode;
+        }
     }
+
 
     strncpy(security_info->u.key.key, param->valuestring, sizeof(security_info->u.key.key) - 1);
 
@@ -1818,7 +1821,7 @@ webconfig_error_t decode_hotspot_open_vap_object(const cJSON *vap, wifi_vap_info
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.bss_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.bss_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
@@ -1863,7 +1866,7 @@ webconfig_error_t decode_hotspot_secure_vap_object(const cJSON *vap, wifi_vap_in
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.bss_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.bss_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
@@ -1905,7 +1908,7 @@ webconfig_error_t decode_lnf_psk_vap_object(const cJSON *vap, wifi_vap_info_t *v
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.bss_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.bss_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
@@ -1950,7 +1953,7 @@ webconfig_error_t decode_lnf_radius_vap_object(const cJSON *vap, wifi_vap_info_t
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.bss_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.bss_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
@@ -1996,7 +1999,7 @@ webconfig_error_t decode_iot_vap_object(const cJSON *vap, wifi_vap_info_t *vap_i
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.bss_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.bss_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
@@ -2042,7 +2045,7 @@ webconfig_error_t decode_mesh_backhaul_vap_object(const cJSON *vap, wifi_vap_inf
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.bss_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.bss_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
@@ -2088,7 +2091,7 @@ webconfig_error_t decode_private_vap_object(const cJSON *vap, wifi_vap_info_t *v
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.bss_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.bss_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
@@ -2142,7 +2145,7 @@ webconfig_error_t decode_wifiapi_vap_object(const cJSON *vap, wifi_vap_info_t *v
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.bss_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.bss_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }
@@ -2249,7 +2252,7 @@ webconfig_error_t decode_mesh_sta_object(const cJSON *vap, wifi_vap_info_t *vap_
     }
 
     decode_param_object(vap, "Security", security);
-    if (decode_security_object(security, &vap_info->u.sta_info.security, band) != webconfig_error_none) {
+    if (decode_security_object(security, &vap_info->u.sta_info.security, band, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Security objects validation failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_decode;
     }

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -504,8 +504,11 @@ webconfig_error_t translate_vap_info_to_em_common(const wifi_vap_info_t *vap, co
         return webconfig_error_translate_to_easymesh;
     }
 
+    vap_row->vap_mode = em_vap_mode_ap;
+
     vap_row->enabled = vap->u.bss_info.enabled;
     strncpy(vap_row->ssid, vap->u.bss_info.ssid, sizeof(vap_row->ssid));
+    vap_row->vap_index = vap->vap_index;
 
     // Set the em_bss_info_t vendor_elements to the same as wifi_vap_info_t vendor_elements
     memset(vap_row->vendor_elements, 0, sizeof(vap_row->vendor_elements));
@@ -927,7 +930,11 @@ webconfig_error_t translate_sta_info_to_em_common(const wifi_vap_info_t *vap, co
     }
     default_em_bss_info(vap_row);
 
+    vap_row->vap_mode = em_vap_mode_sta;
+
     vap_row->enabled = vap->u.sta_info.enabled;
+    vap_row->vap_index = vap->vap_index;
+    wifi_util_info_print(WIFI_WEBCONFIG, "%s:%d: vap_index %d vap_name %s\n", __func__, __LINE__, vap->vap_index, vap->vap_name);
 
     // Copy basic info
     strncpy(vap_row->ssid, vap->u.sta_info.ssid, sizeof(vap->u.sta_info.ssid));

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -1077,7 +1077,7 @@ webconfig_error_t encode_radius_object(const wifi_radius_settings_t *radius_info
 }
 
 webconfig_error_t encode_security_object(const wifi_vap_security_t *security_info, cJSON *security,
-    bool is_6g)
+    bool is_6g, wifi_vap_mode_t vap_mode)
 {
     cJSON *obj;
 
@@ -1271,12 +1271,14 @@ webconfig_error_t encode_security_object(const wifi_vap_security_t *security_inf
         return webconfig_error_none;
     }
 
-    if (security_info->mode != wifi_security_mode_none &&
-        (strlen(security_info->u.key.key) < MIN_PWD_LEN ||
-        strlen(security_info->u.key.key) > MAX_PWD_LEN)) {
-        wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d invalid password length: %d\n", __func__,
-            __LINE__, strlen(security_info->u.key.key));
-        return webconfig_error_encode;
+    if (vap_mode != wifi_vap_mode_sta) {
+        if (security_info->mode != wifi_security_mode_none &&
+            (strlen(security_info->u.key.key) < MIN_PWD_LEN ||
+            strlen(security_info->u.key.key) > MAX_PWD_LEN)) {
+            wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d invalid password length: %d\n", __func__,
+                __LINE__, strlen(security_info->u.key.key));
+            return webconfig_error_encode;
+        }
     }
 
     cJSON_AddBoolToObject(security, "Wpa3_transition_disable",
@@ -1313,7 +1315,7 @@ webconfig_error_t encode_hotspot_open_vap_object(const wifi_vap_info_t *vap_info
     is_6g = strstr(vap_info->vap_name, "6g") ? true : false;
     obj = cJSON_CreateObject();
     cJSON_AddItemToObject(vap_obj, "Security", obj);
-    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g) != webconfig_error_none) {
+    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Security object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }
@@ -1362,7 +1364,7 @@ webconfig_error_t encode_hotspot_secure_vap_object(const wifi_vap_info_t *vap_in
     is_6g = strstr(vap_info->vap_name, "6g") ? true : false;
     obj = cJSON_CreateObject();
     cJSON_AddItemToObject(vap_obj, "Security", obj);
-    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g) != webconfig_error_none) {
+    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Security object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }
@@ -1405,7 +1407,7 @@ webconfig_error_t encode_lnf_psk_vap_object(const wifi_vap_info_t *vap_info,
 
     obj = cJSON_CreateObject();
     cJSON_AddItemToObject(vap_obj, "Security", obj);
-    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g) != webconfig_error_none) {
+    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Security object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }
@@ -1436,7 +1438,7 @@ webconfig_error_t encode_lnf_radius_vap_object(const wifi_vap_info_t *vap_info,
     is_6g = strstr(vap_info->vap_name, "6g") ? true : false;
     obj = cJSON_CreateObject();
     cJSON_AddItemToObject(vap_obj, "Security", obj);
-    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g) != webconfig_error_none) {
+    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Security object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }
@@ -1466,7 +1468,7 @@ webconfig_error_t encode_mesh_backhaul_vap_object(const wifi_vap_info_t *vap_inf
     bool is_6g = strstr(vap_info->vap_name, "6g")?true:false;
     obj = cJSON_CreateObject();
     cJSON_AddItemToObject(vap_obj, "Security", obj);
-    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g) != webconfig_error_none) {
+    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Security object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }
@@ -1496,7 +1498,7 @@ webconfig_error_t encode_iot_vap_object(const wifi_vap_info_t *vap_info,
     bool is_6g = strstr(vap_info->vap_name, "6g")?true:false;
     obj = cJSON_CreateObject();
     cJSON_AddItemToObject(vap_obj, "Security", obj);
-    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g) != webconfig_error_none) {
+    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Security object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }
@@ -1526,7 +1528,7 @@ webconfig_error_t encode_private_vap_object(const wifi_vap_info_t *vap_info,
     bool is_6g = strstr(vap_info->vap_name, "6g")?true:false;
     obj = cJSON_CreateObject();
     cJSON_AddItemToObject(vap_obj, "Security", obj);
-    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g) != webconfig_error_none) {
+    if (encode_security_object(&vap_info->u.bss_info.security, obj, is_6g, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Security object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }
@@ -1608,7 +1610,7 @@ webconfig_error_t encode_mesh_sta_object(const wifi_vap_info_t *vap_info,
     // Security
     obj = cJSON_CreateObject();
     cJSON_AddItemToObject(vap_obj, "Security", obj);
-    if (encode_security_object(&vap_info->u.sta_info.security, obj, is_6g) != webconfig_error_none) {
+    if (encode_security_object(&vap_info->u.sta_info.security, obj, is_6g, vap_info->vap_mode) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Security object encode failed for %s\n",__FUNCTION__, __LINE__, vap_info->vap_name);
         return webconfig_error_encode;
     }


### PR DESCRIPTION
Due to the header changes in `em_base.h` this PR is dependent on unified-wifi-mesh [#418](https://github.com/rdkcentral/unified-wifi-mesh/pull/418) in order to build