### PR TITLE
RDKB-59898: [OneWifi]WiFi Interfaces reconfigured post 5G channel optimization

### DIFF
--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -1121,6 +1121,20 @@ pErr wifi_vap_cfg_subdoc_handler(void *data)
         if(interworking_o == NULL) {
             wifi_util_error_print(WIFI_CTRL, "%s: Failed to get Interworking obj for %s\n", __func__, nm_s);
             continue;
+        } else {
+            //if VenueOptionPresent param missing add it.
+            cJSON *venue_o = cJSON_GetObjectItem(interworking_o, "Venue");
+            if (venue_o != NULL) {
+                cJSON *venue_option = cJSON_GetObjectItem(venue_o, "VenueOptionPresent");
+                if (venue_option == NULL) {
+                    wifi_interworking_t *interworking_info =
+                        &wifi_vap_map->vap_array[vapArrayIndex].u.bss_info.interworking;
+                    cJSON_AddBoolToObject(venue_o, "VenueOptionPresent",
+                        interworking_info->interworking.venueOptionPresent);
+                } else {
+                    wifi_util_info_print(WIFI_CTRL, "%s: VenueOptionPresent param available\n", __func__);
+                }
+            }
         }
 
         if ((status = early_validate_interworking(interworking_o,  execRetVal)) != RETURN_OK) {

--- a/source/db/wifi_db.h
+++ b/source/db/wifi_db.h
@@ -124,6 +124,29 @@ typedef struct {
 #define LNF_PRIMARY_RADIUS_IP      "127.0.0.1"
 #define LNF_SECONDARY_RADIUS_IP    "192.168.106.254"
 
+#define DEFAULT_ANQP_STR_DATA " { \"ANQP\":{ " \
+                               "\"IPAddressTypeAvailabilityANQPElement\":{ " \
+                               "\"IPv6AddressType\":0, " \
+                               "\"IPv4AddressType\":0}, " \
+                               "\"DomainANQPElement\":{\"DomainName\":[]}, " \
+                               "\"NAIRealmANQPElement\":{\"Realm\":[]}, " \
+                               "\"3GPPCellularANQPElement\":{ " \
+                               "\"GUD\":0, " \
+                               "\"PLMN\":[]}, " \
+                               "\"RoamingConsortiumANQPElement\": { " \
+                               "\"OI\": []}, " \
+                               "\"VenueNameANQPElement\": { " \
+                               "\"VenueInfo\": []}}}"
+
+#define DEFAULT_PASSPOINT_STR_DATA "{ \"Passpoint\":{ " \
+                                   "\"PasspointEnable\":false, " \
+                                   "\"NAIHomeRealmANQPElement\":{\"Realms\":[]}, " \
+                                   "\"OperatorFriendlyNameANQPElement\":{\"Name\":[]}, " \
+                                   "\"ConnectionCapabilityListANQPElement\":{\"ProtoPort\":[]}, " \
+                                   "\"GroupAddressedForwardingDisable\":true, " \
+                                   "\"P2pCrossConnectionDisable\":false}}"
+
+
 int start_wifidb();
 int init_wifidb_tables();
 int wifidb_update_wifi_vap_config(int radio_index, wifi_vap_info_map_t *config,

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -3608,6 +3608,56 @@ bool is_6g_supported_device(wifi_platform_property_t *wifi_prop)
     return false;
 }
 
+static bool is_interworking_config_changed(char *vap_name, wifi_interworking_t *old_cfg,
+    wifi_interworking_t *new_cfg)
+{
+    bool is_hotspot_vap = FALSE;
+    if (strncmp((char *)vap_name, "hotspot", strlen("hotspot")) == 0) {
+        is_hotspot_vap = TRUE;
+    }
+
+    return (IS_BIN_CHANGED(&old_cfg->interworking, &new_cfg->interworking,
+            sizeof(wifi_InterworkingElement_t))
+            || (is_hotspot_vap
+                && (IS_BIN_CHANGED(&old_cfg->passpoint, &new_cfg->passpoint,
+                    sizeof(wifi_passpoint_settings_t))
+                   || IS_BIN_CHANGED(&old_cfg->anqp, &new_cfg->anqp,
+                    sizeof(wifi_anqp_settings_t))
+                   || IS_BIN_CHANGED(&old_cfg->roamingConsortium, &new_cfg->roamingConsortium,
+                    sizeof(wifi_roamingConsortiumElement_t)))));
+}
+
+static bool is_vap_preassoc_cac_config_changed(char *vap_name,
+    wifi_preassoc_control_t *old_cfg,
+    wifi_preassoc_control_t *new_cfg)
+{
+    bool is_hotspot_vap = FALSE;
+    if (strncmp((char *)vap_name, "hotspot", strlen("hotspot")) == 0) {
+        is_hotspot_vap = TRUE;
+    }
+
+    if (is_hotspot_vap
+        && (IS_STR_CHANGED(old_cfg->basic_data_transmit_rates,
+                new_cfg->basic_data_transmit_rates,
+                sizeof(old_cfg->basic_data_transmit_rates))
+            || IS_STR_CHANGED(old_cfg->operational_data_transmit_rates,
+                new_cfg->operational_data_transmit_rates,
+                sizeof(old_cfg->operational_data_transmit_rates))
+            || IS_STR_CHANGED(old_cfg->supported_data_transmit_rates,
+                new_cfg->supported_data_transmit_rates,
+                sizeof(old_cfg->supported_data_transmit_rates))
+            || IS_STR_CHANGED(old_cfg->minimum_advertised_mcs,
+                new_cfg->minimum_advertised_mcs,
+                sizeof(old_cfg->minimum_advertised_mcs))
+            || IS_STR_CHANGED(old_cfg->sixGOpInfoMinRate,
+                new_cfg->sixGOpInfoMinRate,
+                sizeof(old_cfg->sixGOpInfoMinRate)))) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 bool is_vap_param_config_changed(wifi_vap_info_t *vap_info_old, wifi_vap_info_t *vap_info_new,
     rdk_wifi_vap_info_t *rdk_old, rdk_wifi_vap_info_t *rdk_new, bool isSta)
 {
@@ -3667,8 +3717,9 @@ bool is_vap_param_config_changed(wifi_vap_info_t *vap_info_old, wifi_vap_info_t 
                 vap_info_new->u.bss_info.vapStatsEnable) ||
             IS_BIN_CHANGED(&vap_info_old->u.bss_info.security, &vap_info_new->u.bss_info.security,
                 sizeof(wifi_vap_security_t)) ||
-            IS_BIN_CHANGED(&vap_info_old->u.bss_info.interworking,
-                &vap_info_new->u.bss_info.interworking, sizeof(wifi_interworking_t)) ||
+            is_interworking_config_changed(vap_info_new->vap_name,
+                &vap_info_old->u.bss_info.interworking,
+                &vap_info_new->u.bss_info.interworking) ||
             IS_CHANGED(vap_info_old->u.bss_info.mac_filter_enable,
                 vap_info_new->u.bss_info.mac_filter_enable) ||
             IS_CHANGED(vap_info_old->u.bss_info.mac_filter_mode,
@@ -3697,21 +3748,8 @@ bool is_vap_param_config_changed(wifi_vap_info_t *vap_info_old, wifi_vap_info_t 
                 vap_info_new->u.bss_info.network_initiated_greylist) ||
             IS_CHANGED(vap_info_old->u.bss_info.mcast2ucast,
                 vap_info_new->u.bss_info.mcast2ucast) ||
-            IS_STR_CHANGED(vap_info_old->u.bss_info.preassoc.basic_data_transmit_rates,
-                vap_info_new->u.bss_info.preassoc.basic_data_transmit_rates,
-                sizeof(vap_info_old->u.bss_info.preassoc.basic_data_transmit_rates)) ||
-            IS_STR_CHANGED(vap_info_old->u.bss_info.preassoc.operational_data_transmit_rates,
-                vap_info_new->u.bss_info.preassoc.operational_data_transmit_rates,
-                sizeof(vap_info_old->u.bss_info.preassoc.operational_data_transmit_rates)) ||
-            IS_STR_CHANGED(vap_info_old->u.bss_info.preassoc.supported_data_transmit_rates,
-                vap_info_new->u.bss_info.preassoc.supported_data_transmit_rates,
-                sizeof(vap_info_old->u.bss_info.preassoc.supported_data_transmit_rates)) ||
-            IS_STR_CHANGED(vap_info_old->u.bss_info.preassoc.minimum_advertised_mcs,
-                vap_info_new->u.bss_info.preassoc.minimum_advertised_mcs,
-                sizeof(vap_info_old->u.bss_info.preassoc.minimum_advertised_mcs)) ||
-            IS_STR_CHANGED(vap_info_old->u.bss_info.preassoc.sixGOpInfoMinRate,
-                vap_info_new->u.bss_info.preassoc.sixGOpInfoMinRate,
-                sizeof(vap_info_old->u.bss_info.preassoc.sixGOpInfoMinRate)) ||
+            is_vap_preassoc_cac_config_changed(vap_info_new->vap_name,
+                    &vap_info_old->u.bss_info.preassoc, &vap_info_new->u.bss_info.preassoc) ||
             IS_CHANGED(vap_info_old->u.bss_info.hostap_mgt_frame_ctrl,
                 vap_info_new->u.bss_info.hostap_mgt_frame_ctrl) ||
             IS_CHANGED(vap_info_old->u.bss_info.mbo_enabled,

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -755,6 +755,9 @@ webconfig_error_t decode_interworking_common_object(const cJSON *interworking, w
 
     decode_param_object(interworking, "Venue", venue);
 
+    decode_param_bool(venue, "VenueOptionPresent", param);
+    interworking_info->interworking.venueOptionPresent = (param->type & cJSON_True) ? true : false;
+
     decode_param_integer(venue, "VenueType", param);
     interworking_info->interworking.venueType = param->valuedouble;
     if (interworking_info->interworking.venueType > 15) {

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -897,6 +897,7 @@ webconfig_error_t encode_interworking_common_object(const wifi_interworking_t *i
         //strncpy(execRetVal->ErrorMsg, "Invalid Venue Group",sizeof(execRetVal->ErrorMsg)-1);
         return webconfig_error_encode;
     }
+    cJSON_AddBoolToObject(obj, "VenueOptionPresent", interworking_info->interworking.venueOptionPresent);
     cJSON_AddNumberToObject(obj, "VenueType", interworking_info->interworking.venueType);
 
     switch (interworking_info->interworking.venueGroup) {

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -893,6 +893,19 @@ webconfig_error_t translator_ovsdb_init(webconfig_subdoc_data_t *data)
         convert_radio_index_to_freq_band(&hal_cap->wifi_prop, radioIndx, &band);
         default_vap_info->u.bss_info.mbo_enabled = true;
         default_vap_info->u.bss_info.interop_ctrl = false;
+
+        char str[600] = {0};
+        snprintf(str,sizeof(str),"%s", DEFAULT_ANQP_STR_DATA);
+        snprintf((char *)default_vap_info->u.bss_info.interworking.anqp.anqpParameters,
+            sizeof(default_vap_info->u.bss_info.interworking.anqp.anqpParameters), "%s" , str);
+        memset(str,0,sizeof(str));
+        snprintf(str,sizeof(str),"%s", DEFAULT_PASSPOINT_STR_DATA);
+        snprintf((char *)default_vap_info->u.bss_info.interworking.passpoint.hs2Parameters,
+            sizeof(default_vap_info->u.bss_info.interworking.passpoint.hs2Parameters), "%s" , str);
+
+        default_vap_info->u.bss_info.interworking.interworking.venueOptionPresent = 1;
+        default_vap_info->u.bss_info.interworking.interworking.venueGroup = 0;
+        default_vap_info->u.bss_info.interworking.interworking.venueType = 0;
 #if defined(_XB7_PRODUCT_REQ_) || defined(_XB8_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) || \
     defined(_SCER11BEL_PRODUCT_REQ_) || defined(_CBR2_PRODUCT_REQ_)
         default_vap_info->u.bss_info.hostap_mgt_frame_ctrl = true;


### PR DESCRIPTION
RDKB-59898: [OneWifi]WiFi Interfaces reconfigured post 5G channel optimization (#460) (#557)

Reason for change: Improved is_vap_configure_changed function logic to Avoids
                   checking pre-association, Passpoint, and ANQP configurations
                   for VAPs other than Hotspot VAPs.

Test Procedure:1. Load the OneWifi build.
               2. Connect client with 2g/5g.
               3. Wait until 5g channel optimizations trigger.
               4. Check Client is connected back to 5g VAPs.

Priority: P0
Risks: Low
Signed-off-by: apatel599@cable.comcast.com

RDKB-59898: [OneWifi]WiFi Interfaces reconfigured post 5G channel optimization (#468)

Reason for change: Improved is_vap_configure_changed function logic to Avoids
                   checking pre-association, Passpoint, and ANQP configurations
                   for VAPs other than Hotspot VAPs.

Test Procedure:1. Load the OneWifi build.
               2. Connect client with 2g/5g.
               3. Wait until 5g channel optimizations trigger.
               4. Check Client is connected back to 5g VAPs.

Priority: P0
Risks: Low
Signed-off-by: apatel599@cable.comcast.com

RDKB-59898:[OneWifi]WiFi Interfaces reconfigured post 5G channel optimization (#481)

Reason for change: Added VenueOptionPresent blob param as part of webconfig blob. Test Procedure:1. Load the OneWifi build.
               2. Connect client with 2g/5g.
               3. Wait until 5g channel optimizations trigger.
               4. Check Client is connected back to 5g VAPs.

Priority: P0
Risks: Low

Signed-off-by: apatel599@cable.comcast.com