### PR TITLE
RDKB-60953, BCOMB-3031: Add AMSDU TID handling (#538) (#597)

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -1486,6 +1486,28 @@ INSTMSMT_PH2 -->
                         </parameter>
                     </parameters>
                     <objects>
+                        <object>
+                            <name>AMSDU_TID</name>
+                            <objectType>staticTable</objectType>
+                            <maxInstance>8</maxInstance>
+                            <functions>
+                                <func_GetEntryCount>AMSDU_TID_GetEntryCount</func_GetEntryCount>
+                                <func_GetEntry>AMSDU_TID_GetEntry</func_GetEntry>
+                                <func_GetParamBoolValue>AMSDU_TID_GetParamBoolValue</func_GetParamBoolValue>
+                                <func_SetParamBoolValue>AMSDU_TID_SetParamBoolValue</func_SetParamBoolValue>
+                                <func_Validate>AMSDU_TID_Validate</func_Validate>
+                                <func_Commit>AMSDU_TID_Commit</func_Commit>
+                                <func_Rollback>AMSDU_TID_Rollback</func_Rollback>
+                            </functions>
+                            <parameters>
+                                <parameter>
+                                    <name>Enable</name>
+                                    <type>boolean</type>
+                                    <syntax>bool</syntax>
+                                    <writable>true</writable>
+                                </parameter>
+                            </parameters>
+                        </object>
 <!-- INSTMSMT_PH2
                         <object>
                             <name>X_TCH_COM_11nCalcResult</name>
@@ -1811,7 +1833,7 @@ INSTMSMT_PH2 -->
 									<func_Commit>BandSetting_Commit</func_Commit>
 									<func_Rollback>BandSetting_Rollback</func_Rollback>
 								</functions>
-								<parameters>	
+								<parameters>
 									<parameter>
 										<name>UtilizationThreshold</name>
 										<type>int</type>

--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -1,6 +1,6 @@
 {
   "name": "Wifi_Rdk_Database",
-  "version": "1.00.036",
+  "version": "1.00.037",
   "cksum": "2353365742 523",
   "tables": {
     "Wifi_Device_Config": {
@@ -1511,6 +1511,15 @@
           }
         },
         "radar_detected": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "amsdu_tid": {
           "type": {
             "key": {
               "type": "string"

--- a/lib/inc/schema_gen.h
+++ b/lib/inc/schema_gen.h
@@ -1576,6 +1576,7 @@
         PJS_OVS_INT(Tidle) \
         PJS_OVS_INT(dfs_timer) \
         PJS_OVS_STRING(radar_detected, 256 + 1) \
+        PJS_OVS_STRING(amsdu_tid, 128 + 1) \
     )
 
 #define PJS_SCHEMA_Wifi_Global_Config \
@@ -3238,7 +3239,8 @@
     COLUMN(Nscan) \
     COLUMN(Tidle) \
     COLUMN(dfs_timer) \
-    COLUMN(radar_detected)
+    COLUMN(radar_detected) \
+    COLUMN(amsdu_tid)
 
 #define SCHEMA__Wifi_Global_Config "Wifi_Global_Config"
 #define SCHEMA_COLUMN__Wifi_Global_Config(COLUMN) \
@@ -4495,6 +4497,7 @@
 #define SCHEMA__Wifi_Radio_Config__Tidle "Tidle"
 #define SCHEMA__Wifi_Radio_Config__dfs_timer "dfs_timer"
 #define SCHEMA__Wifi_Radio_Config__radar_detected "radar_detected"
+#define SCHEMA__Wifi_Radio_Config__amsdu_tid "amsdu_tid"
 
 #define SCHEMA__Wifi_Global_Config__gas_config "gas_config"
 #define SCHEMA__Wifi_Global_Config__notify_wifi_changes "notify_wifi_changes"

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -1594,6 +1594,10 @@ static bool is_radio_param_config_changed(wifi_radio_operationParam_t *old , wif
     if (IS_CHANGED(old->variant,new->variant)) return true;
     if (IS_CHANGED(old->EcoPowerDown,new->EcoPowerDown)) return true;
     if (IS_CHANGED(old->DFSTimer, new->DFSTimer)) return true;
+    for (int i = 0; i < MAX_AMSDU_TID; ++i)
+    {
+        if (IS_CHANGED(old->amsduTid[i], new->amsduTid[i])) return true;
+    }
 
     return false;
 }

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -182,6 +182,27 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
         Fcfg.OffChanTidleInSec = 0;
     }
 
+    for (int j = 0; j < MAX_AMSDU_TID; j++) {
+        cfg.amsduTid[j] = FALSE;
+    }
+
+#if defined(_XB10_PRODUCT_REQ_) || defined(_XER10_PRODUCT_REQ_)
+    if (cfg.band == WIFI_FREQUENCY_6_BAND) {
+        for (int j = 0; j < 5; j++) {
+            cfg.amsduTid[j] = TRUE;
+        }
+    } else {
+        for (int j = 0; j < 4; j++) {
+            cfg.amsduTid[j] = TRUE;
+        }
+    }
+#elif defined(_XB8_PRODUCT_REQ_)
+    cfg.amsduTid[0] = TRUE;
+    if (cfg.band == WIFI_FREQUENCY_6_BAND) {
+        cfg.amsduTid[4] = TRUE;
+    }
+#endif
+
     wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d Tscan:%lu Nscan:%lu Nidle:%lu\n", __func__, __LINE__, Fcfg.OffChanTscanInMsec, Fcfg.OffChanNscanInSec, Fcfg.OffChanTidleInSec);
     /* Call the function to update the operating classes based on Country code and Radio */
     update_radio_operating_classes(&cfg);

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -427,11 +427,22 @@ void callback_Wifi_Radio_Config(ovsdb_update_monitor_t *mon,
             i++;
         }
         l_radio_cfg->numSecondaryChannels = new_rec->num_secondary_channels;
+
+        i = 0;
+        tmp = new_rec->amsdu_tid;
+        while ((ptr = strchr(tmp, ',')) != NULL)
+        {
+            ptr++;
+            l_radio_cfg->amsduTid[i] = atoi(tmp);
+            tmp = ptr;
+            i++;
+        }
+
         f_radio_cfg->OffChanTscanInMsec = new_rec->Tscan;
         f_radio_cfg->OffChanNscanInSec = (new_rec->Nscan == 0) ? 0 : (24*3600)/(new_rec->Nscan);
         f_radio_cfg->OffChanTidleInSec = new_rec->Tidle;
         f_radio_cfg->radio_index = index;
-        wifi_util_dbg_print(WIFI_DB,"%s:%d: Wifi_Radio_Config data enabled=%d freq_band=%d auto_channel_enabled=%d channel=%d  channel_width=%d hw_mode=%d csa_beacon_count=%d country=%d OperatingEnviroment=%d dcs_enabled=%d numSecondaryChannels=%d channelSecondary=%s dtim_period %d beacon_interval %d operating_class %d basic_data_transmit_rate %d operational_data_transmit_rate %d  fragmentation_threshold %d guard_interval %d transmit_power %d rts_threshold %d factory_reset_ssid = %d, radio_stats_measuring_rate = %d, radio_stats_measuring_interval = %d, cts_protection %d, obss_coex= %d, stbc_enable= %d, greenfield_enable= %d, user_control= %d, admin_control= %d,chan_util_threshold= %d, chan_util_selfheal_enable= %d, eco_power_down= %d dfs_timer:%d radar_Detected:%s \n",__func__, __LINE__,l_radio_cfg->enable,l_radio_cfg->band,l_radio_cfg->autoChannelEnabled,l_radio_cfg->channel,l_radio_cfg->channelWidth,l_radio_cfg->variant,l_radio_cfg->csa_beacon_count,l_radio_cfg->countryCode,l_radio_cfg->operatingEnvironment,l_radio_cfg->DCSEnabled,l_radio_cfg->numSecondaryChannels,new_rec->secondary_channels_list,l_radio_cfg->dtimPeriod,l_radio_cfg->beaconInterval,l_radio_cfg->operatingClass,l_radio_cfg->basicDataTransmitRates,l_radio_cfg->operationalDataTransmitRates,l_radio_cfg->fragmentationThreshold,l_radio_cfg->guardInterval,l_radio_cfg->transmitPower,l_radio_cfg->rtsThreshold,l_radio_cfg->factoryResetSsid,l_radio_cfg->radioStatsMeasuringInterval,l_radio_cfg->radioStatsMeasuringInterval,l_radio_cfg->ctsProtection,l_radio_cfg->obssCoex,l_radio_cfg->stbcEnable,l_radio_cfg->greenFieldEnable,l_radio_cfg->userControl,l_radio_cfg->adminControl,l_radio_cfg->chanUtilThreshold,l_radio_cfg->chanUtilSelfHealEnable, l_radio_cfg->EcoPowerDown, l_radio_cfg->DFSTimer, l_radio_cfg->radarDetected);
+        wifi_util_dbg_print(WIFI_DB,"%s:%d: Wifi_Radio_Config data enabled=%d freq_band=%d auto_channel_enabled=%d channel=%d  channel_width=%d hw_mode=%d csa_beacon_count=%d country=%d OperatingEnviroment=%d dcs_enabled=%d numSecondaryChannels=%d channelSecondary=%s dtim_period %d beacon_interval %d operating_class %d basic_data_transmit_rate %d operational_data_transmit_rate %d  fragmentation_threshold %d guard_interval %d transmit_power %d rts_threshold %d factory_reset_ssid = %d, radio_stats_measuring_rate = %d, radio_stats_measuring_interval = %d, cts_protection %d, obss_coex= %d, stbc_enable= %d, greenfield_enable= %d, user_control= %d, admin_control= %d,chan_util_threshold= %d, chan_util_selfheal_enable= %d, eco_power_down= %d dfs_timer:%d radar_Detected:%s amsdu_tid: [%d, %d, %d, %d, %d, %d, %d, %d] \n",__func__, __LINE__,l_radio_cfg->enable,l_radio_cfg->band,l_radio_cfg->autoChannelEnabled,l_radio_cfg->channel,l_radio_cfg->channelWidth,l_radio_cfg->variant,l_radio_cfg->csa_beacon_count,l_radio_cfg->countryCode,l_radio_cfg->operatingEnvironment,l_radio_cfg->DCSEnabled,l_radio_cfg->numSecondaryChannels,new_rec->secondary_channels_list,l_radio_cfg->dtimPeriod,l_radio_cfg->beaconInterval,l_radio_cfg->operatingClass,l_radio_cfg->basicDataTransmitRates,l_radio_cfg->operationalDataTransmitRates,l_radio_cfg->fragmentationThreshold,l_radio_cfg->guardInterval,l_radio_cfg->transmitPower,l_radio_cfg->rtsThreshold,l_radio_cfg->factoryResetSsid,l_radio_cfg->radioStatsMeasuringInterval,l_radio_cfg->radioStatsMeasuringInterval,l_radio_cfg->ctsProtection,l_radio_cfg->obssCoex,l_radio_cfg->stbcEnable,l_radio_cfg->greenFieldEnable,l_radio_cfg->userControl,l_radio_cfg->adminControl,l_radio_cfg->chanUtilThreshold,l_radio_cfg->chanUtilSelfHealEnable, l_radio_cfg->EcoPowerDown, l_radio_cfg->DFSTimer, l_radio_cfg->radarDetected, l_radio_cfg->amsduTid[0], l_radio_cfg->amsduTid[1], l_radio_cfg->amsduTid[2], l_radio_cfg->amsduTid[3], l_radio_cfg->amsduTid[4], l_radio_cfg->amsduTid[5], l_radio_cfg->amsduTid[6], l_radio_cfg->amsduTid[7]);
         wifi_util_dbg_print(WIFI_DB, "%s:%d Wifi_Radio_Config data Tscan=%lu Nscan=%lu, Tidle=%lu\n", __FUNCTION__, __LINE__, f_radio_cfg->OffChanTscanInMsec, f_radio_cfg->OffChanNscanInSec, f_radio_cfg->OffChanTidleInSec);
         pthread_mutex_unlock(&g_wifidb->data_cache_lock);
     }
@@ -1800,8 +1811,8 @@ int wifidb_update_wifi_radio_config(int radio_index, wifi_radio_operationParam_t
     unsigned int i = 0;
     int k = 0;
     int len = 0;
-    char channel_list[BUFFER_LENGTH_WIFIDB] = {0};
-    len = sizeof(channel_list)-1;
+    char list_buffer[BUFFER_LENGTH_WIFIDB] = {0};
+    len = sizeof(list_buffer)-1;
     wifi_db_t *g_wifidb;
     g_wifidb = (wifi_db_t*) get_wifidb_obj();
 
@@ -1871,15 +1882,28 @@ int wifidb_update_wifi_radio_config(int radio_index, wifi_radio_operationParam_t
             wifi_util_dbg_print(WIFI_DB,"%s:%d Wifi_Radio_Config table Maximum size reached for secondary_channels_list\n",__func__, __LINE__);
             break;
         }
-        snprintf(channel_list+k,sizeof(channel_list)-k,"%d,",config->channelSecondary[i]);
-        wifi_util_dbg_print(WIFI_DB,"%s:%d Wifi_Radio_Config table Channel list %s %d\t",__func__, __LINE__,channel_list,strlen(channel_list));
-        k = strlen(channel_list);
+        snprintf(list_buffer+k,sizeof(list_buffer)-k,"%d,",config->channelSecondary[i]);
+        wifi_util_dbg_print(WIFI_DB,"%s:%d Wifi_Radio_Config table Channel list %s %d\t",__func__, __LINE__,list_buffer,strlen(list_buffer));
+        k = strlen(list_buffer);
     }
-    strncpy(cfg.secondary_channels_list,channel_list,sizeof(cfg.secondary_channels_list)-1);
+    strncpy(cfg.secondary_channels_list,list_buffer,sizeof(cfg.secondary_channels_list)-1);
     cfg.num_secondary_channels = config->numSecondaryChannels;
     strncpy(cfg.radio_name,name,sizeof(cfg.radio_name)-1);
 
-    wifi_util_dbg_print(WIFI_DB,"%s:%d: Wifi_Radio_Config data enabled=%d freq_band=%d auto_channel_enabled=%d channel=%d  channel_width=%d hw_mode=%d csa_beacon_count=%d country=%d dcs_enabled=%d numSecondaryChannels=%d channelSecondary=%s dtim_period %d beacon_interval %d operating_class %d basic_data_transmit_rate %d operational_data_transmit_rate %d  fragmentation_threshold %d guard_interval %d transmit_power %d rts_threshold %d factory_reset_ssid = %d  radio_stats_measuring_rate = %d   radio_stats_measuring_interval = %d cts_protection = %d obss_coex = %d  stbc_enable = %d  greenfield_enable = %d user_control = %d  admin_control = %d  chan_util_threshold = %d  chan_util_selfheal_enable = %d  eco_power_down = %d DFSTimer:%d radarDetected:%s \n",__func__, __LINE__,config->enable,config->band,config->autoChannelEnabled,config->channel,config->channelWidth,config->variant,config->csa_beacon_count,config->countryCode,config->DCSEnabled,config->numSecondaryChannels,cfg.secondary_channels_list,config->dtimPeriod,config->beaconInterval,config->operatingClass,config->basicDataTransmitRates,config->operationalDataTransmitRates,config->fragmentationThreshold,config->guardInterval,config->transmitPower,config->rtsThreshold,config->factoryResetSsid,config->radioStatsMeasuringRate,config->radioStatsMeasuringInterval,config->ctsProtection,config->obssCoex,config->stbcEnable,config->greenFieldEnable,config->userControl,config->adminControl,config->chanUtilThreshold,config->chanUtilSelfHealEnable,config->EcoPowerDown, config->DFSTimer, config->radarDetected);
+    k = 0;
+    memset(list_buffer, 0, sizeof(list_buffer));
+    for(i=0;i<MAX_AMSDU_TID;i++)
+    {
+        if(k >= (len-1))
+        {
+            wifi_util_dbg_print(WIFI_DB,"%s:%d Wifi_Radio_Config table Maximum size reached for amsdu_tid list\n",__func__, __LINE__);
+            break;
+        }
+        snprintf(list_buffer+k,sizeof(list_buffer)-k,"%d,",config->amsduTid[i]);
+        k = strlen(list_buffer);
+    }
+    strncpy(cfg.amsdu_tid,list_buffer,sizeof(cfg.amsdu_tid)-1);
+    wifi_util_dbg_print(WIFI_DB,"%s:%d: Wifi_Radio_Config data enabled=%d freq_band=%d auto_channel_enabled=%d channel=%d  channel_width=%d hw_mode=%d csa_beacon_count=%d country=%d dcs_enabled=%d numSecondaryChannels=%d channelSecondary=%s dtim_period %d beacon_interval %d operating_class %d basic_data_transmit_rate %d operational_data_transmit_rate %d  fragmentation_threshold %d guard_interval %d transmit_power %d rts_threshold %d factory_reset_ssid = %d  radio_stats_measuring_rate = %d   radio_stats_measuring_interval = %d cts_protection = %d obss_coex = %d  stbc_enable = %d  greenfield_enable = %d user_control = %d  admin_control = %d  chan_util_threshold = %d  chan_util_selfheal_enable = %d  eco_power_down = %d DFSTimer:%d radarDetected:%s, amsduTid: %d, %d, %d, %d, %d, %d, %d, %d\n",__func__, __LINE__,config->enable,config->band,config->autoChannelEnabled,config->channel,config->channelWidth,config->variant,config->csa_beacon_count,config->countryCode,config->DCSEnabled,config->numSecondaryChannels,cfg.secondary_channels_list,config->dtimPeriod,config->beaconInterval,config->operatingClass,config->basicDataTransmitRates,config->operationalDataTransmitRates,config->fragmentationThreshold,config->guardInterval,config->transmitPower,config->rtsThreshold,config->factoryResetSsid,config->radioStatsMeasuringRate,config->radioStatsMeasuringInterval,config->ctsProtection,config->obssCoex,config->stbcEnable,config->greenFieldEnable,config->userControl,config->adminControl,config->chanUtilThreshold,config->chanUtilSelfHealEnable,config->EcoPowerDown, config->DFSTimer, config->radarDetected, config->amsduTid[0], config->amsduTid[1],config->amsduTid[2], config->amsduTid[3],config->amsduTid[4], config->amsduTid[5],config->amsduTid[6], config->amsduTid[7]);
     wifi_util_dbg_print(WIFI_DB, " %s:%d Wifi_Radio_Config data Tscan=%lu Nscan=%lu Tidle=%lu \n", __FUNCTION__, __LINE__, feat_config->OffChanTscanInMsec, feat_config->OffChanNscanInSec, feat_config->OffChanTidleInSec);
     if(onewifi_ovsdb_table_upsert_f(g_wifidb->wifidb_sock_path,&table_Wifi_Radio_Config,&cfg,false,insert_filter) == false)
     {
@@ -2047,7 +2071,17 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
     }
     config->numSecondaryChannels = cfg->num_secondary_channels;
 
-    wifi_util_dbg_print(WIFI_DB,"%s:%d: Wifi_Radio_Config data enabled=%d freq_band=%d auto_channel_enabled=%d channel=%d  channel_width=%d hw_mode=%d csa_beacon_count=%d country=%d operatingEnvironment=%d dcs_enabled=%d numSecondaryChannels=%d channelSecondary=%s dtim_period %d beacon_interval %d operating_class %d basic_data_transmit_rate %d operational_data_transmit_rate %d  fragmentation_threshold %d guard_interval %d transmit_power %d rts_threshold %d factory_reset_ssid = %d, radio_stats_measuring_rate = %d, radio_stats_measuring_interval = %d, cts_protection %d, obss_coex= %d, stbc_enable= %d, greenfield_enable= %d, user_control= %d, admin_control= %d,chan_util_threshold= %d, chan_util_selfheal_enable= %d, eco_power_down=%d DFSTimer:%d radarDetected:%s \n",__func__, __LINE__,config->enable,config->band,config->autoChannelEnabled,config->channel,config->channelWidth,config->variant,config->csa_beacon_count,config->countryCode,config->operatingEnvironment,config->DCSEnabled,config->numSecondaryChannels,cfg->secondary_channels_list,config->dtimPeriod,config->beaconInterval,config->operatingClass,config->basicDataTransmitRates,config->operationalDataTransmitRates,config->fragmentationThreshold,config->guardInterval,config->transmitPower,config->rtsThreshold,config->factoryResetSsid,config->radioStatsMeasuringInterval,config->radioStatsMeasuringInterval,config->ctsProtection,config->obssCoex,config->stbcEnable,config->greenFieldEnable,config->userControl,config->adminControl,config->chanUtilThreshold,config->chanUtilSelfHealEnable, config->EcoPowerDown, config->DFSTimer, config->radarDetected);
+    i = 0;
+    tmp = cfg->amsdu_tid;
+    while ((ptr = strchr(tmp, ',')) != NULL)
+    {
+        ptr++;
+        config->amsduTid[i] = atoi(tmp);
+        tmp = ptr;
+        i++;
+    }
+
+    wifi_util_dbg_print(WIFI_DB,"%s:%d: Wifi_Radio_Config data enabled=%d freq_band=%d auto_channel_enabled=%d channel=%d  channel_width=%d hw_mode=%d csa_beacon_count=%d country=%d operatingEnvironment=%d dcs_enabled=%d numSecondaryChannels=%d channelSecondary=%s dtim_period %d beacon_interval %d operating_class %d basic_data_transmit_rate %d operational_data_transmit_rate %d  fragmentation_threshold %d guard_interval %d transmit_power %d rts_threshold %d factory_reset_ssid = %d, radio_stats_measuring_rate = %d, radio_stats_measuring_interval = %d, cts_protection %d, obss_coex= %d, stbc_enable= %d, greenfield_enable= %d, user_control= %d, admin_control= %d,chan_util_threshold= %d, chan_util_selfheal_enable= %d, eco_power_down=%d DFSTimer:%d radarDetected:%s, amsduTid:[%d, %d, %d, %d, %d, %d, %d, %d]\n",__func__, __LINE__,config->enable,config->band,config->autoChannelEnabled,config->channel,config->channelWidth,config->variant,config->csa_beacon_count,config->countryCode,config->operatingEnvironment,config->DCSEnabled,config->numSecondaryChannels,cfg->secondary_channels_list,config->dtimPeriod,config->beaconInterval,config->operatingClass,config->basicDataTransmitRates,config->operationalDataTransmitRates,config->fragmentationThreshold,config->guardInterval,config->transmitPower,config->rtsThreshold,config->factoryResetSsid,config->radioStatsMeasuringInterval,config->radioStatsMeasuringInterval,config->ctsProtection,config->obssCoex,config->stbcEnable,config->greenFieldEnable,config->userControl,config->adminControl,config->chanUtilThreshold,config->chanUtilSelfHealEnable, config->EcoPowerDown, config->DFSTimer, config->radarDetected, config->amsduTid[0], config->amsduTid[1], config->amsduTid[2], config->amsduTid[3], config->amsduTid[4], config->amsduTid[5], config->amsduTid[6], config->amsduTid[7]);
     wifi_util_dbg_print(WIFI_DB, " %s:%d Wifi_Radio_Config data Tscan=%lu Nscan=%lu Tidle=%lu \n", __FUNCTION__, __LINE__, feat_config->OffChanTscanInMsec, feat_config->OffChanNscanInSec, feat_config->OffChanTidleInSec);
     free(cfg);
     return RETURN_OK;
@@ -6616,6 +6650,29 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
         Fcfg.OffChanNscanInSec = 0;
         Fcfg.OffChanTidleInSec = 0;
     }
+
+    for (int j = 0; j < MAX_AMSDU_TID; j++) {
+        cfg.amsduTid[j] = FALSE;
+    }
+
+#if defined(_XB10_PRODUCT_REQ_) || defined(_XER10_PRODUCT_REQ_)
+    if (cfg.band == WIFI_FREQUENCY_6_BAND) {
+        for (int i = 0; i < 5; i++)
+        {
+            cfg.amsduTid[i] = TRUE;
+        }
+    } else {
+        for (int i = 0; i < 4; i++)
+        {
+            cfg.amsduTid[i] = TRUE;
+        }
+    }
+#elif defined(_XB8_PRODUCT_REQ_)
+    cfg.amsduTid[0] = TRUE;
+    if (cfg.band == WIFI_FREQUENCY_6_BAND) {
+        cfg.amsduTid[4] = TRUE;
+    }
+#endif
 
     wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d Tscan:%lu Nscan:%lu Nidle:%lu\n", __func__, __LINE__, Fcfg.OffChanTscanInMsec, Fcfg.OffChanNscanInSec, Fcfg.OffChanTidleInSec);
     /* Call the function to update the operating classes based on Country code and Radio */

--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -1455,7 +1455,10 @@ void update_dml_radio_default() {
         radio_cfg[i].ThresholdRange = 100;
         radio_cfg[i].ThresholdInUse = -99;
         radio_cfg[i].ReverseDirectionGrant = 0;
-	radio_cfg[i].AggregationMSDU = 0;
+        radio_cfg[i].AggregationMSDU = 0;
+        for (int j = 0; j < MAX_AMSDU_TID; j++) {
+            radio_cfg[i].AmsduTid[j] = FALSE;
+        }
         radio_cfg[i].AutoBlockAck = 0;
         radio_cfg[i].DeclineBARequest = 0;
         radio_cfg[i].WirelessOnOffButton = 0;
@@ -1477,6 +1480,12 @@ void update_dml_radio_default() {
 #else
             strncpy(radio_cfg[i].SupportedStandards,"g,n,ax",sizeof(radio_cfg[i].SupportedStandards)-1);
 #endif /* CONFIG_IEEE80211BE */
+
+#if defined(_XB10_PRODUCT_REQ_) || defined(_XER10_PRODUCT_REQ_)
+            memset(radio_cfg[i].AmsduTid, 1, sizeof(BOOL) * 4);
+#elif defined(_XB8_PRODUCT_REQ_)
+            radio_cfg[i].AmsduTid[0] = 1;
+#endif
         } else if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_5_BAND) {
             radio_cfg[i].MaxBitRate = 4804;
             strncpy(radio_cfg[i].ChannelsInUse,"44",sizeof(radio_cfg[i].ChannelsInUse)-1);
@@ -1485,6 +1494,11 @@ void update_dml_radio_default() {
 #else
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax",sizeof(radio_cfg[i].SupportedStandards)-1);
 #endif /* CONFIG_IEEE80211BE */
+#if defined(_XB10_PRODUCT_REQ_) || defined(_XER10_PRODUCT_REQ_)
+            memset(radio_cfg[i].AmsduTid, 1, sizeof(BOOL) * 4);
+#elif defined(_XB8_PRODUCT_REQ_)
+            radio_cfg[i].AmsduTid[0] = 1;
+#endif
         } else if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_5L_BAND) {
             radio_cfg[i].MaxBitRate = 4804;
             strncpy(radio_cfg[i].ChannelsInUse,"44",sizeof(radio_cfg[i].ChannelsInUse)-1);
@@ -1493,6 +1507,11 @@ void update_dml_radio_default() {
 #else
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax",sizeof(radio_cfg[i].SupportedStandards)-1);
 #endif /* CONFIG_IEEE80211BE */
+#if defined(_XB10_PRODUCT_REQ_) || defined(_XER10_PRODUCT_REQ_)
+            memset(radio_cfg[i].AmsduTid, 1, sizeof(BOOL) * 4);
+#elif defined(_XB8_PRODUCT_REQ_)
+            radio_cfg[i].AmsduTid[0] = 1;
+#endif
         } else if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_5H_BAND) {
             radio_cfg[i].MaxBitRate = 4804;
             strncpy(radio_cfg[i].ChannelsInUse,"149",sizeof(radio_cfg[i].ChannelsInUse)-1);
@@ -1501,6 +1520,11 @@ void update_dml_radio_default() {
 #else
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax",sizeof(radio_cfg[i].SupportedStandards)-1);
 #endif /* CONFIG_IEEE80211BE */
+#if defined(_XB10_PRODUCT_REQ_) || defined(_XER10_PRODUCT_REQ_)
+            memset(radio_cfg[i].AmsduTid, 1, sizeof(BOOL) * 4);
+#elif defined(_XB8_PRODUCT_REQ_)
+            radio_cfg[i].AmsduTid[0] = 1;
+#endif
         } else if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_6_BAND) {
             radio_cfg[i].MaxBitRate = 9608;
             strncpy(radio_cfg[i].ChannelsInUse,"181",sizeof(radio_cfg[i].ChannelsInUse)-1);
@@ -1510,6 +1534,12 @@ void update_dml_radio_default() {
 #else
             strncpy(radio_cfg[i].SupportedStandards,"ax",sizeof(radio_cfg[i].SupportedStandards)-1);
 #endif /* CONFIG_IEEE80211BE */
+#if defined(_XB10_PRODUCT_REQ_) || defined(_XER10_PRODUCT_REQ_)
+            memset(radio_cfg[i].AmsduTid, (BOOL)1, sizeof(BOOL) * 5);
+#elif defined(_XB8_PRODUCT_REQ_)
+            radio_cfg[i].AmsduTid[0] = 1;
+            radio_cfg[i].AmsduTid[4] = 1;
+#endif
         }
     }
 }

