### PR TITLE
RDKB-61027 WPA3-PCM should not be set for 6GHz

### DIFF
--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -341,9 +341,15 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security,pErr 
             vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
             vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
         } else if (!strcmp(value, "WPA3-Personal-Compatibility")) {
-            vap_info->u.bss_info.security.mode = wifi_security_mode_wpa3_compatibility;
-            vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
-            vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
+            if (strncmp(vap_info->vap_name, "private_ssid_6g", sizeof(vap_info->vap_name)) == 0) {
+                vap_info->u.bss_info.security.mode = wifi_security_mode_wpa3_personal;
+                vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_sae;
+                vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_required;
+            } else {
+                vap_info->u.bss_info.security.mode = wifi_security_mode_wpa3_compatibility;
+                vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_psk_sae;
+                vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
+            }
         } else {
             if (execRetVal) {
                 strncpy(execRetVal->ErrorMsg,"Invalid Security Mode",sizeof(execRetVal->ErrorMsg)-1);


### PR DESCRIPTION
Impacted Platforms:
XB8, XB10

Reason for change: WPA3-PCM is not supported for 6GHz. Only WPA3-Personal is applicable for 6GHz

Test Procedure: Set security mode as WPA3-PCM for private 6GHz and push the blob

Risks: Low
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com