### PR TITLE
RDKB-62581: 2.4Ghz ax mode is disabled after SW upgrade and factory reset.

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -9290,7 +9290,8 @@ int get_all_param_from_psm_and_set_into_db(void)
         }
         if ((strncmp(last_reboot_reason, "factory-reset", strlen("factory-reset")) == 0) ||
             (strncmp(last_reboot_reason, "WPS-Factory-Reset", strlen("WPS-Factory-Reset")) == 0) ||
-            (strncmp(last_reboot_reason, "CM_variant_change", strlen("CM_variant_change")) == 0)) {
+            (strncmp(last_reboot_reason, "CM_variant_change", strlen("CM_variant_change")) == 0) ||
+            (strncmp(last_reboot_reason, "FirmwareDownloadAndFactoryReset", strlen("FirmwareDownloadAndFactoryReset")) == 0)) {
             create_onewifi_factory_reset_flag();
             create_onewifi_factory_reset_reboot_flag();
             wifi_util_info_print(WIFI_MGR, "%s FactoryReset is done \n", __func__);

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -9197,10 +9197,11 @@ int get_all_param_from_psm_and_set_into_db(void)
     **      then update wifi-db with values from psm */
     wifi_util_info_print(WIFI_MGR, "%s \n", __func__);
     if (is_device_type_xb7() == true || is_device_type_xb8() == true ||
-        is_device_type_vbvxb10() == true || is_device_type_vbvxb9() == true || is_device_type_sercommxb10() == true ||
-        is_device_type_scxer10() == true || is_device_type_sr213() == true ||
-        is_device_type_cmxb7() == true || is_device_type_cbr2() == true ||
-        is_device_type_vbvxer5() == true || is_device_type_xle() == true || is_device_type_sr203() == true) {
+        is_device_type_vbvxb10() == true || is_device_type_vbvxb9() == true ||
+        is_device_type_sercommxb10() == true || is_device_type_scxer10() == true ||
+        is_device_type_sr213() == true || is_device_type_cmxb7() == true ||
+        is_device_type_cbr2() == true || is_device_type_vbvxer5() == true ||
+        is_device_type_xle() == true || is_device_type_sr203() == true) {
         bool wifi_psm_db_enabled = false;
         char last_reboot_reason[32];
         raw_data_t data;
@@ -9291,7 +9292,8 @@ int get_all_param_from_psm_and_set_into_db(void)
         if ((strncmp(last_reboot_reason, "factory-reset", strlen("factory-reset")) == 0) ||
             (strncmp(last_reboot_reason, "WPS-Factory-Reset", strlen("WPS-Factory-Reset")) == 0) ||
             (strncmp(last_reboot_reason, "CM_variant_change", strlen("CM_variant_change")) == 0) ||
-            (strncmp(last_reboot_reason, "FirmwareDownloadAndFactoryReset", strlen("FirmwareDownloadAndFactoryReset")) == 0)) {
+            (strncmp(last_reboot_reason, "FirmwareDownloadAndFactoryReset",
+                 strlen("FirmwareDownloadAndFactoryReset")) == 0)) {
             create_onewifi_factory_reset_flag();
             create_onewifi_factory_reset_reboot_flag();
             wifi_util_info_print(WIFI_MGR, "%s FactoryReset is done \n", __func__);


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: As FirmwareDownloadAndFactoryReset was missing in last reboot reason check, factory reset flag wasn't created in /nvram directory. So in Onewifi it goes under reboot case as the flag wasn't created and the callback is being triggered for all RFC Config parameters with values set as 0 even before the db gets initialized.

Test Procedure:

Load the CGM601TCOM_8.2p2s1_DEV_sey image.

And upgrade to the fix build using below command,
dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_FirmwareDownloadURL string " http://dac15cdlserver.ae.ccp.xcal.tv:8080/Images"
dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_FirmwareToDownload string "image name"
dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_FirmwareDownloadAndFactoryReset int 1

After the upgrade check for below output,
a. Last reboot reason should be FirmwareDownloadAndFactoryReset.
b. The 2G AX RFC should be true.
c. The operating standards should have ax mode in it.

If anyone of them failed, then issue got reproduced.

Risks: Medium
Priority: P1
Signed-off-by: sanjayvenkatesan1902@gmail.com