--- a/source/dml/dml_webconfig/dml_onewifi_api.h
+++ b/source/dml/dml_webconfig/dml_onewifi_api.h
@@ -66,6 +66,7 @@ typedef struct {
     BOOL    DCSSupported;
     BOOL    ReverseDirectionGrant;
     BOOL    AggregationMSDU;
+    BOOL    AmsduTid[MAX_AMSDU_TID];
     BOOL    AutoBlockAck;
     BOOL    DeclineBARequest;
     BOOL    WirelessOnOffButton;

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -3188,8 +3188,7 @@ Radio_SetParamBoolValue
 
     if( AnscEqualString(ParamName, "X_CISCO_COM_AggregationMSDU", TRUE))
     {
-	if (rcfg->AggregationMSDU == bValue)
-        {
+        if (rcfg->AggregationMSDU == bValue) {
             return TRUE;
         }
         rcfg->AggregationMSDU = bValue;
@@ -4823,6 +4822,284 @@ Stats3_Commit
     return ANSC_STATUS_SUCCESS; 
 }
 
+/***********************************************************************
+
+  APIs for Object:
+
+ WiFi.Radio.{i}.AMSDU_TID.{i}.Enabled
+
+   *  AMSDU_TID_GetEntryCount
+   *  AMSDU_TID_GetEntry
+   *  AMSDU_TID_GetParamBoolValue
+   *  AMSDU_TID_SetParamBoolValue
+
+ ***********************************************************************/
+/**********************************************************************
+
+        caller:	 owner of this object
+
+  prototype:
+
+    ULONG
+    AMSDU_TID_GetEntryCount
+      (
+        ANSC_HANDLE         hInsContext
+      );
+
+  description:
+
+    This function is called to retrieve the count of the table.
+
+  argument:   ANSC_HANDLE         hInsContext,
+        The instance handle;
+
+  return:   The count of the table
+
+**********************************************************************/
+ULONG
+AMSDU_TID_GetEntryCount(ANSC_HANDLE hInsContext)
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    return MAX_AMSDU_TID;
+}
+
+/**********************************************************************
+
+  caller:   owner of this object
+
+  prototype:
+
+    ANSC_HANDLE
+    AMSDU_TID_GetEntry
+      (
+        ANSC_HANDLE         hInsContext,
+        ULONG            nIndex,
+        ULONG*            pInsNumber
+      );
+
+  description:
+
+    This function is called to retrieve the entry specified by the index.
+
+  argument:  ANSC_HANDLE         hInsContext,
+        The instance handle;
+
+        ULONG            nIndex,
+        The index of this entry;
+
+        ULONG*            pInsNumber
+        The output instance number;
+
+  return:   The handle to identify the entry
+
+**********************************************************************/
+ANSC_HANDLE
+AMSDU_TID_GetEntry(ANSC_HANDLE hInsContext, ULONG nIndex, ULONG *pInsNumber)
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    wifi_util_dbg_print(WIFI_DMCLI, "%s:%d: nIndex:%ld\n", __func__, __LINE__, nIndex);
+    wifi_radio_operationParam_t *wifiRadioOperParam = (wifi_radio_operationParam_t *)hInsContext;
+
+    INT radio_instance_number = 0;
+
+    if (nIndex >= MAX_AMSDU_TID) {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Bad AMSDU TID idx specified: %ld\n", __func__,__LINE__, nIndex);
+        return NULL;
+    }
+
+    if (wifiRadioOperParam == NULL)
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Failed to get wifiRadioOperParam\n", __func__,__LINE__);
+        return FALSE;
+    }
+
+    if (convert_freq_band_to_radio_index(wifiRadioOperParam->band, &radio_instance_number) == RETURN_ERR) {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Invalid frequency band - can't decode radio idx %X\n", __func__, __LINE__, wifiRadioOperParam->band);
+        return FALSE;
+    }
+
+    if ((radio_instance_number < 0) || (radio_instance_number > (INT)get_num_radio_dml()))
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Radio instanceNumber:%d out of range\n", __func__,__LINE__, radio_instance_number);
+        return FALSE;
+    }
+
+    *pInsNumber = nIndex + 1;
+    return (ANSC_HANDLE) ((radio_instance_number << 8) + *pInsNumber);
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        AMSDU_TID_SetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL                        bValue
+            );
+
+    description:
+
+        This function is called to retrieve Boolean parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL                        bValue
+                The buffer of returned boolean value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+
+BOOL AMSDU_TID_SetParamBoolValue(ANSC_HANDLE hInsContext, char *ParamName, BOOL bValue)
+{
+#if !defined(_XB8_PRODUCT_REQ_) && !defined(_XB10_PRODUCT_REQ_) && !defined(_XER10_PRODUCT_REQ_)
+    wifi_util_dbg_print(WIFI_DMCLI, "%s:%d AMSDU not supported on the device\n", __func__,
+        __LINE__);
+    return FALSE;
+#else
+
+
+    unsigned long amsdu_mask = (unsigned long)hInsContext;
+    uint8_t radio_instance_number = amsdu_mask >> 8;
+    uint8_t tid_idx = (amsdu_mask & 0xf) - 1;
+
+    wifi_radio_operationParam_t *wifiRadioOperParam = (wifi_radio_operationParam_t *) get_dml_cache_radio_map(radio_instance_number);
+
+    if (wifiRadioOperParam == NULL)
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Unable to get Radio Param for instance_number:%d\n", __func__, __LINE__, radio_instance_number);
+        return FALSE;
+    }
+
+    if ((radio_instance_number < 0) || (radio_instance_number > (INT)get_num_radio_dml()))
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Radio instanceNumber:%d out of range\n", __func__, __LINE__, radio_instance_number);
+        return FALSE;
+    }
+
+    if (AnscEqualString(ParamName, "Enable", TRUE)) {
+        BOOL *is_enabled = (BOOL *)&wifiRadioOperParam->amsduTid[tid_idx];
+        if (!is_enabled) {
+            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Invalid TID for AMSDU - param was %s\n",
+                __func__, __LINE__, ParamName);
+            return FALSE;
+        }
+
+        if (*is_enabled == bValue) {
+            return TRUE;
+        }
+
+        *is_enabled = bValue;
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d:value=%d\n", __func__, __LINE__, *is_enabled);
+        is_radio_config_changed = TRUE;
+        return TRUE;
+    }
+
+    wifi_util_dbg_print(WIFI_DMCLI, "%s:%d AMSDU param is malformed - param was %s \n", __func__,
+        __LINE__, ParamName);
+    return FALSE;
+
+#endif
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        AMSDU_TID_GetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL*                       pBool
+            );
+
+    description:
+
+        This function is called to retrieve bool parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL*                       pBool
+                The buffer of returned bool value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+
+BOOL AMSDU_TID_GetParamBoolValue(ANSC_HANDLE hInsContext, char *ParamName, BOOL *pBool)
+{
+#if !defined(_XB8_PRODUCT_REQ_) && !defined(_XB10_PRODUCT_REQ_) && !defined(_XER10_PRODUCT_REQ_)
+    wifi_util_dbg_print(WIFI_DMCLI, "%s:%d AMSDU not supported on the device\n", __func__,
+        __LINE__);
+    return FALSE;
+#else
+
+    unsigned long amsdu_mask = (unsigned long)hInsContext;
+    uint8_t radio_instance_number = amsdu_mask >> 8;
+    uint8_t tid_idx = (amsdu_mask & 0xf) - 1;
+
+    wifi_radio_operationParam_t *wifiRadioOperParam = get_dml_radio_operation_param(radio_instance_number);
+
+    if (wifiRadioOperParam == NULL)
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Unable to get Radio Param for instance_number:%d\n", __func__, __LINE__, radio_instance_number);
+        return FALSE;
+    }
+
+    if ((radio_instance_number < 0) || (radio_instance_number > (INT)get_num_radio_dml()))
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Radio instanceNumber:%d out of range\n", __func__, __LINE__, radio_instance_number);
+        return FALSE;
+    }
+
+    if (AnscEqualString(ParamName, "Enable", TRUE)) {
+        *pBool = wifiRadioOperParam->amsduTid[tid_idx];
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d:value=%d\n", __func__, __LINE__, *pBool);
+        return TRUE;
+    }
+
+    wifi_util_dbg_print(WIFI_DMCLI, "%s:%d AMSDU GET param is malformed - param was %s \n",
+        __func__, __LINE__, ParamName);
+    return FALSE;
+#endif
+}
+
+BOOL AMSDU_TID_Validate(ANSC_HANDLE hInsContext, char *pReturnParamName, ULONG *puLength)
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    UNREFERENCED_PARAMETER(pReturnParamName);
+    UNREFERENCED_PARAMETER(puLength);
+    return TRUE;
+}
+
+ULONG
+AMSDU_TID_Commit(ANSC_HANDLE hInsContext)
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    return ANSC_STATUS_SUCCESS;
+}
+
+ULONG
+AMSDU_TID_Rollback(ANSC_HANDLE hInsContext)
+{
+    return ANSC_STATUS_SUCCESS;
+}
 
 /***********************************************************************
 

--- a/source/utils/wifi_validator.c
+++ b/source/utils/wifi_validator.c
@@ -2155,6 +2155,37 @@ int validate_radio_vap(const cJSON *wifi, wifi_radio_operationParam_t *wifi_radi
         validate_param_string(wifi, "RadarDetected", param);
         copy_string(wifi_radio_info->radarDetected, param->valuestring );
 
+        // Amsdu_Tid
+        validate_param_string(wifi, "Amsdu_Tid", param);
+        ptr = param->valuestring;
+        tmp = param->valuestring;
+
+        uint8_t tid_idx = 0;
+        while ((ptr = strchr(tmp, ',')) != NULL) {
+            ptr++;
+            wifi_radio_info->amsduTid[tid_idx] = atoi(tmp);
+            if ((wifi_radio_info->amsduTid[tid_idx] != FALSE ||
+                    wifi_radio_info->amsduTid[tid_idx] != TRUE)) {
+                wifi_util_dbg_print(WIFI_PASSPOINT, "Invalid value when parsing AMSDU TID: %d\n",
+                    wifi_radio_info->amsduTid[tid_idx]);
+                strncpy(execRetVal->ErrorMsg, "Invalid AMSDU TID list",
+                    sizeof(execRetVal->ErrorMsg) - 1);
+                return RETURN_ERR;
+            }
+            tmp = ptr;
+            tid_idx++;
+        }
+        // Last AMSDU TID
+        wifi_radio_info->amsduTid[tid_idx++] = atoi(tmp);
+
+        if (tid_idx != MAX_AMSDU_TID) {
+            wifi_util_dbg_print(WIFI_PASSPOINT,
+                "Number of AMSDU TIDs decoded does not match required value\n");
+            strncpy(execRetVal->ErrorMsg, "Invalid AMSDU TID list",
+                sizeof(execRetVal->ErrorMsg) - 1);
+            return RETURN_ERR;
+        }
+
     return RETURN_OK;
 }
 

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -2984,6 +2984,27 @@ webconfig_error_t decode_radio_object(const cJSON *obj_radio, rdk_wifi_radio_t *
     decode_param_string(obj_radio, "RadarDetected", param);
     strncpy(radio_info->radarDetected, param->valuestring, sizeof(radio_info->radarDetected));
 
+    // AmsduTid
+    unsigned int amsdu_tid_idx = 0;
+    decode_param_string(obj_radio, "Amsdu_Tid", param);
+    ptr = param->valuestring;
+    tmp = param->valuestring;
+
+    while ((ptr = strchr(tmp, ',')) != NULL) {
+        ptr++;
+        radio_info->amsduTid[amsdu_tid_idx] = (BOOL)atoi(tmp);
+        tmp = ptr;
+        amsdu_tid_idx++;
+    }
+    // Last AMSDU TID
+    radio_info->amsduTid[amsdu_tid_idx++] = atoi(tmp);
+
+    if (amsdu_tid_idx != MAX_AMSDU_TID) {
+        wifi_util_error_print(WIFI_WEBCONFIG,
+            "number of AMSDU TIDs decoded - %d does not match required amount - %d!\n", amsdu_tid_idx, MAX_AMSDU_TID);
+        return webconfig_error_decode;
+    }
+
     if (decode_radio_operating_classes(obj_radio, radio_info) != webconfig_error_none) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d Radio operation classes decode failed\n",
             __func__, __LINE__);

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -111,9 +111,9 @@ webconfig_error_t encode_radio_object(const rdk_wifi_radio_t *radio, cJSON *radi
 {
     const wifi_radio_operationParam_t *radio_info;
     const wifi_radio_feature_param_t *radio_feat;
-    char channel_list[BUFFER_LENGTH_WIFIDB] = {0}, str[BUFFER_LENGTH_WIFIDB] = {0};
+    char out_list[BUFFER_LENGTH_WIFIDB] = { 0 }, str[BUFFER_LENGTH_WIFIDB] = { 0 };
     char chan_buf[512] = {0};
-    unsigned int num_channels, i, k = 0, len = sizeof(channel_list) - 1;
+    unsigned int num_channels, i, k = 0, len = sizeof(out_list) - 1;
     int itr = 0, arr_size = 0;
     cJSON *obj;
     CHAR buf[512] = {'\0'};
@@ -159,14 +159,15 @@ webconfig_error_t encode_radio_object(const rdk_wifi_radio_t *radio, cJSON *radi
             break;
         }
 
-        snprintf(channel_list + k, sizeof(channel_list) - k,"%d,", radio_info->channelSecondary[i]);
-        wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d Wifi_Radio_Config table Channel list %s %d\t",__func__, __LINE__,channel_list,strlen(channel_list));
-        k = strlen(channel_list);
+        snprintf(out_list + k, sizeof(out_list) - k, "%d,", radio_info->channelSecondary[i]);
+        wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d Wifi_Radio_Config table Channel list %s %d\t",
+            __func__, __LINE__, out_list, strlen(out_list));
+        k = strlen(out_list);
     }
 
     memset(str, 0, sizeof(str));
-    if ((strlen(channel_list) > 1) && (strlen(channel_list) < sizeof(str))) {
-        strncpy(str,channel_list,strlen(channel_list)-1);
+    if ((strlen(out_list) > 1) && (strlen(out_list) < sizeof(str))) {
+        strncpy(str, out_list, strlen(out_list) - 1);
     } else {
         strcpy(str, " ");
     }
@@ -323,6 +324,29 @@ webconfig_error_t encode_radio_object(const rdk_wifi_radio_t *radio, cJSON *radi
 
     //RadarDetected
     cJSON_AddStringToObject(radio_object, "RadarDetected", radio_info->radarDetected);
+
+    // AmsduTid
+    memset(out_list, 0, sizeof(str));
+    k = 0;
+    for (i = 0; i < MAX_AMSDU_TID; i++) {
+        if (k >= (len - 1)) {
+            wifi_util_error_print(WIFI_WEBCONFIG,
+                "%s:%d Wifi_Radio_Config table Maximum size reached for AMSDU TIDs\n", __func__,
+                __LINE__);
+            break;
+        }
+
+        snprintf(out_list + k, sizeof(out_list) - k, "%d,", radio_info->amsduTid[i]);
+        k = strlen(out_list);
+    }
+
+    if ((strlen(out_list) > 1) && (strlen(out_list) < sizeof(str))) {
+        strncpy(str, out_list, strlen(out_list) - 1);
+    } else {
+        strcpy(str, " ");
+    }
+
+    cJSON_AddStringToObject(radio_object, "Amsdu_Tid", str);
 
     // Operating Class Capability details
     if (encode_radio_operating_classes(radio_info, radio_object) != webconfig_error_none) {


### PR DESCRIPTION
Reason for change: Implements handling of AMSDU TID
Test procedure: Verify build, set/get AMSDU TID
Priority: P1
Risks: None