### PR TITLE
RDKB-60452:WIFI_PASSWORD_FAIL" Telemetry Markers are not reporting

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -2998,8 +2998,7 @@ int device_deauthenticated(int ap_index, char *src_mac, char *dest_mac, int type
     }
 
     if ((ap_reason_code(ap_index, src_mac, dest_mac, type, reason)) != 0) {
-       wifi_util_dbg_print(WIFI_MON,"%s:%d failed in getting the reason code details as mac is null \n", __func__, __LINE__);
-       return -1;
+       wifi_util_dbg_print(WIFI_MON,"%s:%d failed in getting the reason code details \n", __func__, __LINE__);
     }
 
     if (reason == WLAN_RADIUS_GREYLIST_REJECT) {


### PR DESCRIPTION
Impacted Platforms:
All Onewifi Platforms
Reason for change:WIFI_PASSWORD_FAIL" Telemetry Markers are not reporting so make required changes. Test Procedure:
connect the client and check WIFI_PASSWORD_FAIL/WIFI_POSSIBLE_WPS_PSK_FAIL markers are reported in wifihealth.txt after password is changed. Priority: P1
Risks: Low
Signed-off-by:Harshavardhan_Pulluru@comcast.com