### PR TITLE
RDKB-60567: Disable LnF VAPs by default

### DIFF
--- a/source/core/services/vap_svc.c
+++ b/source/core/services/vap_svc.c
@@ -245,6 +245,11 @@ int vap_svc_start_stop(vap_svc_t *svc, bool enable)
                 if(tgt_vap_map->vap_array[tgt_vap_map->num_vaps].u.bss_info.enabled) {
                     tgt_vap_map->vap_array[tgt_vap_map->num_vaps].u.bss_info.enabled = enable;
                 }
+                wifi_util_info_print(WIFI_CTRL,
+                    "%s:%d Vap name is %s and enabled value = %d and rdk_exists = %d\n",
+                    __FUNCTION__, __LINE__, tgt_vap_map->vap_array[tgt_vap_map->num_vaps].vap_name,
+                    tgt_vap_map->vap_array[tgt_vap_map->num_vaps].u.bss_info.enabled,
+                    tgt_rdk_vaps[tgt_vap_map->num_vaps].exists);
                 // VAP is enabled in HAL if it is present in VIF_Config and enabled. Absent VAP
                 // entries are saved to VAP_Config with exist flag set to 0 and default values.
                 enabled[tgt_vap_map->num_vaps] =
@@ -268,7 +273,6 @@ int vap_svc_start_stop(vap_svc_t *svc, bool enable)
 
             tgt_vap_map->num_vaps++;
         }
-
         if (wifi_hal_createVAP(i, tgt_vap_map) != RETURN_OK) {
             wifi_util_error_print(WIFI_CTRL,"%s: wifi vap create failure: radio_index:%d\n",__FUNCTION__, i);
             free(tgt_vap_map);

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -527,22 +527,12 @@ static int update_vap_info_managed_guest(void *data, void *amenities_blob, wifi_
             }
             if (!strcmp(vap_info->vap_name,blob_vap_name_str)) {
                 wifi_util_error_print(WIFI_CTRL, "%s: %d connected_building_enabled %d \n", __func__,__LINE__,connected_building_enabled);
-                strncpy(vap_info->repurposed_bridge_name,"brlan15",sizeof(vap_info->repurposed_bridge_name)-1);
-                int rc = get_managed_guest_bridge(brval, sizeof(brval),radio_index);
-                if (rc != 0)
-                {
-                    snprintf(vap_info->bridge_name, sizeof(vap_info->bridge_name), "brlan%d", radio_index+16);
-                }
-                else
-                {
-                    snprintf(vap_info->bridge_name, sizeof(vap_info->bridge_name), "%s", brval);
-                }
-                                
+
                 if (decode_ssid_blob(vap_info, vb_entry, true, execRetVal) != 0) {
                     wifi_util_error_print(WIFI_CTRL, "%s: Failed to decode SSID blob\n", __func__);
                     status = RETURN_ERR;
                     goto done;
-                 }
+                }
 
                 security_obj = cJSON_GetObjectItem(vb_entry, "Security");
                 if (security_obj == NULL) {
@@ -550,7 +540,6 @@ static int update_vap_info_managed_guest(void *data, void *amenities_blob, wifi_
                     status = RETURN_ERR;
                     goto done;
                 }
-
 
                 /* decode security blob */
                 if (decode_security_blob(vap_info, security_obj, execRetVal) != 0) {
@@ -566,6 +555,15 @@ static int update_vap_info_managed_guest(void *data, void *amenities_blob, wifi_
                 }
                 if (strlen(repurposed_vap_name) != 0) {
                     strncpy(vap_info->repurposed_vap_name, repurposed_vap_name, (strlen(repurposed_vap_name) + 1));
+                }
+                strncpy(vap_info->repurposed_bridge_name, "brlan15",
+                    sizeof(vap_info->repurposed_bridge_name) - 1);
+                int rc = get_managed_guest_bridge(brval, sizeof(brval), radio_index);
+                if (rc != 0) {
+                    snprintf(vap_info->bridge_name, sizeof(vap_info->bridge_name), "brlan%d",
+                        radio_index + 16);
+                } else {
+                    snprintf(vap_info->bridge_name, sizeof(vap_info->bridge_name), "%s", brval);
                 }
             }
         }

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -453,14 +453,17 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         }
 /*For XER5/XB10/XER10 2.4G XHS is disable by default*/
 #if defined(_XER5_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
