### PR TITLE
RDKBWIFI-48: Pass vap password through to easymesh

### DIFF
--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -511,6 +511,7 @@ webconfig_error_t translate_vap_info_to_em_common(const wifi_vap_info_t *vap, co
     vap_row->enabled = vap->u.bss_info.enabled;
     strncpy(vap_row->ssid, vap->u.bss_info.ssid, sizeof(vap_row->ssid));
     vap_row->vap_index = vap->vap_index;
+    strncpy(vap_row->mesh_ap_passphrase, vap->u.bss_info.security.u.key.key, sizeof(vap_row->mesh_ap_passphrase));
 
     // Set the em_bss_info_t vendor_elements to the same as wifi_vap_info_t vendor_elements
     memset(vap_row->vendor_elements, 0, sizeof(vap_row->vendor_elements));


### PR DESCRIPTION
Reason for change: With this, unified-wifi-mesh can read the SSID and password of the backhaul mesh, then tell the backhaul sta that it should connect to that network. `unified-wifi-mesh` should be in charge of telling OneWifi what it should associate to. `OneWifi` shouldn't blindly associate to a network.

Test Procedure: Ensure the `mesh_ap_passphrase` variable is populated in the `em_bss_t` struct.

Risks: Very Low

Priority: P1

Depends on [unified-wifi-mesh #442](https://github.com/rdkcentral/unified-wifi-mesh/pull/442)