### PR TITLE
RDKB-61098: Support for client roam from wpa3-p to wpa2-p

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4807,7 +4807,7 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
 
             if (sec->wpa3_transition_disable != false) {
                 sec->wpa3_transition_disable = false;
-                wifi_util_dbg_print(WIFI_DB, "%s:%d force change wpa3 transition disable state to false\r\n");
+                wifi_util_dbg_print(WIFI_DB, "%s:%d force change wpa3 transition disable state to false\r\n", __func__, __LINE__);
                 wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
                     &rdk_config[i]);
             }


### PR DESCRIPTION
Reason for change: Corrected Wifi db log.

Test Procedure: 1. Build images.
2. Configure 2.4/5G VAP's with WPA2-Personal.
3. Configure 6G VAP with WPA3-Personal.
4. Connect client to 6G VAP.
5. Roam client from 6G to 2.4/5G VAP's.
6. Client roaming should be successul

Risks: Medium
Priority: P1