### PR TITLE
RDKBACCL-1330: Updated current tx_power in onewifi and unified-mesh

### DIFF
--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -79,6 +79,7 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
     wifi_radio_feature_param_t Fcfg;
     memset(&Fcfg,0,sizeof(Fcfg));
     memset(&cfg,0,sizeof(cfg));
+    ULONG curr_txpower = 0;
 
     wifi_radio_capabilities_t radio_capab = g_wifidb->hal_cap.wifi_prop.radiocap[radio_index];
 
@@ -189,7 +190,13 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
         cfg.beaconInterval = 100;
     }
     cfg.fragmentationThreshold = 2346;
-    cfg.transmitPower = 100;
+
+    if (wifi_hal_getRadioTransmitPower(radio_index, &curr_txpower) != RETURN_OK) {
+        wifi_util_error_print(WIFI_DB,"%s:%d: Failed to fetch TX power for radio_index=%d\n",
+                            __func__, __LINE__, radio_index);
+        curr_txpower = 100;
+    }
+    cfg.transmitPower = curr_txpower;
     cfg.rtsThreshold = 2347;
     cfg.guardInterval = wifi_guard_interval_auto;
     cfg.ctsProtection = false;

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -365,6 +365,7 @@ webconfig_error_t translate_radio_object_to_easymesh_for_radio(webconfig_subdoc_
             em_op_class_info->id.type = em_op_class_type_capability;
             em_op_class_info->id.op_class = oper_param->operatingClasses[i].opClass;
             em_op_class_info->op_class = oper_param->operatingClasses[i].opClass;
+            em_op_class_info->tx_power = oper_param->transmitPower;
             em_op_class_info->max_tx_power = oper_param->operatingClasses[i].maxTxPower;
             em_op_class_info->num_channels = oper_param->operatingClasses[i].numberOfNonOperChan;
             for(int k = 0; k < oper_param->operatingClasses[i].numberOfNonOperChan; k++) {
@@ -381,6 +382,7 @@ webconfig_error_t translate_radio_object_to_easymesh_for_radio(webconfig_subdoc_
         em_op_class_info->id.op_class = oper_param->operatingClass;
         em_op_class_info->op_class = oper_param->operatingClass;
         em_op_class_info->channel = oper_param->channel;
+        em_op_class_info->tx_power = oper_param->transmitPower;
         no_of_opclass++;
         proto->set_num_op_class(proto->data_model,no_of_opclass);
     }


### PR DESCRIPTION
- Retrieve current TX power from the hal api `wifi_hal_getRadioTransmitPower`
- Update TX power in OneWifi struct `wifi_radio_operationParam_t`
- Updated TX power in Unified Mesh struct `em_op_class_info_t` from onewifi.

Closes: RDKBACCL-1330
Signed-off-by: Sundram Patel <sundram.p@tataelxsi.co.in>