### PR TITLE
RDKB-61245 RadiusServerIPAddr values are showing as empty by default

### DIFF
--- a/source/apps/blaster/wifi_single_client_msmt.c
+++ b/source/apps/blaster/wifi_single_client_msmt.c
@@ -739,6 +739,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
         wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, radio number set to : \"%s\"\n",
             radio_name);
         if (strcmp(radio_name, "Not_found") == 0) {
+            avro_value_set_branch(&drField, 0, &optional);
             avro_value_set_null(&optional);
         } else {
             avro_value_set_enum(&optional,
@@ -836,6 +837,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
         (blaster->curStepData.ApIndex < 0)) {
         wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, operating_standard = \"%s\"\n",
             "Not defined, set to NULL");
+        avro_value_set_branch(&drField, 0, &optional);
         avro_value_set_null(&optional);
     } else {
         wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, operating_standard = \"%s\"\n",
@@ -866,6 +868,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
         (blaster->curStepData.ApIndex < 0)) {
         wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, operating_channel_bandwidth = \"%s\"\n",
             "set to NULL");
+        avro_value_set_branch(&drField, 0, &optional);
         avro_value_set_null(&optional);
     } else {
         if ( strstr("20MHz", sta_data->sta_active_msmt_data[0].Operating_channelwidth))
@@ -936,6 +939,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
     if (blaster->curStepData.ApIndex < 0)
     {
         wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, frequency_band set to NULL\n");
+        avro_value_set_branch(&drField, 0, &optional);
         avro_value_set_null(&optional);
     }
     else
@@ -956,6 +960,7 @@ void upload_single_client_active_msmt_data(blaster_hashmap_t *sta_info)
                 avro_schema_enum_get_by_name(avro_value_get_schema(&optional), "_6GHz"));
         } else {
             wifi_util_dbg_print(WIFI_BLASTER, "RDK_LOG_DEBUG, frequency_band set to NULL\n");
+            avro_value_set_branch(&drField, 0, &optional);
             avro_value_set_null(&optional);
         }
     }

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -8367,7 +8367,7 @@ Security_GetParamStringValue
 	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d: RadiusServerIPAddr: A%sA\n",__func__, __LINE__,(char *)&pcfg->u.radius.ip);
         result=strcmp((char *)&pcfg->u.radius.ip,"");
 	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d: RadiusServerIPAddr: result - %d\n",__func__, __LINE__,result);
-        if((iscntrl(result) != 0) && result)
+        if((iscntrl(result) == 0) && result)
         {
             AnscCopyString(pValue, (char *)&pcfg->u.radius.ip);
         }

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -8367,7 +8367,7 @@ Security_GetParamStringValue
 	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d: RadiusServerIPAddr: A%sA\n",__func__, __LINE__,(char *)&pcfg->u.radius.ip);
         result=strcmp((char *)&pcfg->u.radius.ip,"");
 	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d: RadiusServerIPAddr: result - %d\n",__func__, __LINE__,result);
-        if(result)
+        if((iscntrl(result) != 0) && result)
         {
             AnscCopyString(pValue, (char *)&pcfg->u.radius.ip);
         }

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -8364,7 +8364,9 @@ Security_GetParamStringValue
     if( AnscEqualString(ParamName, "RadiusServerIPAddr", TRUE))
     {
         int result;
+	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d: RadiusServerIPAddr: A%sA\n",__func__, __LINE__,(char *)&pcfg->u.radius.ip);
         result=strcmp((char *)&pcfg->u.radius.ip,"");
+	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d: RadiusServerIPAddr: result - %d\n",__func__, __LINE__,result);
         if(result)
         {
             AnscCopyString(pValue, (char *)&pcfg->u.radius.ip);

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -8364,9 +8364,7 @@ Security_GetParamStringValue
     if( AnscEqualString(ParamName, "RadiusServerIPAddr", TRUE))
     {
         int result;
-	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d: RadiusServerIPAddr: A%sA\n",__func__, __LINE__,(char *)&pcfg->u.radius.ip);
         result=strcmp((char *)&pcfg->u.radius.ip,"");
-	wifi_util_dbg_print(WIFI_DMCLI,"%s:%d: RadiusServerIPAddr: result - %d\n",__func__, __LINE__,result);
         if((iscntrl(result) == 0) && result)
         {
             AnscCopyString(pValue, (char *)&pcfg->u.radius.ip);


### PR DESCRIPTION
Reason for change: To check whether the RadiusServerIPAddr string is empty when WPA3 is enabled
Test Procedure:
             1. Enable WPA3 with below mentioned dmcli command
                    dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.WPA3_Personal_Transition.Enable bool true
             2. Check the RadiusServerIPAddr using the below mentioned commands
                    dmcli eRT getv Device.WiFi.AccessPoint.1.Security.RadiusServerIPAddr
                    dmcli eRT getv Device.WiFi.AccessPoint.2.Security.RadiusServerIPAddr
Priority: P1
Risks: Low
Signed-off-by: Samyuktha Karthikeyan <samyuktha_karthikeyan@comcast.com>