-        if (isVapLnf(vap_index) || isVapPrivate(vap_index)) {
+        if (isVapLnfSecure(vap_index) || isVapPrivate(vap_index)) {
             cfg.u.bss_info.enabled = true;
         }
 #else
-        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index)) {
+        if ((vap_index == 2) || isVapLnfSecure(vap_index) || isVapPrivate(vap_index)) {
             cfg.u.bss_info.enabled = true;
         }
 #endif 
+        if (isVapLnfPsk(vap_index)) {
+            cfg.u.bss_info.enabled = false;
+        }
 
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4768,9 +4768,11 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
         }
 
         if (g_wifidb->db_version < ONEWIFI_DB_VERSION_MANAGED_WIFI_FLAG) {
-            config->vap_array[i].u.bss_info.am_config.npc.speed_tier = isVapLnfPsk(config->vap_array[i].vap_index) ? DEFAULT_MANAGED_WIFI_SPEED_TIER : 0;
-            wifi_util_dbg_print(WIFI_DB, "%s:%d Update speed_tier:%d for vap_index:%d \n", __func__, __LINE__,
-                config->vap_array[i].u.bss_info.am_config.npc.speed_tier, config->vap_array[i].vap_index);
+            config->vap_array[i].u.bss_info.am_config.npc.speed_tier =
+                isVapLnfPsk(config->vap_array[i].vap_index) ? DEFAULT_MANAGED_WIFI_SPEED_TIER : 0;
+            wifi_util_dbg_print(WIFI_DB, "%s:%d Update speed_tier:%d for vap_index:%d \n", __func__,
+                __LINE__, config->vap_array[i].u.bss_info.am_config.npc.speed_tier,
+                config->vap_array[i].vap_index);
             wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
                 &rdk_config[i]);
         }
@@ -4872,6 +4874,23 @@ void wifidb_vap_config_correction(wifi_vap_info_map_t *l_vap_map_param)
             wifi_util_info_print(WIFI_DB, "%s:%d: Primary Ip and Secondry Ip: %s , %s\n", __func__,
                 __LINE__, (char *)vap_config->u.bss_info.security.u.radius.ip,
                 (char *)vap_config->u.bss_info.security.u.radius.s_ip);
+            continue;
+        }
+        if (isVapLnfPsk(vap_config->vap_index) &&
+            (!vap_config->u.bss_info.mdu_enabled &&
+                !strstr(vap_config->repurposed_vap_name, "managed_guest_")) &&
+            vap_config->u.bss_info.enabled) {
+            vap_config->u.bss_info.enabled = false;
+            rdk_vap_config = get_wifidb_rdk_vaps(vap_config->radio_index);
+            if (rdk_vap_config == NULL) {
+                wifi_util_error_print(WIFI_DB, "%s:%d: failed to get rdk vaps for radio index %d\n",
+                    __func__, __LINE__, vap_config->radio_index);
+                continue;
+            }
+            update_wifi_vap_info(vap_config->vap_name, vap_config, rdk_vap_config);
+            wifi_util_info_print(WIFI_DB,
+                "%s:%d: vap_config->u.bss_info.enabled = false for the vap_name = %s\n", __func__,
+                __LINE__, vap_config->vap_name);
             continue;
         }
     }
@@ -7078,12 +7097,13 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         } else {
             cfg.u.bss_info.showSsid = false;
         }
+
 #if defined(_XER5_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
-        if (isVapLnf(vap_index) || isVapPrivate(vap_index)) {
+        if (isVapLnfSecure(vap_index) || isVapPrivate(vap_index)) {
              cfg.u.bss_info.enabled = true; 
         }
 #else
-        if ((vap_index == 2) || isVapLnf(vap_index) || isVapPrivate(vap_index)) {
+        if ((vap_index == 2) || isVapLnfSecure(vap_index) || isVapPrivate(vap_index)) {
              cfg.u.bss_info.enabled = true;
         }
 #endif
@@ -7093,7 +7113,10 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
             cfg.u.bss_info.enabled = false;
         }
 #endif
-#if defined(_SR213_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+        if (isVapLnfPsk(vap_index)) {
+            cfg.u.bss_info.enabled = false;
+        }
+#if defined(_SR213_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
         cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
 #else
         cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_SKY;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -7116,7 +7116,7 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         if (isVapLnfPsk(vap_index)) {
             cfg.u.bss_info.enabled = false;
         }
-#if defined(_SR213_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
+#if defined(_SR213_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
         cfg.u.bss_info.bssMaxSta = wifi_hal_cap_obj->wifi_prop.BssMaxStaAllow;
 #else
         cfg.u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_SKY;


### PR DESCRIPTION
RDKB-60567: Disable LnF VAPs by default

Impacted Platforms:
TXB7

Reason for change: Make LnF PSK Vaps disabled by default. Only when Managed Wifi Phase 1 or Phase 2 is enabled, should they be in an enabled state.

Test Procedure: Test

Risks: Low

Signed-off-by:Srijeyarankesh_JS@comcast.com1