### PR TITLE
RDKB-59638: CAC_COMPLETED status observed for previous DFS channels in Radio_State table.

### DIFF
--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3017,7 +3017,7 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
                 chan_state = CHAN_STATE_DFS_NOP_FINISHED;
                 break;
             case WIFI_EVENT_RADAR_PRE_CAC_EXPIRED :
-                chan_state = CHAN_STATE_DFS_CAC_COMPLETED;
+                chan_state = CHAN_STATE_DFS_NOP_FINISHED;
                 break;
             case WIFI_EVENT_RADAR_CAC_STARTED :
                 chan_state = CHAN_STATE_DFS_CAC_START;


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: Invalid channel state has been set for PRECAC expired event in OneWiFi.

Test Procedure:
1. Load the above mentioned build.
2. Switch to DFS channel and check whether the channel state of the DFS channel is cac completed.
3. And then move to any other channel and check the channel state of previous DFS channel.
4. If that channel state is observed as cac_completed instead of nop_finished, then issue got reproduced.

Risks: Low

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com