### PR TITLE
RDKB-60452:WIFI_PASSWORD_FAIL" Telemetry Markers are not reporting

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1364,11 +1364,27 @@ int set_sta_client_mode(int ap_index, char *mac, int key_mgmt, frame_type_t fram
     return RETURN_OK;
 }
 
-
 void process_deauthenticate	(unsigned int ap_index, auth_deauth_dev_t *dev)
 {
+    char buff[2048];
+    char tmp[128];
     sta_key_t sta_key;
     wifi_util_info_print(WIFI_MON, "%s:%d Device:%s deauthenticated on ap:%d with reason : %d\n", __func__, __LINE__, to_sta_key(dev->sta_mac, sta_key), ap_index, dev->reason);
+    /*Wrong password on private, Xfinity Home and LNF SSIDs*/
+    if ((dev->reason == 2) && ( isVapPrivate(ap_index) || isVapXhs(ap_index) || isVapLnfPsk(ap_index) ) ) {
+        get_formatted_time(tmp);
+        snprintf(buff, 2048, "%s WIFI_PASSWORD_FAIL:%d,%s\n", tmp, ap_index + 1, to_sta_key(dev->sta_mac, sta_key));
+        /* send telemetry of password failure */
+        write_to_file(wifi_health_log, buff);
+    }
+    /*ARRISXB6-11979 Possible Wrong WPS key on private SSIDs*/
+    if ((dev->reason == 2 || dev->reason == 14 || dev->reason == 19) && ( isVapPrivate(ap_index) ))  {
+        get_formatted_time(tmp);
+        snprintf(buff, 2048, "%s WIFI_POSSIBLE_WPS_PSK_FAIL:%d,%s,%d\n", tmp, ap_index + 1, to_sta_key(dev->sta_mac, sta_key), dev->reason);
+        /* send telemetry of WPS failure */
+        write_to_file(wifi_health_log, buff);
+    }
+    /*Calling process_disconnect as station is disconncetd from vAP*/
     process_disconnect(ap_index, dev);
 }
 
@@ -2958,8 +2974,7 @@ int device_deauthenticated(int ap_index, char *src_mac, char *dest_mac, int type
     }
 
     if ((ap_reason_code(ap_index, src_mac, dest_mac, type, reason)) != 0) {
-       wifi_util_dbg_print(WIFI_MON,"%s:%d failed in getting the reason code details as mac is null \n", __func__, __LINE__);
-       return -1;
+       wifi_util_dbg_print(WIFI_MON,"%s:%d failed in getting the particular reason code details \n", __func__, __LINE__);
     }
 
     if (reason == WLAN_RADIUS_GREYLIST_REJECT) {


### PR DESCRIPTION
Impacted Platforms:
All Onewifi Platforms
Reason for change:WIFI_PASSWORD_FAIL" Telemetry Markers are not reporting so make required changes. Test Procedure:
connect the client and check WIFI_PASSWORD_FAIL/WIFI_POSSIBLE_WPS_PSK_FAIL markers are reported in wifihealth.txt after password is changed. 
Priority: P1
Risks: Low
Signed-off-by:Harshavardhan_Pulluru@comcast.com