### PR TITLE
RDKB-61233, RDKBACCL-1098: Easymesh - AP MLD details not populated for extender DML subdoc

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1624,6 +1624,14 @@ int init_wireless_interface_mac()
                         wifi_vap_info->u.bss_info.bssid[4],
                         wifi_vap_info->u.bss_info.bssid[5]
                         );
+#if defined EASY_MESH_NODE || defined EASY_MESH_COLOCATED_NODE
+                // For fronthaul interfaces, update the mld info
+                wifi_vap_info->u.bss_info.mld_info.common_info.mld_enable = hal_vap_info_map.vap_array[j].u.bss_info.mld_info.common_info.mld_enable;
+                memcpy(wifi_vap_info->u.bss_info.mld_info.common_info.mld_addr, hal_vap_info_map.vap_array[j].u.bss_info.mld_info.common_info.mld_addr, sizeof(wifi_vap_info->u.bss_info.mld_info.common_info.mld_addr));
+                wifi_vap_info->u.bss_info.mld_info.common_info.mld_link_id = hal_vap_info_map.vap_array[j].u.bss_info.mld_info.common_info.mld_link_id;
+                wifi_vap_info->u.bss_info.mld_info.common_info.mld_id = hal_vap_info_map.vap_array[j].u.bss_info.mld_info.common_info.mld_id;
+                wifi_vap_info->u.bss_info.mld_info.common_info.mld_apply = hal_vap_info_map.vap_array[j].u.bss_info.mld_info.common_info.mld_apply;
+#endif
             }
         }
     }


### PR DESCRIPTION
RDKB-61233, RDKBACCL-1098: Easymesh - AP MLD details not populated for extender DML subdoc

Reason for change: Added change to populate AP MLD details to onewifi from hal.
Test Procedure: Ensure AP MLD details are present in DML for extender device.
Risks: Medium
Priority: P1