### PR TITLE
RDKB-59898: [OneWifi]WiFi Interfaces reconfigured post 5G channel opt…

### DIFF
--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -1149,6 +1149,20 @@ pErr wifi_vap_cfg_subdoc_handler(void *data)
         if(interworking_o == NULL) {
             wifi_util_error_print(WIFI_CTRL, "%s: Failed to get Interworking obj for %s\n", __func__, nm_s);
             continue;
+        } else {
+            //if VenueOptionPresent param missing add it.
+            cJSON *venue_o = cJSON_GetObjectItem(interworking_o, "Venue");
+            if (venue_o != NULL) {
+                cJSON *venue_option = cJSON_GetObjectItem(venue_o, "VenueOptionPresent");
+                if (venue_option == NULL) {
+                    wifi_interworking_t *interworking_info =
+                        &wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.interworking;
+                    cJSON_AddBoolToObject(venue_o, "VenueOptionPresent",
+                        interworking_info->interworking.venueOptionPresent);
+                } else {
+                    wifi_util_info_print(WIFI_CTRL, "%s: VenueOptionPresent param available\n", __func__);
+                }
+            }
         }
 
         if ((status = early_validate_interworking(interworking_o,  execRetVal)) != RETURN_OK) {

--- a/source/db/wifi_db.h
+++ b/source/db/wifi_db.h
@@ -124,6 +124,29 @@ typedef struct {
 #define LNF_PRIMARY_RADIUS_IP      "127.0.0.1"
 #define LNF_SECONDARY_RADIUS_IP    "192.168.106.254"
 
+#define DEFAULT_ANQP_STR_DATA " { \"ANQP\":{ " \
+                               "\"IPAddressTypeAvailabilityANQPElement\":{ " \
+                               "\"IPv6AddressType\":0, " \
+                               "\"IPv4AddressType\":0}, " \
+                               "\"DomainANQPElement\":{\"DomainName\":[]}, " \
+                               "\"NAIRealmANQPElement\":{\"Realm\":[]}, " \
+                               "\"3GPPCellularANQPElement\":{ " \
+                               "\"GUD\":0, " \
+                               "\"PLMN\":[]}, " \
+                               "\"RoamingConsortiumANQPElement\": { " \
+                               "\"OI\": []}, " \
+                               "\"VenueNameANQPElement\": { " \
+                               "\"VenueInfo\": []}}}"
+
+#define DEFAULT_PASSPOINT_STR_DATA "{ \"Passpoint\":{ " \
+                                   "\"PasspointEnable\":false, " \
+                                   "\"NAIHomeRealmANQPElement\":{\"Realms\":[]}, " \
+                                   "\"OperatorFriendlyNameANQPElement\":{\"Name\":[]}, " \
+                                   "\"ConnectionCapabilityListANQPElement\":{\"ProtoPort\":[]}, " \
+                                   "\"GroupAddressedForwardingDisable\":true, " \
+                                   "\"P2pCrossConnectionDisable\":false}}"
+
+
 int start_wifidb();
 int init_wifidb_tables();
 int wifidb_update_wifi_vap_config(int radio_index, wifi_vap_info_map_t *config,

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -768,6 +768,9 @@ webconfig_error_t decode_interworking_common_object(const cJSON *interworking, w
 
     decode_param_object(interworking, "Venue", venue);
 
+    decode_param_bool(venue, "VenueOptionPresent", param);
+    interworking_info->interworking.venueOptionPresent = (param->type & cJSON_True) ? true : false;
+
     decode_param_integer(venue, "VenueType", param);
     interworking_info->interworking.venueType = param->valuedouble;
     if (interworking_info->interworking.venueType > 15) {

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -902,6 +902,7 @@ webconfig_error_t encode_interworking_common_object(const wifi_interworking_t *i
         //strncpy(execRetVal->ErrorMsg, "Invalid Venue Group",sizeof(execRetVal->ErrorMsg)-1);
         return webconfig_error_encode;
     }
+    cJSON_AddBoolToObject(obj, "VenueOptionPresent", interworking_info->interworking.venueOptionPresent);
     cJSON_AddNumberToObject(obj, "VenueType", interworking_info->interworking.venueType);
 
     switch (interworking_info->interworking.venueGroup) {

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -902,6 +902,19 @@ webconfig_error_t translator_ovsdb_init(webconfig_subdoc_data_t *data)
         convert_radio_index_to_freq_band(&hal_cap->wifi_prop, radioIndx, &band);
         default_vap_info->u.bss_info.mbo_enabled = true;
         default_vap_info->u.bss_info.interop_ctrl = false;
+
+        char str[600] = {0};
+        snprintf(str,sizeof(str),"%s", DEFAULT_ANQP_STR_DATA);
+        snprintf((char *)default_vap_info->u.bss_info.interworking.anqp.anqpParameters,
+            sizeof(default_vap_info->u.bss_info.interworking.anqp.anqpParameters), "%s" , str);
+        memset(str,0,sizeof(str));
+        snprintf(str,sizeof(str),"%s", DEFAULT_PASSPOINT_STR_DATA);
+        snprintf((char *)default_vap_info->u.bss_info.interworking.passpoint.hs2Parameters,
+            sizeof(default_vap_info->u.bss_info.interworking.passpoint.hs2Parameters), "%s" , str);
+
+        default_vap_info->u.bss_info.interworking.interworking.venueOptionPresent = 1;
+        default_vap_info->u.bss_info.interworking.interworking.venueGroup = 0;
+        default_vap_info->u.bss_info.interworking.interworking.venueType = 0;
 #if defined(_XB7_PRODUCT_REQ_) || defined(_XB8_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) || \
     defined(_SCER11BEL_PRODUCT_REQ_) || defined(_CBR2_PRODUCT_REQ_) ||                         \
     defined(_WNXL11BWL_PRODUCT_REQ_)


### PR DESCRIPTION
…imization (#460)

Reason for change: Improved is_vap_configure_changed function logic to Avoids
                   checking pre-association, Passpoint, and ANQP configurations
                   for VAPs other than Hotspot VAPs.

Test Procedure:1. Load the OneWifi build.
               2. Connect client with 2g/5g.
               3. Wait until 5g channel optimizations trigger.
               4. Check Client is connected back to 5g VAPs.

Priority: P0
Risks: Low

Signed-off-by: apatel599@cable.comcast.com

Signed-off-by: apatel599@cable.comcast.com

RDKB-59898: [OneWifi]WiFi Interfaces reconfigured post 5G channel optimization (#468)

Reason for change: Improved is_vap_configure_changed function logic to Avoids
                   checking pre-association, Passpoint, and ANQP configurations
                   for VAPs other than Hotspot VAPs.

Test Procedure:1. Load the OneWifi build.
               2. Connect client with 2g/5g.
               3. Wait until 5g channel optimizations trigger.
               4. Check Client is connected back to 5g VAPs.

Priority: P0
Risks: Low

Signed-off-by: apatel599@cable.comcast.com

Signed-off-by: apatel599@cable.comcast.com

RDKB-59898:[OneWifi]WiFi Interfaces reconfigured post 5G channel optimization (#481)

Reason for change: Added VenueOptionPresent blob param as part of webconfig blob.

Test Procedure:1. Load the OneWifi build.
               2. Connect client with 2g/5g.
               3. Wait until 5g channel optimizations trigger.
               4. Check Client is connected back to 5g VAPs.

Priority: P0
Risks: Low

Signed-off-by: apatel599@cable.comcast.com

Signed-off-by: apatel599@cable.comcast.com