### PR TITLE
RDKB-61190:[OneWifi] Implemented HE bus async method invoke API

### DIFF
--- a/source/platform/dbus/bus.c
+++ b/source/platform/dbus/bus.c
@@ -1825,7 +1825,7 @@ bus_error_t bus_reg_data_elements(bus_handle_t *handle, bus_data_element_t *data
     return bus_error_success;
 }
 bus_error_t bus_method_invoke(bus_handle_t *handle, void *paramName, char *event,
-    raw_data_t *input_data, raw_data_t *output_data, uint8_t input_bus_data)
+    bus_data_obj_t *input_data, bus_data_obj_t *output_data, uint8_t input_bus_data)
 {
     bus_error_t rc = bus_error_general;
     char *dbus_path = NULL, *dst_component_id = NULL;
@@ -2172,6 +2172,12 @@ static enum dataType_e convert_bus_to_ccsp_data_type(bus_data_type_t type)
     return ccsp_data_type;
 }
 
+static bus_error_t bus_method_async_invoke(bus_handle_t *handle, void *param_name, char *event_name,
+    bus_data_obj_t *input_data, wifi_bus_method_async_resp_handler_t cb, uint32_t timeout)
+{
+    return bus_error_success;
+}
+
 static bus_error_t bus_add_table_row(bus_handle_t *handle, char const *name,
     char const *alias, uint32_t *row_index)
 {
@@ -2208,5 +2214,6 @@ void rdkb_bus_desc_init(wifi_bus_desc_t *desc)
     desc->bus_get_trace_context_fn = bus_get_trace_context;
     desc->bus_set_trace_context_fn = bus_set_trace_context;
     desc->bus_error_to_string_fn = bus_error_to_string;
+    desc->bus_method_async_invoke_fn = bus_method_async_invoke;
     desc->bus_add_table_row_fn = bus_add_table_row;
 }

--- a/source/platform/linux/bus.c
+++ b/source/platform/linux/bus.c
@@ -241,7 +241,7 @@ bus_error_t bus_reg_data_elements(bus_handle_t *handle, bus_data_element_t *data
 }
 
 bus_error_t bus_method_invoke(bus_handle_t *handle, void *paramName, char *event,
-    raw_data_t *input_data, raw_data_t *output_data, uint8_t input_bus_data)
+    bus_data_obj_t *input_data, bus_data_obj_t *output_data, uint8_t input_bus_data)
 {
     VERIFY_NULL_WITH_RC(handle);
     VERIFY_NULL_WITH_RC(event);
@@ -378,6 +378,12 @@ static bus_error_t bus_remove_table_row(bus_handle_t *handle, char const *name)
     return bus_error_success;
 }
 
+static bus_error_t bus_method_async_invoke(bus_handle_t *handle, void *param_name, char *event_name,
+    bus_data_obj_t *input_data, wifi_bus_method_async_resp_handler_t cb, uint32_t timeout)
+{
+    return bus_error_success;
+}
+
 static bus_error_t bus_add_table_row(bus_handle_t *handle, char const *name,
     char const *alias, uint32_t *row_index)
 {
@@ -417,4 +423,5 @@ static void bus_desc_init(wifi_bus_desc_t *desc)
     desc->bus_remove_table_row_fn         = bus_remove_table_row;
     desc->bus_error_to_string_fn          = bus_error_to_string;
     desc->bus_convert_handle_to_actual_ptr_fn = bus_convert_handle_to_ptr;
+    desc->bus_method_async_invoke_fn = bus_method_async_invoke;
 }

