### PR TITLE
DTMESH-795: Follower mode manager restarts on 2nd iteration of parentchange.

### DIFF
--- a/source/core/services/vap_svc_mesh_ext.c
+++ b/source/core/services/vap_svc_mesh_ext.c
@@ -2120,13 +2120,11 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
     } else if (sta_data->stats.connect_status == wifi_connection_status_ap_not_found || sta_data->stats.connect_status == wifi_connection_status_disconnected) {
         apply_pending_channel_change(svc, sta_data->stats.vap_index);
 
-        memcpy(temp_vap_info->u.sta_info.bssid, sta_data->bss_info.bssid,
-            sizeof(temp_vap_info->u.sta_info.bssid));
-
         bssid_mac_str = (char *)malloc(MAC_ADDR_STR_LEN);
         if (bssid_mac_str != NULL) {
             memset(bssid_mac_str, '\0', MAC_ADDR_STR_LEN);
-            uint8_mac_to_string_mac(temp_vap_info->u.sta_info.bssid, bssid_mac_str);
+            uint8_mac_to_string_mac(sta_data->bss_info.bssid,
+                bssid_mac_str);
             wifi_util_dbg_print(WIFI_CTRL, "%s:%d bssid mac=%s\n", __func__, __LINE__,
                 bssid_mac_str);
             apps_mgr_link_quality_event(&ctrl->apps_mgr, wifi_event_type_exec,

--- a/source/core/services/vap_svc_mesh_ext.c
+++ b/source/core/services/vap_svc_mesh_ext.c
@@ -2120,15 +2120,16 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
     } else if (sta_data->stats.connect_status == wifi_connection_status_ap_not_found || sta_data->stats.connect_status == wifi_connection_status_disconnected) {
         apply_pending_channel_change(svc, sta_data->stats.vap_index);
 
-        bssid_mac_str = (char *)malloc(MAC_ADDR_STR_LEN);
-        if (bssid_mac_str != NULL) {
-            memset(bssid_mac_str, '\0', MAC_ADDR_STR_LEN);
-            uint8_mac_to_string_mac(sta_data->bss_info.bssid,
-                bssid_mac_str);
-            wifi_util_dbg_print(WIFI_CTRL, "%s:%d bssid mac=%s\n", __func__, __LINE__,
-                bssid_mac_str);
-            apps_mgr_link_quality_event(&ctrl->apps_mgr, wifi_event_type_exec,
-                wifi_event_exec_unregister_station, bssid_mac_str, MAC_ADDR_STR_LEN);
+        if (ctrl->rf_status_down) {
+            bssid_mac_str = (char *)malloc(MAC_ADDR_STR_LEN);
+            if (bssid_mac_str != NULL) {
+                memset(bssid_mac_str, '\0', MAC_ADDR_STR_LEN);
+                uint8_mac_to_string_mac(sta_data->bss_info.bssid, bssid_mac_str);
+                wifi_util_dbg_print(WIFI_CTRL, "%s:%d bssid mac=%s\n", __func__, __LINE__,
+                    bssid_mac_str);
+                apps_mgr_link_quality_event(&ctrl->apps_mgr, wifi_event_type_exec,
+                    wifi_event_exec_unregister_station, bssid_mac_str, MAC_ADDR_STR_LEN);
+            }
         }
 
         if (ext->conn_state == connection_state_connected &&


### PR DESCRIPTION
DTMESH-795: Follower mode manager restarts on 2nd iteration of parentchange.

Impacted Platforms:
Extenders using OneWifi

Reason for change: Avoid doing a memcpy to temp_vap_info->u.sta_info.bssid as it overrides the
memset to 0 causing the check to see if they are both same. If they are same then it fails.

Test Procedure: Please refer the JIRA.

Risk: Low

Signed off by:Srijeyarankesh_JS@comcast.com