### PR TITLE
RDKCOM-5543, RDKBWIFI-364 : Generalizing bus abstraction functions for retrieving and setting bus data property types.

### DIFF
--- a/source/apps/csi/wifi_csi_analytics.c
+++ b/source/apps/csi/wifi_csi_analytics.c
@@ -391,7 +391,7 @@ void run_csi_enable_timer(wifi_app_t *p_app, bool status)
     }
 }
 
-static void do_nothing_handler(char *event_name, raw_data_t *p_data, void *userData)
+static void do_nothing_handler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     UNREFERENCED_PARAMETER(event_name);
     UNREFERENCED_PARAMETER(p_data);

--- a/source/apps/sm/wifi_sm.c
+++ b/source/apps/sm/wifi_sm.c
@@ -822,20 +822,20 @@ int sm_event(wifi_app_t *app, wifi_event_t *event)
     return RETURN_OK;
 }
 
-static void sm_app_enable_handler(char *event_name, raw_data_t *p_data)
+static void sm_app_enable_handler(char *event_name, bus_data_prop_t *p_data)
 {
     bool sm_app_enable;
 
     wifi_util_dbg_print(WIFI_SM, "%s:%d recvd event\n", __func__, __LINE__);
 
     if ((strcmp(event_name, BUS_SM_APP_ENABLE) != 0) ||
-        (p_data->data_type != bus_data_type_boolean)) {
+        (p_data->value.data_type != bus_data_type_boolean)) {
         wifi_util_error_print(WIFI_SM, "%s:%d invalid event received,%s:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
         return;
     }
 
-    sm_app_enable = p_data->raw_data.b;
+    sm_app_enable = p_data->value.raw_data.b;
 
     push_event_to_ctrl_queue(&sm_app_enable, sizeof(sm_app_enable), wifi_event_type_command,
         wifi_event_type_sm_app_enable, NULL);

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1129,7 +1129,7 @@ bus_error_t webconfig_set_subdoc(char *event_name, raw_data_t *p_data, bus_user_
     return bus_error_success;
 }
 
-static void MarkerListConfigHandler (char *event_name, raw_data_t *p_data, void *userData)
+static void MarkerListConfigHandler (char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     wifi_event_subtype_t list_type;
     (void)userData;
@@ -1153,10 +1153,10 @@ static void MarkerListConfigHandler (char *event_name, raw_data_t *p_data, void 
         return;
     }
 
-    pTmp = (char *) p_data->raw_data.bytes;
-    if ((p_data->data_type != bus_data_type_string) || (pTmp == NULL)) {
+    pTmp = (char *)p_data->value.raw_data.bytes;
+    if ((p_data->value.data_type != bus_data_type_string) || (pTmp == NULL)) {
         wifi_util_dbg_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
-                __func__, __LINE__, event_name, p_data->data_type);
+                __func__, __LINE__, event_name, p_data->value.data_type);
         return;
     }
 
@@ -1166,7 +1166,7 @@ static void MarkerListConfigHandler (char *event_name, raw_data_t *p_data, void 
 }
 
 #if defined(GATEWAY_FAILOVER_SUPPORTED)
-static void activeGatewayCheckHandler(char *event_name, raw_data_t *p_data, void *userData)
+static void activeGatewayCheckHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     bool other_gateway_present = false;
@@ -1174,20 +1174,20 @@ static void activeGatewayCheckHandler(char *event_name, raw_data_t *p_data, void
     if(strcmp(event_name, WIFI_ACTIVE_GATEWAY_CHECK) != 0) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Event Received %s", __func__, __LINE__, event_name);
         return;
-    } else if (p_data->data_type != bus_data_type_boolean) {
+    } else if (p_data->value.data_type != bus_data_type_boolean) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
-                __func__, __LINE__, event_name, p_data->data_type);
+                __func__, __LINE__, event_name, p_data->value.data_type);
         return;
     }
 
-    other_gateway_present = p_data->raw_data.b;
+    other_gateway_present = p_data->value.raw_data.b;
 
     push_event_to_ctrl_queue(&other_gateway_present, sizeof(other_gateway_present),
         wifi_event_type_command, wifi_event_type_active_gw_check, NULL);
 }
 #endif
 
-static void wan_failover_handler(char *event_name, raw_data_t *p_data, void *userData)
+static void wan_failover_handler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     bool data_value = false;
@@ -1196,17 +1196,17 @@ static void wan_failover_handler(char *event_name, raw_data_t *p_data, void *use
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Event Received %s",
                 __func__, __LINE__, event_name);
         return;
-    } else if (p_data->data_type != bus_data_type_boolean) {
+    } else if (p_data->value.data_type != bus_data_type_boolean) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
-                __func__, __LINE__, event_name, p_data->data_type);
+                __func__, __LINE__, event_name, p_data->value.data_type);
         return;
     }
 
-    data_value = p_data->raw_data.b;
+    data_value = p_data->value.raw_data.b;
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d: recv data:%d\r\n", __func__, __LINE__, data_value);
 }
-static void hotspotTunnelHandler(char *event_name, raw_data_t *p_data, void *userData)
+static void hotspotTunnelHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     char *pTmp;
@@ -1216,13 +1216,13 @@ static void hotspotTunnelHandler(char *event_name, raw_data_t *p_data, void *use
     if(strcmp(event_name, "TunnelStatus") != 0) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Not Tunnel event, %s\n", __func__, __LINE__, event_name);
         return;
-    } else if (p_data->data_type != bus_data_type_string) {
+    } else if (p_data->value.data_type != bus_data_type_string) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
-                __func__, __LINE__, event_name, p_data->data_type);
+                __func__, __LINE__, event_name, p_data->value.data_type);
         return;
     }
 
