### PR TITLE
RDKB-62029 Enhance the support for generating client telemetry stats …

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -207,7 +207,7 @@
         </parameter>
         <parameter>
             <name>WHIX_LogInterval</name>
-            <type>int[300:3600]</type>
+            <type>int[60:3600]</type>
             <syntax>int</syntax>
             <writable>true</writable>
         </parameter>

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -158,7 +158,7 @@ extern void* bus_handle;
 //#define UPLOAD_AP_TELEMETRY_INTERVAL_MS 24*60*60*1000 // 24 Hours
 
 //#define NEIGHBOR_SCAN_RESULT_INTERVAL 5000 //5 seconds
-#define Min_LogInterval 300 //5 minutes
+#define Min_LogInterval 60 //1 minute
 #define Max_LogInterval 3600 //60 minutes
 #define Min_Chan_Util_LogInterval 5 //5 seconds
 
@@ -3727,10 +3727,10 @@ long get_sys_uptime()
      gettimeofday(&polling_time, NULL);
 
      if ((fp = fopen("/tmp/upload", "r")) == NULL) {
-     /* Minimum LOG Interval we can set is 300 sec, just verify every 5 mins any change in the LogInterval
+     /* Minimum LOG Interval we can set is 60 sec, just verify every 1 min any change in the LogInterval
         if any change in log_interval do the calculation and dump the VAP status */
           time_gap = polling_time.tv_sec - lastpolledtime;
-          if ( time_gap >= 300 )
+          if ( time_gap >= 60 )
           {
                logInterval=readLogInterval();
                lastpolledtime = polling_time.tv_sec;


### PR DESCRIPTION
…to 1 minute (#642)

RDKB-62029 Enhance the support for generating client telemetry stats to 1 minute

Reason for change: To change the Min_LogInterval value to 60 seconds

Test Procedure:
   1. Change the Min_LogInterval value to 60 seconds using below mentioned DMCLI dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.LogInterval.
   2.    Connect clients
   3.    Check for the telemetry stats for every one minute

Priority: P0
Risks: Low