### PR TITLE
RDKB-60904 Enable Force reset flag if SSID is defaulted (#549)

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -837,7 +837,8 @@ int start_wifi_services(void)
         start_radios(rdk_dev_mode_type_gw);
         start_gateway_vaps();
         captive_portal_check();
-#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_)
+#if !defined(NEWPLATFORM_PORT) && !defined(_SR213_PRODUCT_REQ_) && \
+        (defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_))
         /* Function to check for default SSID and Passphrase for Private VAPS
         if they are default and last-reboot reason is SW get the previous config from Webconfig */
         validate_and_sync_private_vap_credentials();


### PR DESCRIPTION
Impacted Platforms:
XB10, XER10

Reason for change: Force reset flag should persist across reboot

Test Procedure: Check if force reset flag exists in nvram if SSID is default during bootup

Risks: Low
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com

---------