-    pTmp = (char *) p_data->raw_data.bytes;
+    pTmp = (char *)p_data->value.raw_data.bytes;
 
     if (pTmp == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: wrong bus data recived for Event %s", __func__, __LINE__, event_name);
@@ -1791,15 +1791,15 @@ bus_error_t set_ignite_link_quality_threshold(char *event_name, raw_data_t *p_da
 }
 
 #if defined(RDKB_EXTENDER_ENABLED) || defined(WAN_FAILOVER_SUPPORTED)
-static void deviceModeHandler(char *event_name, raw_data_t *p_data, void *userData)
+static void deviceModeHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     int device_mode;
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d recvd event:%s\n", __func__, __LINE__, event_name);
 
-    if ((strcmp(event_name, WIFI_DEVICE_MODE) == 0) && (p_data->data_type == bus_data_type_uint32)) {
-        device_mode = p_data->raw_data.u32;
+    if ((strcmp(event_name, WIFI_DEVICE_MODE) == 0) && (p_data->value.data_type == bus_data_type_uint32)) {
+        device_mode = p_data->value.raw_data.u32;
 
         wifi_util_dbg_print(WIFI_CTRL, "%s:%d: event:%s: value:%d\n", __func__, __LINE__,
             event_name, device_mode);
@@ -1808,20 +1808,20 @@ static void deviceModeHandler(char *event_name, raw_data_t *p_data, void *userDa
 
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Unsupported event:%s:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
     }
 }
 #endif
 
-static void testDeviceModeHandler(char *event_name, raw_data_t *p_data, void *userData)
+static void testDeviceModeHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     int device_mode = rdk_dev_mode_type_gw;
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d recvd event:%s\n", __func__, __LINE__, event_name);
 
-    if ((strcmp(event_name, TEST_WIFI_DEVICE_MODE) == 0) && (p_data->data_type == bus_data_type_uint32)) {
-        device_mode = p_data->raw_data.u32;
+    if ((strcmp(event_name, TEST_WIFI_DEVICE_MODE) == 0) && (p_data->value.data_type == bus_data_type_uint32)) {
+        device_mode = p_data->value.raw_data.u32;
 
         wifi_util_dbg_print(WIFI_CTRL, "%s:%d: event:%s: value:%d\n", __func__, __LINE__,
             event_name, device_mode);
@@ -1829,29 +1829,29 @@ static void testDeviceModeHandler(char *event_name, raw_data_t *p_data, void *us
             wifi_event_type_device_network_mode, NULL);
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Unsupported event:%s:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
     }
 }
 
-static void meshStatusHandler(char *event_name, raw_data_t *p_data, void *userData)
+static void meshStatusHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
    (void)userData;
     bool mesh_status = false;
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d Recvd Event\n", __func__, __LINE__);
 
-    if((strcmp(event_name, MESH_STATUS) != 0) || (p_data->data_type != bus_data_type_boolean)) {
-        wifi_util_error_print(WIFI_CTRL,"%s:%d Invalid event received,%s:%x\n", __func__, __LINE__, event_name, p_data->data_type);
+    if((strcmp(event_name, MESH_STATUS) != 0) || (p_data->value.data_type != bus_data_type_boolean)) {
+        wifi_util_error_print(WIFI_CTRL,"%s:%d Invalid event received,%s:%x\n", __func__, __LINE__, event_name, p_data->value.data_type);
         return;
     }
 
-    mesh_status = p_data->raw_data.b;
+    mesh_status = p_data->value.raw_data.b;
 
     push_event_to_ctrl_queue(&mesh_status, sizeof(mesh_status), wifi_event_type_command,
         wifi_event_type_command_mesh_status, NULL);
 }
 
-static void eventReceiveHandler(char *event_name, raw_data_t *p_data, void *userData)
+static void eventReceiveHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     bool tunnel_status = false;
@@ -1859,9 +1859,9 @@ static void eventReceiveHandler(char *event_name, raw_data_t *p_data, void *user
 
     wifi_util_dbg_print(WIFI_CTRL, " %s:%d Recvd Event\n", __func__, __LINE__);
 
-    if ((strcmp(event_name, WIFI_DEVICE_TUNNEL_STATUS) == 0) && p_data->data_type == bus_data_type_string) {
+    if ((strcmp(event_name, WIFI_DEVICE_TUNNEL_STATUS) == 0) && p_data->value.data_type == bus_data_type_string) {
 
-        pTmp = (char *)p_data->raw_data.bytes;
+        pTmp = (char *)p_data->value.raw_data.bytes;
         if(pTmp == NULL) {
             wifi_util_error_print(WIFI_CTRL, "%s:%d: Unable to get  value in event:%s\n", __func__, __LINE__, event_name);
             return;
@@ -1880,7 +1880,7 @@ static void eventReceiveHandler(char *event_name, raw_data_t *p_data, void *user
             event_name, tunnel_status);
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Unsupported event:%s:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
         return;
     }
     wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
@@ -1889,7 +1889,7 @@ static void eventReceiveHandler(char *event_name, raw_data_t *p_data, void *user
         NULL);
 }
 
-static void frame_802_11_injector_Handler(char *event_name, raw_data_t *p_data, void *userData)
+static void frame_802_11_injector_Handler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     frame_data_t *data_ptr;
@@ -1899,14 +1899,14 @@ static void frame_802_11_injector_Handler(char *event_name, raw_data_t *p_data, 
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d Recvd Event\n", __func__, __LINE__);
 
-    if (p_data->data_type != bus_data_type_bytes) {
+    if (p_data->value.data_type != bus_data_type_bytes) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: event:%s Unsupported data type:%x\n", __func__,
-            __LINE__, event_name, p_data->data_type);
+            __LINE__, event_name, p_data->value.data_type);
         return;
     }
 
-    len = p_data->raw_data_len;
-    data_ptr = (frame_data_t *)p_data->raw_data.bytes;
+    len = p_data->value.raw_data_len;
+    data_ptr = (frame_data_t *)p_data->value.raw_data.bytes;
 
     if (data_ptr != NULL && len != 0) {
         memcpy((uint8_t *)&frame_data.frame.sta_mac, (uint8_t *)&data_ptr->frame.sta_mac,
@@ -1942,20 +1942,20 @@ static void frame_802_11_injector_Handler(char *event_name, raw_data_t *p_data, 
     }
 }
 
-static void wps_test_event_receive_handler(char *event_name, raw_data_t *p_data, void *userData)
+static void wps_test_event_receive_handler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     uint32_t vap_index = 0;
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d bus event name=%s\n", __func__, __LINE__, event_name);
 
-    if (p_data->data_type != bus_data_type_uint32) {
+    if (p_data->value.data_type != bus_data_type_uint32) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d event:%s wrong data type:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
         return;
     }
 
-    vap_index = p_data->raw_data.u32;
+    vap_index = p_data->value.raw_data.u32;
 
     if (wifi_util_is_vap_index_valid(&((wifi_mgr_t *)get_wifimgr_obj())->hal_cap.wifi_prop,
             (int)vap_index)) {
@@ -1971,33 +1971,33 @@ static void wps_test_event_receive_handler(char *event_name, raw_data_t *p_data,
 }
 
 #if defined(EASY_MESH_NODE)
-static void wifi_sta_2g_status_handler(char *event_name, raw_data_t *p_data, void *userData)
+static void wifi_sta_2g_status_handler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d Received event:%s with data type :%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
     return;
 }
 
-static void wifi_sta_5g_status_handler(char *event_name, raw_data_t *p_data, void *userData)
+static void wifi_sta_5g_status_handler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d Received event:%s with data type:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
     return;
 }
 #endif
 
 #if defined(RDKB_EXTENDER_ENABLED)
-static void eth_bh_status_handler(char *event_name, raw_data_t *p_data, void *userData)
+static void eth_bh_status_handler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     bool eth_bh_status;
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d recvd event:%s\n", __func__, __LINE__, event_name);
 
-    if ((strcmp(event_name, ETH_BH_STATUS) == 0) && (p_data->data_type == bus_data_type_boolean)) {
-        eth_bh_status = p_data->raw_data.b;
+    if ((strcmp(event_name, ETH_BH_STATUS) == 0) && (p_data->value.data_type == bus_data_type_boolean)) {
+        eth_bh_status = p_data->value.raw_data.b;
 
         wifi_util_dbg_print(WIFI_CTRL, "%s:%d: event: %s value: %d\n", __func__, __LINE__,
             event_name, eth_bh_status);
@@ -2005,7 +2005,7 @@ static void eth_bh_status_handler(char *event_name, raw_data_t *p_data, void *us
             wifi_event_type_eth_bh_status, NULL);
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: unsupported event: %s:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
     }
 }
 
@@ -2043,15 +2043,15 @@ static int eth_bh_status_notify()
 }
 #endif
 
-static void acs_keep_out_evt_handler(char* event_name, raw_data_t *p_data, void *userData)
+static void acs_keep_out_evt_handler(char* event_name, bus_data_prop_t *p_data, void *userData)
 {    
     (void)userData;
-    if (p_data->data_type != bus_data_type_string) {
+    if (p_data->value.data_type != bus_data_type_string) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d event:%s wrong data type:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
         return;
     }
-    char *json_schema = (char *)p_data->raw_data.bytes;
+    char *json_schema = (char *)p_data->value.raw_data.bytes;
     if (json_schema == NULL) {
         return;
     }
@@ -2082,26 +2082,26 @@ void* bus_get_keep_out_json()
     return (void*)json_schema;
 }
 
-void speed_test_handler (char *event_name, raw_data_t *p_data, void *userData)
+void speed_test_handler (char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     speed_test_data_t speed_test_data = { 0 };
 
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
 
-    if ((p_data->data_type != bus_data_type_uint32)) {
+    if ((p_data->value.data_type != bus_data_type_uint32)) {
         wifi_util_error_print(WIFI_CTRL,"%s:%d event:%s wrong data_type:%x\n", __func__, __LINE__,
-            event_name, p_data->data_type);
+            event_name, p_data->value.data_type);
         return;
     }
 
     wifi_util_dbg_print(WIFI_CTRL, "%s: %d event name : [%s] Data received : [%u]\n", __func__,
-        __LINE__, event_name, p_data->raw_data.u32);
+        __LINE__, event_name, p_data->value.raw_data.u32);
 
     if ((strcmp(event_name, SPEEDTEST_STATUS)) == 0) {
-        ctrl->speed_test_running = p_data->raw_data.u32;
+        ctrl->speed_test_running = p_data->value.raw_data.u32;
     } else if ((strcmp(event_name, SPEEDTEST_SUBSCRIBE)) == 0) {
-        ctrl->speed_test_timeout = p_data->raw_data.u32;
+        ctrl->speed_test_timeout = p_data->value.raw_data.u32;
     }
     speed_test_data.speed_test_running = ctrl->speed_test_running;
     speed_test_data.speed_test_timeout = ctrl->speed_test_timeout;
@@ -3738,9 +3738,12 @@ int events_bus_publish(wifi_event_t *evt)
     return 0;
 }
 
-bus_error_t get_client_assoc_request_multi(char const* methodName, raw_data_t *inParams,
-    raw_data_t *outParams, void *asyncHandle)
+bus_error_t get_client_assoc_request_multi(char const* methodName, bus_data_prop_t *inParams,
+    bus_data_prop_t *outParams, void *asyncHandle)
 {
+    (void)methodName;
+    (void)asyncHandle;
+
     sta_data_t *sta;
     unsigned int vap_index = 0;
     frame_data_t tmp_data;
@@ -3752,12 +3755,12 @@ bus_error_t get_client_assoc_request_multi(char const* methodName, raw_data_t *i
 
     unsigned char *pTmp;
 
-    pTmp = inParams->raw_data.bytes;
-    len = inParams->raw_data_len;
+    pTmp = inParams->value.raw_data.bytes;
+    len = inParams->value.raw_data_len;
 
-    if(pTmp == NULL || inParams->data_type != bus_data_type_bytes) {
+    if(pTmp == NULL || inParams->value.data_type != bus_data_type_bytes) {
         wifi_util_error_print(WIFI_CTRL,"%s:%d object not found:0x%x for vap_index:\r\n",
-            __func__, __LINE__, inParams->data_type);
+            __func__, __LINE__, inParams->value.data_type);
         return bus_error_destination_not_found;
     }
 
@@ -3798,20 +3801,24 @@ bus_error_t get_client_assoc_request_multi(char const* methodName, raw_data_t *i
 
     uint32_t output_len = (sizeof(l_data->frame) + l_data->frame.len);
 
-    outParams->data_type = bus_data_type_bytes;
-    outParams->raw_data.bytes = malloc(output_len);
-    if (outParams->raw_data.bytes == NULL) {
+    outParams->value.data_type = bus_data_type_bytes;
+    outParams->value.raw_data.bytes = malloc(output_len);
+    if (outParams->value.raw_data.bytes == NULL) {
         wifi_util_error_print(WIFI_CTRL,"%s:%d memory allocation is failed:%d\r\n",__func__,
             __LINE__, output_len);
         return bus_error_out_of_resources;
     }
-    memset(outParams->raw_data.bytes, '\0', output_len);
-    memcpy(outParams->raw_data.bytes, (uint8_t *)l_data, output_len);
+    memset(outParams->value.raw_data.bytes, '\0', output_len);
+    memcpy(outParams->value.raw_data.bytes, (uint8_t *)l_data, output_len);
 
-    outParams->raw_data_len = output_len;
-    wifi_util_dbg_print(WIFI_CTRL, "%s %d Length updated as %u\n", __func__, __LINE__, outParams->raw_data_len);
+    outParams->value.raw_data_len = output_len;
+    outParams->is_data_set = true;
+    outParams->status = bus_error_success;
+    outParams->ref_count = 1;
+    outParams->next_data = NULL;
+    wifi_util_dbg_print(WIFI_CTRL, "%s %d Length updated as %u\n", __func__, __LINE__, outParams->value.raw_data_len);
 
-    if (outParams->raw_data.bytes == NULL) {
+    if (outParams->value.raw_data.bytes == NULL) {
         wifi_util_info_print(WIFI_CTRL, "%s %d output bytes were NULL\n", __func__, __LINE__);
     }
     return bus_error_success;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -9673,7 +9673,7 @@ int wifi_db_update_psm_values()
 }
 
 //static void bus_subscription_handler(bus_handle_t handle, bus_event_t *event,
-static void bus_subscription_handler(char *event_name, raw_data_t *p_data, void *userData)
+static void bus_subscription_handler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)p_data;
     (void)userData;

--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -558,16 +558,16 @@ void dml_cache_update(webconfig_subdoc_data_t *data)
     }
 }
 
-void set_webconfig_dml_data(char *eventName, raw_data_t *p_data, void *userData)
+void set_webconfig_dml_data(char *eventName, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
     char *pTmp = NULL;
     webconfig_subdoc_data_t *data = NULL;
 
     wifi_util_dbg_print(WIFI_DMCLI,"bus event callback Event is %s\r\n",eventName);
-    pTmp = p_data->raw_data.bytes;
-    if ((p_data->data_type != bus_data_type_string) || (pTmp == NULL)) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d:[%s]wrong bus object data:%02x\r\n", __func__, __LINE__, eventName, p_data->data_type);
+    pTmp = p_data->value.raw_data.bytes;
+    if ((p_data->value.data_type != bus_data_type_string) || (pTmp == NULL)) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d:[%s]wrong bus object data:%02x\r\n", __func__, __LINE__, eventName, p_data->value.data_type);
         return;
     }
 

--- a/source/platform/common/bus_common.c
+++ b/source/platform/common/bus_common.c
@@ -832,11 +832,17 @@ void bus_release_data_prop(bus_data_prop_t *p_data_prop, uint32_t *num_prop)
 {
     bus_data_prop_t *next, *prev, *cur;
 
+    if (p_data_prop == NULL) {
+        return;
+    }
+
     if (p_data_prop->ref_count == 1) {
         free_bus_raw_data(&p_data_prop->value);
         p_data_prop->is_data_set = false;
         p_data_prop->ref_count = 0;
-        (*num_prop)--;
+        if (num_prop && (*num_prop > 0)) {
+            (*num_prop)--;
+        }
     } else if (p_data_prop->ref_count > 1) {
         wifi_util_info_print(WIFI_BUS,"%s:%d memory:%p still have some references:%d\r\n",
                 __func__, __LINE__, p_data_prop, p_data_prop->ref_count);
@@ -853,7 +859,9 @@ void bus_release_data_prop(bus_data_prop_t *p_data_prop, uint32_t *num_prop)
         if (cur->ref_count == 1) {
             free_bus_raw_data(&cur->value);
             free(cur);
-            (*num_prop)--;
+            if (num_prop && (*num_prop > 0)) {
+                (*num_prop)--;
+            }
             prev->next_data = next;
         } else if (cur->ref_count > 1) {
             wifi_util_info_print(WIFI_BUS,"%s:%d memory:%p still have some references:%d\r\n",
@@ -868,7 +876,9 @@ void bus_release_data_prop(bus_data_prop_t *p_data_prop, uint32_t *num_prop)
         cur = next;
     }
 
-    wifi_util_info_print(WIFI_BUS,"%s:%d remaining num_prop:%d\r\n", __func__, __LINE__, *num_prop);
+    if (num_prop) {
+        wifi_util_info_print(WIFI_BUS,"%s:%d remaining num_prop:%d\r\n", __func__, __LINE__, *num_prop);
+    }
 }
 
 void bus_release_data_obj(bus_data_obj_t *p_bus_obj)

--- a/source/platform/common/bus_common.h
+++ b/source/platform/common/bus_common.h
@@ -228,10 +228,10 @@ typedef bus_error_t (*bus_table_add_row_handler_t)(char const* tableName, char c
 typedef bus_error_t (*bus_table_remove_row_handler_t)(char const* rowName);
 //typedef bus_error_t (*bus_method_handler_t)(char const* method_name, bus_data_prop_t const *in_params,
     //bus_data_prop_t *out_params, void *async_handle);//we need to do it later
-typedef bus_error_t (*bus_method_handler_t)(char const* methodName, raw_data_t *inParams, raw_data_t *outParams, void *asyncHandle);
+typedef bus_error_t (*bus_method_handler_t)(char const* methodName, bus_data_prop_t *inParams, bus_data_prop_t *outParams, void *asyncHandle);
 typedef bus_error_t (*bus_name_sub_handler_t)(char *eventName, bus_event_sub_action_t action, int32_t interval, bool* autoPublish);
 
-typedef bus_error_t (*bus_event_sub_handler_t)(char *event_name, raw_data_t *p_data, void *userData);
+typedef bus_error_t (*bus_event_sub_handler_t)(char *event_name, bus_data_prop_t *p_data, void *userData);
 typedef bus_error_t (*bus_event_sub_ex_async_handler_t)(char *event_name, bus_error_t ret, void *userData);
 
 typedef void (* wifi_bus_method_async_resp_handler_t) (char const* method_name, bus_error_t error, bus_data_prop_t *params, void *user_data);

--- a/source/platform/common/data_model/wfa/wfa_data_model.c
+++ b/source/platform/common/data_model/wfa/wfa_data_model.c
@@ -204,7 +204,7 @@ static void de_sync_rows(char const* tableName, uint32_t old_cnt, uint32_t new_c
     free(rowPath);
 }
 
-bus_error_t de_apmld_sync_handler(char const* tableName, raw_data_t *inParams, raw_data_t *outParams, void *asyncHandle)
+bus_error_t de_apmld_sync_handler(char const* tableName, bus_data_prop_t *inParams, bus_data_prop_t *outParams, void *asyncHandle)
 {
     (void)inParams;
     (void)outParams;
@@ -220,7 +220,7 @@ bus_error_t de_apmld_sync_handler(char const* tableName, raw_data_t *inParams, r
     return bus_error_success;
 }
 
-bus_error_t de_affap_sync_handler(char const* tableName, raw_data_t *inParams, raw_data_t *outParams, void *asyncHandle)
+bus_error_t de_affap_sync_handler(char const* tableName, bus_data_prop_t *inParams, bus_data_prop_t *outParams, void *asyncHandle)
 {
     (void)inParams;
     (void)outParams;
@@ -269,7 +269,7 @@ static bus_error_t de_stamld_get(char *event_name, raw_data_t *p_data, struct bu
     return status;
 }
 
-bus_error_t de_stamld_sync_handler(char const* tableName, raw_data_t *inParams, raw_data_t *outParams, void *asyncHandle)
+bus_error_t de_stamld_sync_handler(char const* tableName, bus_data_prop_t *inParams, bus_data_prop_t *outParams, void *asyncHandle)
 {
     (void)inParams;
     (void)outParams;
@@ -335,7 +335,7 @@ static bus_error_t de_affsta_get(char *event_name, raw_data_t *p_data, struct bu
     return status;
 }
 
-bus_error_t de_affsta_sync_handler(char const* tableName, raw_data_t *inParams, raw_data_t *outParams, void *asyncHandle)
+bus_error_t de_affsta_sync_handler(char const* tableName, bus_data_prop_t *inParams, bus_data_prop_t *outParams, void *asyncHandle)
 {
     (void)inParams;
     (void)outParams;

--- a/source/platform/linux/he_bus/inc/he_bus_core.h
+++ b/source/platform/linux/he_bus/inc/he_bus_core.h
@@ -93,7 +93,7 @@ typedef he_bus_error_t (*he_bus_event_sub_handler_t)(char *eventName,
     he_bus_event_sub_action_t action, int32_t interval, bool *autoPublish);
 
 typedef he_bus_error_t (
-    *he_bus_event_consumer_sub_handler_t)(char *event_name, he_bus_raw_data_t *p_data, void *userData);
+    *he_bus_event_consumer_sub_handler_t)(char *event_name, he_bus_data_object_t *p_data, void *userData);
 typedef he_bus_error_t (*he_bus_event_sub_ex_async_handler_t)(char *event_name, he_bus_error_t ret, void *userData);
 
 typedef void (*he_bus_method_async_resp_handler_t) (char const* methodName, he_bus_error_t ret,

--- a/source/platform/linux/he_bus/src/he_bus_data_conversion.c
+++ b/source/platform/linux/he_bus/src/he_bus_data_conversion.c
@@ -835,9 +835,8 @@ he_bus_error_t process_bus_sub_ex_async_res_event(hash_map_t *p_sub_map, char *c
         if (p_sub_data->sub_cb_table.sub_ex_async_handler != NULL) {
             he_bus_core_dbg_print("%s:%d Async subscribe callback is triggered\r\n", __func__,
                 __LINE__);
-	    void *userData = NULL;
             p_sub_data->sub_cb_table.sub_ex_async_handler(p_obj_data->name,
-                (he_bus_error_t)p_obj_data->data.raw_data.u32, userData);
+                (he_bus_error_t)p_obj_data->data.raw_data.u32, NULL);
         }
         if (p_obj_data->data.data_type == he_bus_data_type_uint32 &&
             p_obj_data->data.raw_data.u32 != he_bus_error_success) {
@@ -894,14 +893,13 @@ he_bus_error_t process_bus_publish_event(hash_map_t *p_sub_map, he_bus_data_obje
         return he_bus_error_invalid_input;
     }
 
-    void *userData = NULL;
     own_sub_element_t *p_sub_data = get_bus_user_cb(p_sub_map, p_obj_data->name);
     if (p_sub_data != NULL) {
         he_bus_core_info_print("%s:%d subscribe callback is found for [%s]\r\n", __func__, __LINE__,
             p_obj_data->name);
         if (p_sub_data->sub_cb_table.sub_handler != NULL) {
             he_bus_core_dbg_print("%s:%d subscribe callback is triggered\r\n", __func__, __LINE__);
-            p_sub_data->sub_cb_table.sub_handler(p_obj_data->name, &p_obj_data->data, userData);
+            p_sub_data->sub_cb_table.sub_handler(p_obj_data->name, p_obj_data, NULL);
         }
     } else {
         he_bus_core_error_print("%s:%d subscribe callback not found for [%s]\r\n", __func__,

--- a/source/platform/rdkb/bus.c
+++ b/source/platform/rdkb/bus.c
@@ -614,90 +614,231 @@ bus_error_t set_rbus_property_data(char *event_name, rbusProperty_t property, ra
     return ret;
 }
 
-bus_error_t get_rbus_object_data(char *name, rbusObject_t inParams, raw_data_t *bus_data)
+// Convert an rbus value and append it into the bus_data property list.
+static bus_error_t rbus_value_to_bus_prop(bus_data_prop_t *bus_data, const char *prop_name,
+    rbusValue_t value)
 {
-    bus_error_t rc = bus_error_success;
-    int len = 0;
+    if (bus_data == NULL || value == NULL) {
+        return bus_error_invalid_input;
+    }
 
-    if (bus_data == NULL) {
+    bus_error_t rc = bus_error_success;
+    bus_data_prop_t *prop = NULL;
+    bool use_head = (!bus_data->is_data_set && bus_data->next_data == NULL);
+
+    if (use_head) {
+        prop = bus_data;
+        memset(prop, 0, sizeof(*prop));
+    } else {
+        prop = calloc(1, sizeof(*prop));
+        if (prop == NULL) {
+            return bus_error_out_of_resources;
+        }
+    }
+
+    if (prop_name != NULL) {
+        size_t name_len = strnlen(prop_name, sizeof(prop->name));
+        if (name_len >= sizeof(prop->name)) {
+            rc = bus_error_invalid_input;
+            goto cleanup;
+        }
+        memcpy(prop->name, prop_name, name_len + 1);
+        prop->name_len = (uint32_t)(name_len + 1);
+    } else {
+        prop->name_len = 0;
+        memset(prop->name, 0, sizeof(prop->name));
+    }
+
+    memset(&prop->value, 0, sizeof(prop->value));
+
+    rbusValueType_t type = rbusValue_GetType(value);
+    prop->value.data_type = convert_rbus_to_bus_data_type(type);
+
+    switch (type) {
+        case RBUS_STRING: {
+            int len = 0;
+            const char *str_val = rbusValue_GetString(value, &len);
+            if (!str_val || len < 0) {
+                rc = bus_error_invalid_input;
+                goto cleanup;
+            }
+            prop->value.raw_data.bytes = calloc(1, (size_t)len + 1);
+            if (!prop->value.raw_data.bytes) {
+                rc = bus_error_out_of_resources;
+                goto cleanup;
+            }
+            memcpy(prop->value.raw_data.bytes, str_val, (size_t)len);
+            ((char *)prop->value.raw_data.bytes)[len] = '\0';
+            prop->value.raw_data_len = (unsigned int)len + 1;
+            break;
+        }
+        case RBUS_BYTES: {
+            int len = 0;
+            const uint8_t *bytes_val = rbusValue_GetBytes(value, &len);
+            if (len < 0 || (len > 0 && !bytes_val)) {
+                rc = bus_error_invalid_input;
+                goto cleanup;
+            }
+            if (len > 0) {
+                prop->value.raw_data.bytes = calloc(1, (size_t)len);
+                if (!prop->value.raw_data.bytes) {
+                    rc = bus_error_out_of_resources;
+                    goto cleanup;
+                }
+                memcpy(prop->value.raw_data.bytes, bytes_val, (size_t)len);
+            }
+            prop->value.raw_data_len = (unsigned int)len;
+            break;
+        }
+        case RBUS_BOOLEAN:
+            prop->value.raw_data.b = rbusValue_GetBoolean(value);
+            prop->value.raw_data_len = sizeof(bool);
+            break;
+        case RBUS_INT32:
+            prop->value.raw_data.i32 = rbusValue_GetInt32(value);
+            prop->value.raw_data_len = sizeof(int32_t);
+            break;
+        case RBUS_UINT32:
+            prop->value.raw_data.u32 = rbusValue_GetUInt32(value);
+            prop->value.raw_data_len = sizeof(uint32_t);
+            break;
+        default:
+            rc = bus_error_invalid_input;
+            goto cleanup;
+    }
+
+    prop->is_data_set = true;
+    prop->status = bus_error_success;
+    prop->ref_count = 1;
+
+    if (!use_head) {
+        prop->next_data = bus_data->next_data;
+        bus_data->next_data = prop;
+    }
+
+    return bus_error_success;
+
+cleanup:
+    free_raw_data_struct(&prop->value);
+    if (use_head) {
+        memset(prop, 0, sizeof(*prop));
+    } else {
+        free(prop);
+    }
+    return rc;
+}
+
+// get rbus object data from rbus
+static bus_error_t get_rbus_object_data(char *name, rbusObject_t inParams, bus_data_prop_t *bus_data)
+{
+    if (bus_data == NULL || inParams == NULL) {
         wifi_util_error_print(WIFI_BUS, "%s:%d bus buff is NULL\n",__func__, __LINE__);
         return bus_error_invalid_input;
     }
 
-    rbusValue_t value = rbusObject_GetValue(inParams, NULL);
-    rbusValueType_t type = rbusValue_GetType(value);
-    bus_data->data_type = convert_rbus_to_bus_data_type(type);
+    bus_error_t rc = bus_error_success;
+    rbusProperty_t prop_head = rbusObject_GetProperties(inParams);
 
-    switch(type) {
-        case RBUS_STRING:
-            bus_data->raw_data.bytes = (char *)rbusValue_GetString(value, &len);
-            if (bus_data->raw_data.bytes != NULL) {
-                bus_data->raw_data_len = (unsigned int)len;
-                wifi_util_dbg_print(WIFI_BUS,"%s Rbus get string len=%d\n",__FUNCTION__,len);
-            } else {
+    if (prop_head != NULL) {
+        for (rbusProperty_t prop = prop_head; prop && rc == bus_error_success; prop = rbusProperty_GetNext(prop)) {
+            const char *prop_name = rbusProperty_GetName(prop);
+            if (prop_name == NULL) {
                 rc = bus_error_invalid_input;
-                wifi_util_error_print(WIFI_BUS,"%s Rbus get string failure len=%d\n",__FUNCTION__, len);
+                break;
             }
-        break;
-        case RBUS_UINT32:
-            bus_data->raw_data.u32 = rbusValue_GetUInt32(value);
-            bus_data->raw_data_len = sizeof(uint32_t);
-        break;
-        case RBUS_INT32:
-	    bus_data->raw_data.i32 = rbusValue_GetInt32(value);
-	    bus_data->raw_data_len = sizeof(int32_t);
-        break;
-        case RBUS_BOOLEAN:
-            bus_data->raw_data.b = rbusValue_GetBoolean(value);
-            bus_data->raw_data_len = sizeof(bool);
-        break;
-        case RBUS_BYTES:
-            bus_data->raw_data.bytes = (uint8_t *)rbusValue_GetBytes(value, &len);
-            if (bus_data->raw_data.bytes != NULL) {
-                bus_data->raw_data_len = (unsigned int)len;
-                wifi_util_dbg_print(WIFI_BUS,"%s Rbus get bytes len=%d\n",__FUNCTION__, len);
-            } else {
-                rc = bus_error_invalid_input;
-                wifi_util_error_print(WIFI_BUS,"%s Rbus get bytes failure len=%d\n",__FUNCTION__, len);
-            }
-        break;
-        default:
-            wifi_util_error_print(WIFI_BUS,"%s Rbus value type not found =%d\n",__FUNCTION__, type);
-            rc = bus_error_invalid_input;
-        break;
-    }
 
-    if (rc != bus_error_success) {
-        wifi_util_error_print(WIFI_BUS,"%s rbus read failed for %s\n",__FUNCTION__, name);
+            rbusValue_t prop_val = rbusProperty_GetValue(prop);
+            if (prop_val == NULL) {
+                rc = bus_error_invalid_input;
+                break;
+            }
+
+            rc = rbus_value_to_bus_prop(bus_data, prop_name, prop_val);
+            if (rc != bus_error_success) {
+                break;
+            }
+        }
+
+        if (rc != bus_error_success) {
+            bus_release_data_prop(bus_data, NULL);
+            wifi_util_error_print(WIFI_BUS, "%s:%d rbus property parse failed for %s\n",
+                __func__, __LINE__, name ? name : "unknown");
+        }
         return rc;
     }
-
-    return rc;
+    else{
+        // Fallback: no properties, try value as a single unnamed parameter.
+        rbusValue_t value = rbusObject_GetValue(inParams, NULL);
+        if (value == NULL) {
+            return bus_error_invalid_input;
+        }
+        rbusValueType_t type = rbusValue_GetType(value);
+        if (type == RBUS_NONE) {
+            return bus_error_success;
+        }
+        return rbus_value_to_bus_prop(bus_data, NULL, value);
+    }
 }
 
-bus_error_t set_rbus_object_data(char *name, rbusObject_t outParams, raw_data_t *bus_data)
+// set bus object data to rbus
+static bus_error_t set_rbus_object_data(char *name, rbusObject_t outParams, bus_data_prop_t *bus_data)
 {
-    bus_error_t rc = bus_error_success;
-    rbusValue_t  value;
-    rbusValue_Init(&value);
-    wifi_util_dbg_print(WIFI_BUS,"%s:%d Rbus object:%s data type=%d set\r\n", __func__, __LINE__, name, bus_data->data_type);
-
-    switch(bus_data->data_type) {
-        case bus_data_type_bytes:
-            rbusValue_SetBytes(value, (uint8_t *)bus_data->raw_data.bytes, bus_data->raw_data_len);
-        break;
-        case bus_data_type_string:
-            rbusValue_SetString(value, (char *)bus_data->raw_data.bytes);
-        break;
-        default:
-            wifi_util_error_print(WIFI_BUS,"%s Rbus:%s value type not found =%d\n",__FUNCTION__, name, bus_data->data_type);
-            rc = bus_error_invalid_input;
-        break;
+    if (bus_data == NULL) {
+        return bus_error_invalid_input;
     }
-    rbusObject_SetValue(outParams, name, value);
-    rbusValue_Release(value);
 
-    return rc;
+    if (!bus_data->is_data_set && bus_data->next_data == NULL) {
+        return bus_error_success;
+    }
+
+    for (bus_data_prop_t *prop = bus_data; prop != NULL; prop = prop->next_data) {
+        if (!prop->is_data_set) {
+            continue;
+        }
+
+        rbusValue_t v = NULL;
+        rbusProperty_t p = NULL;
+        rbusValue_Init(&v);
+
+        switch (prop->value.data_type) {
+            case bus_data_type_string:
+                rbusValue_SetString(v, prop->value.raw_data.bytes ? (char *)prop->value.raw_data.bytes : "");
+                break;
+            case bus_data_type_bytes:
+                rbusValue_SetBytes(v, (uint8_t *)prop->value.raw_data.bytes, prop->value.raw_data_len);
+                break;
+            case bus_data_type_int32:
+                rbusValue_SetInt32(v, prop->value.raw_data.i32);
+                break;
+            case bus_data_type_uint32:
+                rbusValue_SetUInt32(v, prop->value.raw_data.u32);
+                break;
+            case bus_data_type_boolean:
+                rbusValue_SetBoolean(v, prop->value.raw_data.b);
+                break;
+            default:
+                wifi_util_error_print(WIFI_BUS,"%s Rbus:%s unsupported property value type=%d\n",
+                    __FUNCTION__, name, prop->value.data_type);
+                rbusValue_Release(v);
+                return bus_error_invalid_input;
+        }
+
+        const char *prop_name = NULL;
+        if (prop->name_len > 0) {
+            prop_name = prop->name;
+        } else if (name && *name) {
+            prop_name = name;
+        } else {
+            prop_name = "value";
+        }
+
+        rbusProperty_Init(&p, prop_name, v);
+        rbusObject_SetProperty(outParams, p);
+        rbusProperty_Release(p);
+        rbusValue_Release(v);
+    }
+
+    return bus_error_success;
 }
 
 rbusError_t rbus_get_handler(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* options)
@@ -859,7 +1000,7 @@ rbusError_t rbus_sync_table_handler(rbusHandle_t handle, char const* tableName)
 
 rbusError_t rbus_method_handler(rbusHandle_t handle, char const* methodName, rbusObject_t inParams, rbusObject_t outParams, rbusMethodAsyncHandle_t asyncHandle)
 {
-    raw_data_t  bus_input_data = { 0 }, bus_output_data = { 0 };
+    bus_data_prop_t bus_input_data = { 0 }, bus_output_data = { 0 };
     bus_error_t ret = bus_error_success;
 
     wifi_util_info_print(WIFI_BUS,"%s:%d rbus cb triggered for %s\n", __func__, __LINE__, methodName);
@@ -878,7 +1019,9 @@ rbusError_t rbus_method_handler(rbusHandle_t handle, char const* methodName, rbu
             } else {
                 ret = set_rbus_object_data((char *)methodName, outParams, &bus_output_data);
             }
-            free_raw_data_struct(&bus_output_data);
+            // free the input and output data structures.
+            bus_release_data_prop(&bus_input_data, NULL);
+            bus_release_data_prop(&bus_output_data, NULL);
         }
     }
     return convert_bus_to_rbus_error_code(ret);
@@ -907,7 +1050,7 @@ static void rbus_sub_handler(rbusHandle_t handle, rbusEvent_t const* event,
     (void)handle;
 
     bus_error_t ret = bus_error_success;
-    raw_data_t  bus_data = { 0 };
+    bus_data_prop_t  bus_data = { 0 };
     char *event_name = (char *)subscription->eventName;
     void *userData = subscription->userData;
 
@@ -925,6 +1068,7 @@ static void rbus_sub_handler(rbusHandle_t handle, rbusEvent_t const* event,
                 " triggered for:%s, event:%s\n", __func__, __LINE__, event_name, event->name);
             user_cb->sub_handler((char *)event->name, &bus_data, userData);
         }
+        bus_release_data_prop(&bus_data, NULL);
     }
 }
 


### PR DESCRIPTION
Reason for change : Converted the generic raw_data type to bus_data_prop_t. 
Risks: Medium
Priority: P0
Test Procedure: Flash the image and verify that all OneWifi-related features work properly.