### PR TITLE
RDKB-61015: [openwrt] updated openwrt makefile_package to install the default Reset config to nvram

### DIFF
--- a/build/openwrt/Makefile_package
+++ b/build/openwrt/Makefile_package
@@ -118,6 +118,7 @@ define Package/easymesh/install
 		$(INSTALL_BIN) $(PKG_BUILD_DIR)/unified-wifi-mesh/config/openwrt/banana-pi/etc/init.d/* $(1)/etc/init.d/; \
 		$(CP) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/config/test_cert.crt $(1)/nvram/; \
 		$(CP) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/config/test_cert.key $(1)/nvram/; \
+		$(CP) $(PKG_BUILD_DIR)/unified-wifi-mesh/install/bin/Reset.json $(1)/nvram/; \
 	fi
 endef
 


### PR DESCRIPTION
updated openwrt makefile_package to install the default Reset config to nvram