### PR TITLE
RDKB-60516: Onewifi restarts post upgrade to 8.2p1s1.

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -3039,8 +3039,9 @@ int wifidb_update_wifi_global_config(wifi_global_param_t *config)
         "inst_wifi_client_def_reporting_period %d wifi_active_msmt_enabled %d "
         "wifi_active_msmt_pktsize %d wifi_active_msmt_num_samples %d "
         "wifi_active_msmt_sample_duration %d vlan_cfg_version %d wps_pin %s "
-        "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d assoc_gate_time "
-        "%d assoc_monitor_duration %d rapid_reconnect_enable %d vap_stats_feature %d "
+        "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d assoc_gate_time %d "
+        "rss_memory_restart_threshold_low %d rss_memory_restart_threshold_high %d "
+        "assoc_monitor_duration %d rapid_reconnect_enable %d vap_stats_feature %d "
         "mfp_config_feature %d force_disable_radio_feature %d force_disable_radio_status %d "
         "fixed_wmm_params %d wifi_region_code %s diagnostic_enable %d validate_ssid %d "
         "device_network_mode:%d normalized_rssi_list %s snr_list %s cli_stat_list %s "
@@ -3054,6 +3055,7 @@ int wifidb_update_wifi_global_config(wifi_global_param_t *config)
         config->wifi_active_msmt_num_samples, config->wifi_active_msmt_sample_duration,
         config->vlan_cfg_version, config->wps_pin, config->bandsteering_enable,
         config->good_rssi_threshold, config->assoc_count_threshold, config->assoc_gate_time,
+        config->rss_memory_restart_threshold_low, config->rss_memory_restart_threshold_high,
         config->assoc_monitor_duration, config->rapid_reconnect_enable, config->vap_stats_feature,
         config->mfp_config_feature, config->force_disable_radio_feature,
         config->force_disable_radio_status, config->fixed_wmm_params, config->wifi_region_code,
@@ -3165,7 +3167,8 @@ int wifidb_get_wifi_global_config(wifi_global_param_t *config)
             "wifi_active_msmt_pktsize %d wifi_active_msmt_num_samples %d "
             "wifi_active_msmt_sample_duration %d vlan_cfg_version %d wps_pin %s "
             "bandsteering_enable %d good_rssi_threshold %d assoc_count_threshold %d "
-            "assoc_gate_time %d assoc_monitor_duration %d rapid_reconnect_enable %d "
+            "assoc_gate_time %d rss_memory_restart_threshold_low %d rss_memory_restart_threshold_high %d "
+            "assoc_monitor_duration %d rapid_reconnect_enable %d "
             "vap_stats_feature %d mfp_config_feature %d force_disable_radio_feature %d "
             "force_disable_radio_status %d fixed_wmm_params %d wifi_region_code %s "
             "diagnostic_enable %d validate_ssid %d device_network_mode:%d normalized_rssi_list %s "
@@ -3180,6 +3183,7 @@ int wifidb_get_wifi_global_config(wifi_global_param_t *config)
             config->wifi_active_msmt_num_samples, config->wifi_active_msmt_sample_duration,
             config->vlan_cfg_version, config->wps_pin, config->bandsteering_enable,
             config->good_rssi_threshold, config->assoc_count_threshold, config->assoc_gate_time,
+            config->rss_memory_restart_threshold_low, config->rss_memory_restart_threshold_high,
             config->assoc_monitor_duration, config->rapid_reconnect_enable,
             config->vap_stats_feature, config->mfp_config_feature,
             config->force_disable_radio_feature, config->force_disable_radio_status,
@@ -4417,6 +4421,14 @@ static void wifidb_global_config_upgrade()
     if (g_wifidb->db_version < ONEWIFI_DB_VERSION_RSS_MEMORY_THRESHOLD_FLAG) {
         wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade global config, old db version %d \n", __func__,
             __LINE__, g_wifidb->db_version);
+        g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low =
+            RSS_MEM_THRESHOLD1_DEFAULT;
+        g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high =
+            RSS_MEM_THRESHOLD2_DEFAULT;
+    }
+
+    if ((g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low) == 0 ||
+        (g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high) == 0) {
         g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_low =
             RSS_MEM_THRESHOLD1_DEFAULT;
         g_wifidb->global_config.global_parameters.rss_memory_restart_threshold_high =


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: Threshold variable names were different in 8.2p1s1, so the values were fetched as zero.

Test Procedure:
Load CGM4331COM_8.1p7s1_DEV_sey image
CDL to CGM4331COM_8.2p1s1_DEV_sey and
Check for both the threshold values are proper and for onewifi restart due to selfheal script. 

Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com