### PR TITLE
DTMESH-646 [DT][OneWifi] DFS event updates

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -6865,6 +6865,9 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
 #if defined (_PP203X_PRODUCT_REQ_)
             cfg.variant = WIFI_80211_VARIANT_A | WIFI_80211_VARIANT_N | WIFI_80211_VARIANT_AC;
             cfg.DfsEnabled = true;
+#elif defined (_GREXT02ACTS_PRODUCT_REQ_)
+	    cfg.variant = WIFI_80211_VARIANT_A | WIFI_80211_VARIANT_N | WIFI_80211_VARIANT_AC | WIFI_80211_VARIANT_AX;
+	    cfg.DfsEnabled = true;
 #else
             cfg.variant = WIFI_80211_VARIANT_A | WIFI_80211_VARIANT_N | WIFI_80211_VARIANT_AC | WIFI_80211_VARIANT_AX;
 #endif


### PR DESCRIPTION
Reason for change: Enable DFS flag for DT platform

Test Procedure: DFS channels should be populated in radio state table once booted up

Risks: Low

Priority: P1