### PR TITLE
RDKB-62312: Observed onewifi crash with fingerprint 95397002.

### DIFF
--- a/source/dml/tr_181/ml/cosa_wifi_internal.c
+++ b/source/dml/tr_181/ml/cosa_wifi_internal.c
@@ -1139,8 +1139,7 @@ CosaWifiInitialize
     if ( !pPoamIrepFoCOSA )
     {
         returnStatus = ANSC_STATUS_FAILURE;
-        CcspTraceWarning(("CosaWifiInitialize - hIrepFolderCOSA failed\n"));
-
+        CcspWifiTrace(("RDK_LOG_WARN, CosaWifiInitialize - hIrepFolderCOSA failed\n"));
         goto  EXIT;
     }
 
@@ -1166,9 +1165,8 @@ CosaWifiInitialize
     if ( !pPoamIrepFoWifi )
     {
         returnStatus = ANSC_STATUS_FAILURE;
-        CcspTraceWarning(("CosaWifiInitialize - pPoamIrepFoWifi failed\n"));
-
-        goto  EXIT;
+        CcspWifiTrace(("RDK_LOG_WARN, CosaWifiInitialize - pPoamIrepFoWifi failed\n"));
+        goto EXIT;
     }
     else
     {
@@ -1204,7 +1202,7 @@ CosaWifiInitialize
 #endif // NEWPLATFORM_PORT
 
 EXIT:
-        CcspTraceWarning(("CosaWifiInitialize - returnStatus %ld\n", returnStatus));
+        CcspWifiTrace(("RDK_LOG_WARN, CosaWifiInitialize - returnStatus %lu\n", returnStatus));
 
 	return returnStatus;
 }


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change:
During the several macro expansions of CcspTraceWarning , the pComponentName pointer 
seems to be corrupted and leads to crash. So using CcspWifiTrace defined in Onewifi.

Test Procedure:
1. Load the above mentioned build.
2. Connect 20 candela clients and run layer-3 traffic
3. Soak the devices for testing
4. If crash occurs, issue reproduced.

Risks: Low

Priority: P1
Signed-off-by: sanjayvenkatesan1902@gmail.com