--- a/source/platform/linux/he_bus/inc/he_bus_common.h
+++ b/source/platform/linux/he_bus/inc/he_bus_common.h
@@ -34,6 +34,8 @@ extern "C" {
 
 typedef struct _he_bus_handle *he_bus_handle_t;
 
+typedef volatile int atomic_int;
+
 #define HE_BUS_RETURN_ERR -1
 #define HE_BUS_RETURN_OK 0
 
@@ -47,6 +49,7 @@ typedef struct _he_bus_handle *he_bus_handle_t;
 
 #define HE_BUS_MSG_IDENTIFICATION_NUM 0x12345678
 #define HE_BUS_RES_RECV_TIMEOUT_S 10
+//if you change this value, remember to change BUS_MAX_NAME_LENGTH too
 #define HE_BUS_MAX_NAME_LENGTH 128
 
 #define HE_BUS_VERIFY_NULL(T) \
@@ -63,6 +66,13 @@ typedef struct _he_bus_handle *he_bus_handle_t;
     if (NULL == T) {                   \
         return HE_BUS_RETURN_ERR;      \
     }
+
+#define HE_BUS_CHECK_NULL_WITH_RC(ptr, rc) \
+    do { \
+        if ((ptr) == NULL) { \
+            return (rc); \
+        } \
+    } while (0)
 
 #define HE_BUS_NO_DATA_OBJ 0
 #define HE_BUS_SINGLE_DATA_OBJ 1
@@ -210,6 +220,7 @@ typedef struct he_bus_stretch_buff {
 } he_bus_stretch_buff_t;
 
 typedef struct he_bus_data_object {
+    atomic_int ref_count;
     uint32_t name_len;
     he_bus_name_string_t name;
     he_bus_msg_sub_type_t msg_sub_type;
@@ -228,6 +239,11 @@ typedef struct he_bus_raw_data_msg {
     uint32_t num_of_obj;
     he_bus_data_object_t data_obj;
 } he_bus_raw_data_msg_t;
+
+typedef struct he_bus_data_objs {
+    uint32_t num_obj;
+    he_bus_data_object_t data_obj;
+} he_bus_data_objs_t;
 
 typedef struct sub_payload_data {
     he_bus_event_sub_action_t action;

--- a/source/platform/linux/he_bus/inc/he_bus_core.h
+++ b/source/platform/linux/he_bus/inc/he_bus_core.h
@@ -88,13 +88,16 @@ typedef he_bus_error_t (*he_bus_table_add_row_handler_t)(char const *tableName,
     char const *aliasName, uint32_t *instNum);
 typedef he_bus_error_t (*he_bus_table_remove_row_handler_t)(char const *rowName);
 typedef he_bus_error_t (*he_bus_method_handler_t)(char const *methodName,
-    he_bus_raw_data_t *inParams, he_bus_raw_data_t *outParams, void *asyncHandle);
+    he_bus_data_object_t const *inParams, he_bus_data_object_t *outParams, void *asyncHandle);
 typedef he_bus_error_t (*he_bus_event_sub_handler_t)(char *eventName,
     he_bus_event_sub_action_t action, int32_t interval, bool *autoPublish);
 
 typedef he_bus_error_t (
     *he_bus_event_consumer_sub_handler_t)(char *event_name, he_bus_raw_data_t *p_data, void *userData);
 typedef he_bus_error_t (*he_bus_event_sub_ex_async_handler_t)(char *event_name, he_bus_error_t ret, void *userData);
+
+typedef void (*he_bus_method_async_resp_handler_t) (char const* methodName, he_bus_error_t ret,
+    he_bus_data_object_t *params, void *userData);
 
 typedef struct he_bus_callback_table {
     he_bus_get_handler_t get_handler; /**< Get parameters handler for the named paramter   */
@@ -194,6 +197,14 @@ typedef struct _he_bus_handle {
     pthread_mutex_t handle_mutex;
 } he_bus_handle;
 
+typedef struct he_bus_method_invoke_async_data {
+    he_bus_handle_t handle;
+    he_bus_name_string_t method_name;
+    he_bus_data_objs_t in_params;
+    he_bus_method_async_resp_handler_t cb;
+    uint32_t timeout;
+} he_bus_method_invoke_async_data_t;
+
 typedef struct traversal_cb_param {
     union {
         hash_map_t *node_data;
@@ -246,6 +257,10 @@ he_bus_error_t he_bus_get_data(he_bus_handle_t handle, char const *event_name, h
 he_bus_error_t he_bus_set_data(he_bus_handle_t handle, char const *event_name, he_bus_raw_data_t *p_data);
 he_bus_error_t he_bus_publish_event(he_bus_handle_t handle, char const *event_name,
     he_bus_raw_data_t *p_data);
+he_bus_error_t he_bus_method_invoke(he_bus_handle_t handle, char const *event_name,
+    he_bus_data_objs_t *p_input_data, he_bus_data_objs_t *p_output_data);
+he_bus_error_t he_bus_async_method_invoke(he_bus_handle_t handle, char const *event_name,
+    he_bus_data_objs_t *input_data, he_bus_method_async_resp_handler_t cb, uint32_t timeout);
 
 #ifdef __cplusplus
 }

--- a/source/platform/linux/he_bus/inc/he_bus_data_conversion.h
+++ b/source/platform/linux/he_bus/inc/he_bus_data_conversion.h
@@ -51,6 +51,14 @@ he_bus_error_t prepare_initial_bus_header(he_bus_raw_data_msg_t *p_data, char *c
 he_bus_error_t prepare_rem_payload_bus_msg_data(char *event_name,
     he_bus_raw_data_msg_t *p_base_hdr_data, he_bus_msg_sub_type_t msg_sub_type,
     he_bus_raw_data_t *payload_data, he_bus_error_t ret_status);
+uint32_t get_total_size_from_he_bus_raw_data(he_bus_raw_data_t *cfg_data);
+uint32_t get_total_objs_size_from_he_bus_objs(he_bus_data_object_t *p_objs);
+uint32_t get_max_objs_cnt(he_bus_data_object_t *p_objs);
+int set_obj_status(he_bus_data_object_t *p_objs, he_bus_error_t ret_status);
+he_bus_data_object_t *memory_alloc_for_he_bus_data_obj(void);
+int he_bus_data_object_retain(he_bus_data_object_t *p_obj);
+int he_bus_all_objs_retain(he_bus_data_object_t *p_obj);
+int move_multi_objs_data(he_bus_raw_data_msg_t *dst, he_bus_data_object_t *src);
 
 #ifdef __cplusplus
 }

--- a/source/platform/linux/he_bus/inc/he_bus_dml.h
+++ b/source/platform/linux/he_bus/inc/he_bus_dml.h
@@ -41,8 +41,8 @@ he_bus_error_t radio_table_add_row_handler(char const *tableName, char const *al
 he_bus_error_t radio_table_remove_row_handler(char const *rowName);
 he_bus_error_t radio_event_sub_handler(char *eventName, he_bus_event_sub_action_t action,
     int32_t interval, bool *autoPublish);
-he_bus_error_t radio_method_handler(char const *methodName, he_bus_raw_data_t *inParams,
-    he_bus_raw_data_t *outParams, void *asyncHandle);
+he_bus_error_t radio_method_handler(char const *methodName, he_bus_data_object_t *inParams,
+    he_bus_data_object_t *outParams, void *asyncHandle);
 
 he_bus_error_t accesspoint_get_param_value(char *event_name, he_bus_raw_data_t *p_data);
 he_bus_error_t accesspoint_set_param_value(char *event_name, he_bus_raw_data_t *p_data);

--- a/source/platform/linux/he_bus/src/he_bus_dml.c
+++ b/source/platform/linux/he_bus/src/he_bus_dml.c
@@ -119,13 +119,25 @@ he_bus_error_t radio_event_sub_handler(char *eventName, he_bus_event_sub_action_
     return he_bus_error_success;
 }
 
-he_bus_error_t radio_method_handler(char const *methodName, he_bus_raw_data_t *inParams,
-    he_bus_raw_data_t *outParams, void *asyncHandle)
+he_bus_error_t radio_method_handler(char const *methodName, he_bus_data_object_t *inParams,
+    he_bus_data_object_t *outParams, void *asyncHandle)
 {
     (void)inParams;
     (void)outParams;
     (void)asyncHandle;
     he_bus_dml_dbg_print("%s:%d enter:%s\r\n", __func__, __LINE__, methodName);
+    he_bus_dml_dbg_print("%s:%d =====>recv data name:%s\r\n", __func__, __LINE__, inParams->name);
+
+    int index = 0;
+    he_bus_raw_data_t payload_data = { 0 };
+
+    while(index < 3) {
+        payload_data.data_type = he_bus_data_type_uint32;
+        payload_data.raw_data.u32 = index;
+        payload_data.raw_data_len = sizeof(unsigned int);
+        set_bus_object_data("device.wifi.aniket.output.enter", outParams, 0, payload_data, 0);
+        index++;
+    }
     return he_bus_error_success;
 }
 

--- a/source/platform/openwrt/bus.c
+++ b/source/platform/openwrt/bus.c
@@ -126,8 +126,8 @@ char *bus_property_get_name(bus_handle_t handle, bus_property_t property)
     return c_ret;
 }
 
-bus_error_t bus_method_invoke(bus_handle_t handle, void *paramName, char *event, char *input_data,
-    char *output_data, bool input_bus_data)
+bus_error_t bus_method_invoke(bus_handle_t handle, void *paramName, char *event, bus_data_obj_t *input_data,
+    bus_data_obj_t *output_data, bool input_bus_data)
 {
     bus_error_t rc = bus_error_success;
     return rc;
@@ -201,6 +201,12 @@ static bus_error_t bus_remove_table_row(bus_handle_t *handle, char const *name)
     return bus_error_success;
 }
 
+static bus_error_t bus_method_async_invoke(bus_handle_t *handle, void *param_name, char *event_name,
+    bus_data_obj_t *input_data, wifi_bus_method_async_resp_handler_t cb, uint32_t timeout)
+{
+    return bus_error_success;
+}
+
 static bus_error_t bus_add_table_row(bus_handle_t *handle, char const *name,
     char const *alias, uint32_t *row_index)
 {
@@ -244,4 +250,5 @@ void wifi_bus_init(void)
     g_bus.bus_remove_table_row_fn = bus_remove_table_row;
     g_bus.desc.bus_error_to_string_fn = bus_error_to_string;
     g_bus.desc.bus_convert_handle_to_actual_ptr_fn = bus_convert_handle_to_ptr;
+    g_bus.desc.bus_method_async_invoke_fn = bus_method_async_invoke;
 }

--- a/source/platform/rdkb/bus.c
+++ b/source/platform/rdkb/bus.c
@@ -1418,7 +1418,7 @@ bus_error_t bus_reg_data_elements(bus_handle_t *handle, bus_data_element_t *data
 }
 
 bus_error_t bus_method_invoke(bus_handle_t *handle, void *paramName, char *event,
-    raw_data_t *input_data, raw_data_t *output_data, uint8_t input_bus_data)
+    bus_data_obj_t *input_data, bus_data_obj_t *output_data, uint8_t input_bus_data)
 {
     rbusError_t rc;
     rbusHandle_t p_rbus_handle = handle->u.rbus_handle;
@@ -1796,6 +1796,12 @@ static bus_error_t bus_remove_table_row(bus_handle_t *handle, char const *name)
     return convert_rbus_to_bus_error_code(rc);
 }
 
+static bus_error_t bus_method_async_invoke(bus_handle_t *handle, void *param_name, char *event_name,
+    bus_data_obj_t *input_data, wifi_bus_method_async_resp_handler_t cb, uint32_t timeout)
+{
+    return bus_error_success;
+}
+
 void rdkb_bus_desc_init(wifi_bus_desc_t *desc)
 {
     desc->bus_init_fn = bus_init;
@@ -1823,4 +1829,5 @@ void rdkb_bus_desc_init(wifi_bus_desc_t *desc)
     desc->bus_unreg_table_row_fn = bus_unreg_table_row;
     desc->bus_add_table_row_fn = bus_add_table_row;
     desc->bus_remove_table_row_fn = bus_remove_table_row;
+    desc->bus_method_async_invoke_fn = bus_method_async_invoke;
 }


### PR DESCRIPTION
Reason for change: Implemented the HE bus asynchronous method invoke
                   API to asynchronously set and get data between a
                   consumer and a producer.

Test Procedure: 1) Load Linux(RPI) or OpenWRT(BPI) HE bus Build. 2) Trigger "bus_method_async_invoke" API from code to test those changes. 3) Verify device memory.

Risks: Low
Priority: P1

Signed-off-by: apatel599@cable.comcast.com