### PR TITLE
RDKB-59404: OpenWRT: Add iot vap in InterfaceMap and scripts

### DIFF
--- a/config/openwrt/banana-pi/InterfaceMap.json
+++ b/config/openwrt/banana-pi/InterfaceMap.json
@@ -31,15 +31,22 @@
                             "InterfaceName": "wifi1.1",
                             "Bridge": "br-lan",
                             "vlanId": 0,
-                            "vapIndex": 15,
-                            "vapName": "mesh_sta_5g"
+                            "vapIndex": 13,
+                            "vapName": "mesh_backhaul_5g"
                         },
                         {
                             "InterfaceName": "wifi1.2",
                             "Bridge": "br-lan",
                             "vlanId": 0,
-                            "vapIndex": 13,
-                            "vapName": "mesh_backhaul_5g"
+                            "vapIndex": 3,
+                            "vapName": "iot_ssid_5g"
+                        },
+                        {
+                            "InterfaceName": "wifi1.3",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 15,
+                            "vapName": "mesh_sta_5g"
                         }
                     ]
                 },
@@ -53,6 +60,20 @@
                             "vlanId": 0,
                             "vapIndex": 0,
                             "vapName": "private_ssid_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi0.1",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 12,
+                            "vapName": "mesh_backhaul_2g"
+                        },
+                        {
+                            "InterfaceName": "wifi0.2",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 2,
+                            "vapName": "iot_ssid_2g"
                         }
                     ]
                 }

--- a/config/openwrt/banana-pi/wifi_interface_down.sh
+++ b/config/openwrt/banana-pi/wifi_interface_down.sh
@@ -2,14 +2,24 @@
 
 echo "Bringing down all wifi interfaces and deleting it"
 ifconfig wifi0 down
+ifconfig wifi0.1 down
+ifconfig wifi0.2 down
 ifconfig wifi1 down
 ifconfig wifi1.1 down
 ifconfig wifi1.2 down
+ifconfig wifi1.3 down
 ifconfig wifi2 down
+#ifconfig wifi2.1 down
+#ifconfig wifi2.2 down
 
 #delete the interfaces
 iw dev wifi0 del
+iw dev wifi0.1 del
+iw dev wifi0.2 del
 iw dev wifi1 del
 iw dev wifi1.1 del
 iw dev wifi1.2 del
+iw dev wifi1.3 del
 iw dev wifi2 del
+#iw dev wifi2.1 del
+#iw dev wifi2.2 del

--- a/config/openwrt/banana-pi/wifi_interface_up.sh
+++ b/config/openwrt/banana-pi/wifi_interface_up.sh
@@ -3,10 +3,15 @@
 /etc/init.d/wpad stop
 
 iw phy phy0 interface add wifi0 type __ap
+iw phy phy0 interface add wifi0.1 type __ap
+iw phy phy0 interface add wifi0.2 type __ap
 iw phy phy0 interface add wifi1 type __ap
 iw phy phy0 interface add wifi1.1 type __ap
 iw phy phy0 interface add wifi1.2 type __ap
+iw phy phy0 interface add wifi1.3 type __ap
 iw phy phy0 interface add wifi2 type __ap
+#iw phy phy0 interface add wifi2.1 type __ap
+#iw phy phy0 interface add wifi2.2 type __ap
 
 #Derive the initial wifi mac address from eth0 or erouter0 address
 #as they are unique for each Banana PI
@@ -28,9 +33,16 @@ else
 fi
 
 #Obtain the wifi0 mac address from primary_wifi_mac by converting to str format
-wifi0_mac=$(printf "%012x" $primary_wifi_mac | sed 's/../&:/g;s/:$//')
-#Increment primary_wifi_mac by 1 to get wifi1_mac
-mac_incr=$(($primary_wifi_mac + 1))
+mac_incr=$(($primary_wifi_mac + 0))
+wifi0_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi0.1_mac
+mac_incr=$(($mac_incr + 1))
+wifi0_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi0.2_mac
+mac_incr=$(($mac_incr + 1))
+wifi0_2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment primary_wifi_mac by 0x10 (decimal 16) to get wifi1 address
+mac_incr=$(($primary_wifi_mac + 16))
 wifi1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
 #Increment again by 1 to get wifi1.1 address
 mac_incr=$(($mac_incr + 1))
@@ -38,32 +50,61 @@ wifi1_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
 #Increment again by 1 to get wifi1.2 address
 mac_incr=$(($mac_incr + 1))
 wifi1_2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
-#Increment again by 1 to get wifi2 address
+#Increment again by 1 to get wifi1.3 address
 mac_incr=$(($mac_incr + 1))
+wifi1_3_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment primary_wifi_mac by 0x20 (decimal 32) to get wifi2 address
+mac_incr=$(($primary_wifi_mac + 32))
 wifi2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi2.1 address
+#mac_incr=$(($mac_incr + 1))
+#wifi2_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+#Increment again by 1 to get wifi2.2 address
+#mac_incr=$(($mac_incr + 1))
+#wifi2_2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
 #print the mac address
 echo $wifi0_mac
+echo $wifi0_1_mac
+echo $wifi0_2_mac
 echo $wifi1_mac
 echo $wifi1_1_mac
 echo $wifi1_2_mac
+echo $wifi1_3_mac
 echo $wifi2_mac
+#echo $wifi2_1_mac
+#echo $wifi2_2_mac
 
 #Update the mac address using ip link command
 ifconfig wifi0 down
+ifconfig wifi0.1 down
+ifconfig wifi0.2 down
 ifconfig wifi1 down
 ifconfig wifi1.1 down
 ifconfig wifi1.2 down
+ifconfig wifi1.3 down
 ifconfig wifi2 down
+#ifconfig wifi2.1 down
+#ifconfig wifi2.2 down
 ip link set dev wifi0 address $wifi0_mac
+ip link set dev wifi0.1 address $wifi0_1_mac
+ip link set dev wifi0.2 address $wifi0_2_mac
 ip link set dev wifi1 address $wifi1_mac
 ip link set dev wifi1.1 address $wifi1_1_mac
 ip link set dev wifi1.2 address $wifi1_2_mac
+ip link set dev wifi1.3 address $wifi1_3_mac
 ip link set dev wifi2 address $wifi2_mac
+#ip link set dev wifi2.1 address $wifi2_1_mac
+#ip link set dev wifi2.2 address $wifi2_2_mac
 ifconfig wifi0 up
+ifconfig wifi0.1 up
+ifconfig wifi0.2 up
 ifconfig wifi1 up
 ifconfig wifi1.1 up
 ifconfig wifi1.2 up
+ifconfig wifi1.3 up
 ifconfig wifi2 up
+#ifconfig wifi2.1 up
+#ifconfig wifi2.2 up
 
 
 #Copy configuration file to nvram
@@ -71,8 +112,8 @@ mkdir -p /nvram
 cp InterfaceMap.json /nvram/.
 
 # Create the EasyMeshCfg.json which will have the al_mac_address
-# same as that of wifi_1_1_mac
-al_mac_addr=$wifi1_1_mac
+# same as that of sta wifi_1_3_mac
+al_mac_addr=$wifi1_3_mac
 colocated_mode=0
 backhaul_ssid="mesh_backhaul"
 backhaul_keypassphrase="test-backhaul"


### PR DESCRIPTION
Reason for change: Add support for iot vap in InterfaceMap, wifi_interface_up.sh and wifi_interface_down.sh scripts. Risks: None
Priority: P1