### PR TITLE
RDKB-60494: EM translator: Update vap_mode in em_bss_info_t

### DIFF
--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -122,6 +122,8 @@ webconfig_error_t webconfig_easymesh_encode(webconfig_t *config,
 // sets the default values in em_bss_info_t Easymesh structure
 void default_em_bss_info(em_bss_info_t  *vap_row)
 {
+    vap_row->vap_mode = em_vap_mode_ap;
+    vap_row->connect_status = false;
     memset(vap_row->est_svc_params_be,'\0',sizeof(vap_row->est_svc_params_be));
     memset(vap_row->est_svc_params_bk,'\0',sizeof(vap_row->est_svc_params_bk));
     memset(vap_row->est_svc_params_vi,'\0',sizeof(vap_row->est_svc_params_vi));
@@ -983,6 +985,7 @@ webconfig_error_t translate_sta_info_to_em_common(const wifi_vap_info_t *vap, co
     } else {
         vap_row->connect_status = false;
     }
+    vap_row->vap_mode = vap->vap_mode;
 
     return webconfig_error_none;
 }


### PR DESCRIPTION
Reason for change: The vap_mode needs to be updated to the controller for building the right topology. Ensure that the vap_mode is correctly updated in em object in agent which in turn is sent to controller as part of topology response.

Test Procedure: Tested multiple ssid change and channel change across colocated agent and remote agent scenario.

Risks: Low
Priority: P1