### PR TITLE
RDKBWIFI-401: Add VAP traffic stats collection and fix AP metrics reporting

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -356,6 +356,7 @@ typedef enum {
     mon_stats_type_associated_device_stats,
     mon_stats_type_radio_diagnostic_stats,
     mon_stats_type_radio_temperature,
+    mon_stats_type_vap_stats,
     mon_stats_type_max
 } wifi_mon_stats_type_t;
 
@@ -1024,6 +1025,7 @@ typedef struct {
     bool            connection_authorized;
     bool            rapid_disconnect_flag;
     assoc_req_elem_t assoc_frame_data;
+    struct timespec timestamp;
 
     /* wifi7 client specific data */
     bool            assoc_link; /* TRUE for auth/primary link, FALSE for secondary links */
@@ -1308,10 +1310,10 @@ typedef struct {
 
 typedef struct {
     mac_addr_t bssid;
-    int time_delta;
-    int est_mac_rate_down;
-    int est_mac_rate_up;
-    int rcpi;
+    unsigned int time_delta;
+    unsigned int est_mac_rate_down;
+    unsigned int est_mac_rate_up;
+    unsigned int rcpi;
 } assoc_sta_link_metrics_data_t;
 
 typedef struct {
@@ -1419,13 +1421,13 @@ typedef struct {
 
 typedef struct {
     mac_addr_t sta_mac;
-    int bytes_sent;
-    int bytes_rcvd;
-    int packets_sent;
-    int packets_rcvd;
-    int tx_packtes_errs;
-    int rx_packtes_errs;
-    int retrans_cnt;
+    ULONG bytes_sent;
+    ULONG bytes_rcvd;
+    ULONG packets_sent;
+    ULONG packets_rcvd;
+    ULONG tx_packtes_errs;
+    ULONG rx_packtes_errs;
+    ULONG retrans_cnt;
 } assoc_sta_traffic_stats_t;
 
 typedef struct {

--- a/source/apps/em/wifi_em.c
+++ b/source/apps/em/wifi_em.c
@@ -63,10 +63,15 @@ typedef struct {
 } client_assoc_stats_t;
 
 typedef struct {
+    wifi_associated_dev3_t associated_dev3;
+    struct timespec last_update_time; // last_update_time for wifi_associated_dev3_t
+} wifi_associated_dev3_timestamp_t;
+
+typedef struct {
     int vap_index;
     ap_metrics_t ap_metrics;
     int sta_count;
-    hash_map_t *client_stats_map; // wifi_associated_dev3_t
+    hash_map_t *client_stats_map; // wifi_associated_dev3_timestamp_t
 } ap_metrics_data_t;
 
 typedef struct {
@@ -195,10 +200,10 @@ int em_route(wifi_event_route_t *route)
 }
 
 int em_client_stats_store(unsigned int radio_index, unsigned int vap_index, int sta_cnt,
-    wifi_associated_dev3_t *dev3)
+    wifi_associated_dev3_t *dev3, struct timespec *timestamp)
 {
-    wifi_associated_dev3_t *stats = NULL;
-    wifi_associated_dev3_t *new_stats = NULL;
+    wifi_associated_dev3_timestamp_t *stats = NULL;
+    wifi_associated_dev3_timestamp_t *new_stats = NULL;
     mac_addr_str_t mac_str = { 0 }, bss_str = { 0 };
     unsigned char key[64] = { 0 };
     int arr_vap_index = -1;
@@ -248,22 +253,28 @@ int em_client_stats_store(unsigned int radio_index, unsigned int vap_index, int 
     wifi_util_dbg_print(WIFI_EM, "%s:%d key while updating cache is =%s and arr_vap_index:%d\n",
         __func__, __LINE__, key, arr_vap_index);
 
-    stats = (wifi_associated_dev3_t *)hash_map_get(
+    stats = (wifi_associated_dev3_timestamp_t *)hash_map_get(
         em_ap_metrics_report_cache.radio_report[radio_index].ap_data[arr_vap_index].client_stats_map, key);
     if (stats == NULL) {
         // add new entries
-        new_stats = (wifi_associated_dev3_t *)malloc(sizeof(wifi_associated_dev3_t));
+        new_stats = (wifi_associated_dev3_timestamp_t *)calloc(1, sizeof(wifi_associated_dev3_timestamp_t));
         if (new_stats == NULL) {
             wifi_util_error_print(WIFI_EM, "%s:%d null stats=%d\n", __func__, __LINE__,
                 radio_index);
             return RETURN_ERR;
         }
+        memcpy(&new_stats->associated_dev3, dev3, sizeof(wifi_associated_dev3_t));
+        if (timestamp != NULL) {
+            new_stats->last_update_time = *timestamp;
+        }
 
-        memcpy(new_stats, dev3, sizeof(wifi_associated_dev3_t));
         hash_map_put(em_ap_metrics_report_cache.radio_report[radio_index].ap_data[arr_vap_index].client_stats_map,
             strdup(key), new_stats);
     } else {
-        memcpy(stats, dev3, sizeof(wifi_associated_dev3_t));
+        memcpy(&stats->associated_dev3, dev3, sizeof(wifi_associated_dev3_t));
+        if (timestamp != NULL) {
+            stats->last_update_time = *timestamp;
+        }
     }
 
     wifi_util_dbg_print(WIFI_EM, "%s:%d added sample for radio_index=%d, vap_index=%d, client=%s\n",
@@ -273,7 +284,7 @@ int em_client_stats_store(unsigned int radio_index, unsigned int vap_index, int 
 }
 
 static int prepare_sta_traffic_stats_data(assoc_sta_traffic_stats_t *data,
-    wifi_associated_dev3_t *stats)
+    wifi_associated_dev3_timestamp_t *stats)
 {
     if (data == NULL) {
         wifi_util_error_print(WIFI_EM, "%s:%d Error in allocating table for encode stats\n",
@@ -282,22 +293,26 @@ static int prepare_sta_traffic_stats_data(assoc_sta_traffic_stats_t *data,
         return RETURN_ERR;
     }
 
-    memcpy(data->sta_mac, stats->cli_MACAddress, sizeof(mac_address_t));
-    data->bytes_sent = stats->cli_BytesSent;
-    data->bytes_rcvd = stats->cli_BytesReceived;
-    data->packets_sent = stats->cli_PacketsSent;
-    data->packets_rcvd = stats->cli_PacketsReceived;
-    data->tx_packtes_errs = stats->cli_ErrorsSent;
-    data->rx_packtes_errs = stats->cli_RxErrors;
-    data->retrans_cnt = stats->cli_RetransCount;
+    memcpy(data->sta_mac, stats->associated_dev3.cli_MACAddress, sizeof(mac_address_t));
+    data->bytes_sent = stats->associated_dev3.cli_BytesSent;
+    data->bytes_rcvd = stats->associated_dev3.cli_BytesReceived;
+    data->packets_sent = stats->associated_dev3.cli_PacketsSent;
+    data->packets_rcvd = stats->associated_dev3.cli_PacketsReceived;
+    data->tx_packtes_errs = stats->associated_dev3.cli_ErrorsSent;
+    data->rx_packtes_errs = stats->associated_dev3.cli_RxErrors;
+    data->retrans_cnt = stats->associated_dev3.cli_RetransCount;
+    return RETURN_OK;
 }
 
-static int prepare_sta_lins_metrics_data(per_sta_metrics_t *data, wifi_associated_dev3_t *stats,
+static int prepare_sta_lins_metrics_data(per_sta_metrics_t *data, wifi_associated_dev3_timestamp_t *stats,
     unsigned int vap_index)
 {
     sta_client_info_t *cli_data = NULL;
     mac_addr_str_t key = { 0 };
     wifi_vap_info_t *vap_info = NULL;
+    struct timespec now;
+    struct timespec diff;
+    uint32_t delta_ms = 0;
 
     vap_info = getVapInfo(vap_index);
     if (vap_info == NULL) {
@@ -313,10 +328,24 @@ static int prepare_sta_lins_metrics_data(per_sta_metrics_t *data, wifi_associate
         return RETURN_ERR;
     }
 
+    if (stats->last_update_time.tv_sec != 0) {
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        if (((long)now.tv_nsec - (long)stats->last_update_time.tv_nsec) < 0) {
+                diff.tv_sec = now.tv_sec - stats->last_update_time.tv_sec - 1;
+                diff.tv_nsec = now.tv_nsec - stats->last_update_time.tv_nsec + 1000000000L;
+        } else {
+            diff.tv_sec = now.tv_sec - stats->last_update_time.tv_sec;
+            diff.tv_nsec = now.tv_nsec - stats->last_update_time.tv_nsec;
+        }
+        delta_ms = ((uint64_t)diff.tv_sec * 1000) + (diff.tv_nsec / 1000000);
+    } else {
+        delta_ms = 0;
+    }
+
     // Associated STA Link Metrics
-    memcpy(data->sta_mac, stats->cli_MACAddress, sizeof(mac_address_t));
+    memcpy(data->sta_mac, stats->associated_dev3.cli_MACAddress, sizeof(mac_address_t));
     // Retrive client type info
-    to_mac_str(stats->cli_MACAddress, key);
+    to_mac_str(stats->associated_dev3.cli_MACAddress, key);
     cli_data = hash_map_get(client_type_info.sta_client_type.client_type_map, key);
     if (cli_data != NULL) {
         strncpy(data->client_type, cli_data->client_type, sizeof(cli_data->client_type));
@@ -325,25 +354,22 @@ static int prepare_sta_lins_metrics_data(per_sta_metrics_t *data, wifi_associate
     data->assoc_sta_link_metrics.num_bssid = 1; // must be changed for STA multiple associations
     memcpy(data->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].bssid,
         vap_info->u.bss_info.bssid, sizeof(mac_address_t));
-    data->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].time_delta =
-        0; // How to calculate time Delta (The time delta in ms between the time at
-           // which the earliest measurement that contributed to the data rate estimates
-           // were made, and the time at which this report was sent.)
+    data->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].time_delta = delta_ms;
     data->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].est_mac_rate_down =
-        (stats->cli_LastDataDownlinkRate / 1000);
+        (stats->associated_dev3.cli_LastDataDownlinkRate / 1000);
     data->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].est_mac_rate_up =
-        (stats->cli_LastDataUplinkRate / 1000);
+        (stats->associated_dev3.cli_LastDataUplinkRate / 1000);
     data->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].rcpi = em_rssi_to_rcpi(
-        stats->cli_RSSI);
+        stats->associated_dev3.cli_RSSI);
 
     // Associated STA Extended Link Metrics
     data->assoc_sta_ext_link_metrics.num_bssid = 1; // must be changed for STA multiple associations
     memcpy(data->assoc_sta_ext_link_metrics.assoc_sta_ext_link_metrics_data[0].bssid,
         vap_info->u.bss_info.bssid, sizeof(mac_address_t));
     data->assoc_sta_ext_link_metrics.assoc_sta_ext_link_metrics_data[0].last_data_downlink_rate =
-        stats->cli_LastDataDownlinkRate;
+        stats->associated_dev3.cli_LastDataDownlinkRate;
     data->assoc_sta_ext_link_metrics.assoc_sta_ext_link_metrics_data[0].last_data_uplink_rate =
-        stats->cli_LastDataUplinkRate;
+        stats->associated_dev3.cli_LastDataUplinkRate;
     data->assoc_sta_ext_link_metrics.assoc_sta_ext_link_metrics_data[0].utilization_receive =
         0; // do we have that data?
     data->assoc_sta_ext_link_metrics.assoc_sta_ext_link_metrics_data[0].utilization_transmit = 0;
@@ -490,7 +516,7 @@ static int handle_ready_client_stats(wifi_app_t *app, client_assoc_data_t *stats
 
                     case em_app_event_type_assoc_dev_stats_periodic:
                         em_client_stats_store(radio_index, vap_index, stat_array_size,
-                            &sta_data->dev_stats);
+                            &sta_data->dev_stats, &sta_data->timestamp);
                         break;
 
                     default:
@@ -926,6 +952,83 @@ static int em_process_chan_stats_data(wifi_provider_response_t *provider_respons
     return RETURN_OK;
 }
 
+int vap_stats_response(wifi_provider_response_t *provider_response)
+{
+    unsigned int radio_index = provider_response->args.radio_index;
+    unsigned int vap_index = provider_response->args.vap_index;
+    vap_traffic_stats_t *vap_stats = (vap_traffic_stats_t *)provider_response->stat_pointer;
+    int arr_vap_index = -1;
+    int i;
+    wifi_mgr_t *wifi_mgr = get_wifimgr_obj();
+
+    if (radio_index >= MAX_NUM_RADIOS) {
+        wifi_util_error_print(WIFI_EM, "%s:%d Invalid radio index %d\n", __func__, __LINE__,
+            radio_index);
+        return RETURN_ERR;
+    }
+
+    if (wifi_mgr == NULL) {
+        wifi_util_error_print(WIFI_EM,"%s:%d Mgr object is NULL \r\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+
+    if (provider_response->stat_array_size <= 0 || vap_stats == NULL) {
+        wifi_util_error_print(WIFI_EM, "%s:%d: No VAP stats data\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+
+    for (i = 0; i < MAX_NUM_VAP_PER_RADIO; i++) {
+        if (vap_index == em_ap_metrics_report_cache.radio_report[radio_index].ap_data[i].vap_index) {
+            arr_vap_index = i;
+            break;
+        }
+    }
+
+    if (arr_vap_index == -1) {
+        wifi_util_error_print(WIFI_EM, "%s:%d: No arr_vap_index\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+
+    ap_metrics_data_t *ap_data = &em_ap_metrics_report_cache.radio_report[radio_index].ap_data[arr_vap_index];
+    ap_data->ap_metrics.unicast_bytes_sent = vap_stats->ssid_UnicastBytesSent;
+    ap_data->ap_metrics.unicast_bytes_rcvd = vap_stats->ssid_UnicastBytesReceived;
+    ap_data->ap_metrics.multicast_bytes_sent = vap_stats->ssid_MulticastBytesSent;
+    ap_data->ap_metrics.multicast_bytes_rcvd = vap_stats->ssid_MulticastBytesReceived;
+    ap_data->ap_metrics.broadcast_bytes_sent = vap_stats->ssid_BroadcastBytesSent;
+    ap_data->ap_metrics.broadcast_bytes_rcvd = vap_stats->ssid_BroadcastBytesReceived;
+    wifi_util_dbg_print(WIFI_EM, "%s:%d: Stored VAP traffic stats for vap_index %d arr_vap_index %d radio index %d \n",
+         __func__, __LINE__, vap_index, arr_vap_index, radio_index);
+
+    /*
+     * TODO: ESP AC BE parameters are currently hard-coded as no HAL API is
+     * available to retrieve real values. These defaults were chosen as follows:
+     *   - access_category = 1  (AC_BE)
+     *   - data_format     = 3  (A-MSDU aggregation)
+     *   - ba_window       = 7  (BA window size 64)
+     *   - airtime_fraction= 255 (100%)
+     *   - ppdu_duration   = 0  (unknown)
+     *
+     * Once a HAL API is available, replace the hard-coded values with real
+     * measurements and set inc_esp_ac_be accordingly.
+     */
+    int access_category = 1;      // 3 bit
+    int data_format = 3;          // 2 bit
+    int ba_window = 7;            // 3 bit
+    int airtime_fraction = 255;   // 8 bit
+    int ppdu_duration = 0;        // 8 bit
+    // Bit-level packing (24 bit int)
+    int esp_ac_be = 0;
+    esp_ac_be |= (access_category & 0x07) << 21;
+    esp_ac_be |= (data_format & 0x03) << 19;
+    esp_ac_be |= (ba_window & 0x07) << 16;
+    esp_ac_be |= (airtime_fraction & 0xFF) << 8;
+    esp_ac_be |= (ppdu_duration & 0xFF);
+
+    ap_data->ap_metrics.inc_esp_ac_be = 1;
+    ap_data->ap_metrics.esp_ac_be = esp_ac_be;
+    return RETURN_OK;
+}
+
 static int radio_chan_stats_response(wifi_provider_response_t *provider_response)
 {
     int radio_index = -1;
@@ -1012,7 +1115,7 @@ static int radio_chan_stats_response(wifi_provider_response_t *provider_response
         radio_metrics->noise = channel_stats[count].ch_noise;
         radio_metrics->transmit = channel_stats[count].ch_utilization_busy_tx;
         radio_metrics->receive_self = channel_stats[count].ch_utilization_busy_self;
-        radio_metrics->receive_other = 0;
+        radio_metrics->receive_other = channel_stats[count].ch_utilization_busy_ext;
 
         // now save radio channel util for each vap
         for (j = 0; j < radio->vaps.num_vaps; j++) {
@@ -1093,6 +1196,9 @@ int handle_monitor_provider_response(wifi_app_t *app, wifi_event_t *event)
     case em_app_event_type_ap_metrics_rad_chan_stats:
         ret = radio_chan_stats_response(provider_response);
         break;
+    case em_app_event_type_vap_stats_periodic:
+        ret = vap_stats_response(provider_response);
+        break;
     default:
         wifi_util_error_print(WIFI_EM, "%s:%d: event not handle[%d]\r\n", __func__, __LINE__,
             provider_response->args.app_info);
@@ -1139,7 +1245,7 @@ static int em_handle_disassoc_device(wifi_app_t *app, void *arg)
     wifi_platform_property_t *wifi_prop = &wifi_mgr->hal_cap.wifi_prop;
     int arr_vap_index = -1;
     wifi_vap_info_t *vap_info = NULL;
-    wifi_associated_dev3_t *stats = NULL;
+    wifi_associated_dev3_timestamp_t *stats = NULL;
 
     wifi_util_dbg_print(WIFI_EM, "%s:%d : Sta disassoc event \n", __func__, __LINE__);
 
@@ -1176,7 +1282,7 @@ static int em_handle_disassoc_device(wifi_app_t *app, void *arg)
     to_mac_str(vap_info->u.bss_info.bssid, bss_str);
     to_mac_str(assoc_data->dev_stats.cli_MACAddress, sta_mac_str);
     snprintf(key, 64, "%s@%s", bss_str, sta_mac_str);
-    stats = (wifi_associated_dev3_t *)hash_map_remove(
+    stats = (wifi_associated_dev3_timestamp_t *)hash_map_remove(
         em_ap_metrics_report_cache.radio_report[radio_index].ap_data[arr_vap_index].client_stats_map, key);
     if (stats == NULL) {
         wifi_util_error_print(WIFI_EM, "%s:%d: Sta Mac %s not present in hash map\n", __func__,
@@ -1347,7 +1453,7 @@ static int ap_report_push_cb(em_ap_report_callback_arg_t *args)
     webconfig_subdoc_data_t *data = NULL;
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     em_vap_metrics_t *vap_report = NULL;
-    wifi_associated_dev3_t *stats = NULL;
+    wifi_associated_dev3_timestamp_t *stats = NULL;
     mac_addr_str_t bss_str, bss_str1;
     em_ap_metrics_report_t *ap_metrics_report = NULL;
     ap_metrics_t *ap_metrics = NULL;
@@ -1627,6 +1733,13 @@ int ap_metrics_collector_config(wifi_app_t *app, wifi_monitor_data_t *data,
     int radio_index = -1;
     int radio_count = -1;
     unsigned int i = 0;
+    unsigned int vapArrayIndex = 0;
+    wifi_mgr_t *wifi_mgr = get_wifimgr_obj();
+
+    if (wifi_mgr == NULL) {
+        wifi_util_error_print(WIFI_EM, "%s:%d: wifi_mgr is NULL\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
 
     em_route(&route);
 
@@ -1652,12 +1765,33 @@ int ap_metrics_collector_config(wifi_app_t *app, wifi_monitor_data_t *data,
         data[i].u.mon_stats_config.data_type = mon_stats_type_radio_channel_stats;
         data[i].u.mon_stats_config.args.radio_index = radio_index;
         data[i].u.mon_stats_config.args.app_info = em_app_event_type_ap_metrics_rad_chan_stats;
-        data[i].u.mon_stats_config.args.scan_mode = WIFI_RADIO_SCAN_MODE_ONCHAN;
+        data[i].u.mon_stats_config.args.scan_mode = WIFI_RADIO_SCAN_MODE_NONE;
         data[i].u.mon_stats_config.interval_ms =
             em_config->ap_metric_policy.interval * 1000;
         data->u.mon_stats_config.start_immediately = true;
-
         push_event_to_monitor_queue(data + i, wifi_event_monitor_data_collection_config, &route);
+
+        data[i].u.mon_stats_config.data_type = mon_stats_type_vap_stats;
+        data[i].u.mon_stats_config.args.radio_index = radio_index;
+        data[i].u.mon_stats_config.args.app_info = em_app_event_type_vap_stats_periodic;
+        data[i].u.mon_stats_config.interval_ms =
+            em_config->ap_metric_policy.interval * 1000;
+        data->u.mon_stats_config.start_immediately = true;
+        // for each vap push the event to monitor queue
+        // for extended metrics
+        for (vapArrayIndex = 0;
+             vapArrayIndex < getNumberVAPsPerRadio(radio_index);
+             vapArrayIndex++) {
+            data[i].u.mon_stats_config.args.vap_index =
+                wifi_mgr->radio_config[data[i].u.mon_stats_config.args.radio_index]
+                    .vaps.rdk_vap_array[vapArrayIndex]
+                    .vap_index;
+            push_event_to_monitor_queue(data + i, wifi_event_monitor_data_collection_config, &route);
+            wifi_util_dbg_print(WIFI_EM, "%s:%d:configuring mon_stats_type_vap_stats radio=%d vap=%d app_info=%d\n",
+                __func__, __LINE__, data[i].u.mon_stats_config.args.radio_index,
+                data[i].u.mon_stats_config.args.vap_index,
+                data[i].u.mon_stats_config.args.app_info);
+        }
 
         if (em_config->ap_metric_policy.interval == 0 ||
             em_ap_metrics_report_cache.args.sched_id == 0) {

--- a/source/apps/em/wifi_em.h
+++ b/source/apps/em/wifi_em.h
@@ -76,6 +76,7 @@ typedef enum {
     em_app_event_type_neighbor_stats,
     em_app_event_type_ap_metrics_rad_chan_stats,
     em_app_event_type_assoc_dev_stats_periodic,
+    em_app_event_type_vap_stats_periodic,
 
     em_app_event_type_max
 } em_app_event_type_t;

--- a/source/core/Makefile.am
+++ b/source/core/Makefile.am
@@ -99,7 +99,7 @@ OneWifi_SOURCES += $(top_srcdir)/source/core/services/vap_svc.c  $(top_srcdir)/s
 OneWifi_SOURCES += $(top_srcdir)/source/core/services/vap_svc_mesh_ext.c
 
 OneWifi_SOURCES += $(top_srcdir)/source/utils/jsonconv.c $(top_srcdir)/source/utils/collection.c $(top_srcdir)/source/utils/scheduler.c $(top_srcdir)/source/utils/caps.c
-OneWifi_SOURCES += $(top_srcdir)/source/stats/wifi_monitor.c $(top_srcdir)/source/utils/ext_blaster.pb-c.c $(top_srcdir)/source/stats/wifi_stats.c $(top_srcdir)/source/stats/wifi_stats_radio_channel.c $(top_srcdir)/source/stats/wifi_stats_neighbor_report.c $(top_srcdir)/source/stats/wifi_stats_radio_diagnostics.c $(top_srcdir)/source/stats/wifi_stats_assoc_client.c $(top_srcdir)/source/stats/wifi_stats_radio_temperature.c
+OneWifi_SOURCES += $(top_srcdir)/source/stats/wifi_monitor.c $(top_srcdir)/source/utils/ext_blaster.pb-c.c $(top_srcdir)/source/stats/wifi_stats.c $(top_srcdir)/source/stats/wifi_stats_radio_channel.c $(top_srcdir)/source/stats/wifi_stats_neighbor_report.c $(top_srcdir)/source/stats/wifi_stats_radio_diagnostics.c $(top_srcdir)/source/stats/wifi_stats_assoc_client.c $(top_srcdir)/source/stats/wifi_stats_radio_temperature.c $(top_srcdir)/source/stats/wifi_stats_vap.c
 
 OneWifi_SOURCES += $(top_srcdir)/source/stubs/wifi_stubs.c
 OneWifi_SOURCES += $(top_srcdir)/source/ccsp/ccsp.c

--- a/source/core/wifi_events.c
+++ b/source/core/wifi_events.c
@@ -492,6 +492,21 @@ wifi_event_t *create_wifi_monitor_response_event(const void *msg, unsigned int m
             }
         }
         break;
+    case mon_stats_type_vap_stats:
+        if (response->stat_array_size > 0) {
+            event->u.provider_response->stat_pointer = calloc(response->stat_array_size,
+                sizeof(vap_traffic_stats_t));
+            if (event->u.provider_response->stat_pointer == NULL) {
+                wifi_util_error_print(WIFI_CTRL, "%s %d response allocation failed for %d\n",
+                    __FUNCTION__, __LINE__, response->data_type);
+                free(event->u.provider_response);
+                event->u.provider_response = NULL;
+                free(event);
+                event = NULL;
+                return NULL;
+            }
+        }
+    break;
     default:
         wifi_util_error_print(WIFI_CTRL, "%s %d default response type : %d\n", __FUNCTION__,
             __LINE__, response->data_type);
@@ -657,6 +672,18 @@ int copy_msg_to_event(const void *data, unsigned int msg_len, wifi_event_type_t 
                 }
                 memcpy(event->u.provider_response->stat_pointer, response->stat_pointer,
                     (response->stat_array_size * sizeof(radio_data_t)));
+                break;
+            case mon_stats_type_vap_stats:
+                if ((event->u.provider_response->stat_pointer == NULL) ||
+                    (response->stat_pointer == NULL)) {
+                    wifi_util_error_print(WIFI_CTRL,
+                        "%s %d data_type %d stat_pointer is NULL : %p, %p\n", __FUNCTION__,
+                        __LINE__, response->data_type, event->u.provider_response->stat_pointer,
+                        response->stat_pointer);
+                    return RETURN_ERR;
+                }
+                memcpy(event->u.provider_response->stat_pointer, response->stat_pointer,
+                    (response->stat_array_size * sizeof(vap_traffic_stats_t)));
                 break;
             default:
                 wifi_util_error_print(WIFI_CTRL, "%s %d default response type : %d\n", __FUNCTION__,

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -4677,7 +4677,6 @@ int provider_execute_task(void *arg)
     return RETURN_OK;
 }
 
-
 int coordinator_create_collector_task(wifi_mon_collector_element_t *collector_elem)
 {
     wifi_monitor_t *mon_data = (wifi_monitor_t *)get_wifi_monitor();

--- a/source/stats/wifi_monitor.h
+++ b/source/stats/wifi_monitor.h
@@ -38,6 +38,15 @@ typedef struct {
 } ap_params_t;
 
 typedef struct {
+    ULONG ssid_UnicastBytesSent;
+    ULONG ssid_UnicastBytesReceived;
+    ULONG ssid_MulticastBytesSent;
+    ULONG ssid_MulticastBytesReceived;
+    ULONG ssid_BroadcastBytesSent;
+    ULONG ssid_BroadcastBytesReceived;
+} vap_traffic_stats_t;
+
+typedef struct {
     unsigned char bssid[32];
     hash_map_t *sta_map; //of type sta_data_t
     hash_map_t *interop_sta_map;
@@ -45,6 +54,7 @@ typedef struct {
     struct timespec last_sta_update_time;
     ap_params_t ap_params;
     ssid_t                  ssid;
+    vap_traffic_stats_t vap_traffic;
 } bssid_data_t;
 
 #define WPA2_PSK 2
@@ -373,5 +383,13 @@ int generate_radio_temperature_clctr_stats_key(wifi_mon_stats_args_t *args, char
 int generate_radio_temperature_provider_stats_key(wifi_mon_stats_config_t *config, char *key_str, size_t key_len);
 int execute_radio_temperature_stats_api(wifi_mon_collector_element_t *c_elem, wifi_monitor_t *mon_data, unsigned long task_interval_ms);
 int copy_radio_temperature_stats_from_cache(wifi_mon_provider_element_t *p_elem, void **stats, unsigned int *stat_array_size, wifi_monitor_t *mon_cache);
+
+/*Vap stats*/
+int validate_vap_args(wifi_mon_stats_args_t *args);
+int generate_vap_clctr_stats_key(wifi_mon_stats_args_t *args, char *key_str, size_t key_len);
+int generate_vap_provider_stats_key(wifi_mon_stats_config_t *config, char *key_str, size_t key_len);
+int execute_vap_stats_api(wifi_mon_collector_element_t *c_elem, wifi_monitor_t *mon_data,  unsigned long task_interval_ms);
+int copy_vap_stats_from_cache(wifi_mon_provider_element_t *p_elem, void **stats, unsigned int *stat_array_size, wifi_monitor_t *mon_cache);
+
 
 #endif	//_WIFI_MON_H_

--- a/source/stats/wifi_stats.c
+++ b/source/stats/wifi_stats.c
@@ -27,7 +27,7 @@
 #include "wifi_monitor.h"
 #include "wifi_util.h"
 
-#define WIFI_STATS_NUM 5
+#define WIFI_STATS_NUM 6
 
 wifi_mon_stats_descriptor_t g_stats_descriptor[WIFI_STATS_NUM] = {
     {
@@ -78,6 +78,16 @@ wifi_mon_stats_descriptor_t g_stats_descriptor[WIFI_STATS_NUM] = {
         generate_radio_temperature_provider_stats_key,
         execute_radio_temperature_stats_api,
         copy_radio_temperature_stats_from_cache,
+        NULL,
+        NULL
+    },
+    {
+        mon_stats_type_vap_stats,
+        validate_vap_args,
+        generate_vap_clctr_stats_key,
+        generate_vap_provider_stats_key,
+        execute_vap_stats_api,
+        copy_vap_stats_from_cache,
         NULL,
         NULL
     }

--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -381,6 +381,8 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
             sta->updated = true;
             sta->dev_stats.cli_Active = true;
             sta->dev_stats.cli_SignalStrength = hal_sta->cli_SignalStrength;
+            sta->timestamp.tv_sec = tv_now.tv_sec;
+            sta->timestamp.tv_nsec = tv_now.tv_nsec;
 
             if (timespeccmp(&(sta->last_connected_time),
                     &(mon_data->bssid_data[vap_array_index].last_sta_update_time),

--- a/source/stats/wifi_stats_radio_channel.c
+++ b/source/stats/wifi_stats_radio_channel.c
@@ -881,6 +881,18 @@ int execute_radio_channel_api(wifi_mon_collector_element_t *c_elem, wifi_monitor
         return RETURN_ERR;
     }
 
+
+    // Update Channel Stats cache
+    if (args->scan_mode == WIFI_RADIO_SCAN_MODE_NONE) {
+        ret = execute_radio_channel_stats_api(c_elem, mon_data);
+        if (ret != RETURN_OK) {
+            wifi_util_error_print(WIFI_MON,
+                "%s:%d execute_radio_channel_stats_api failed for radio: %d\n",
+                __func__, __LINE__, args->radio_index);
+        }
+        return ret;
+    }
+
     if (args->scan_mode == WIFI_RADIO_SCAN_MODE_ONCHAN) {
         if (get_on_channel_scan_list(radioOperation->band, radioOperation->channelWidth,
                 radioOperation->channel, channels, &num_channels) != 0) {

--- a/source/stats/wifi_stats_radio_diagnostics.c
+++ b/source/stats/wifi_stats_radio_diagnostics.c
@@ -134,7 +134,6 @@ int execute_radio_diagnostic_stats_api(wifi_mon_collector_element_t *c_elem, wif
     }
 
     memset(radioTrafficStats, 0, sizeof(wifi_radioTrafficStats2_t));
-
     if (radioOperation->enable == true) {
         ret = get_misc_descriptor()->wifi_getRadioTrafficStats2_fn(args->radio_index, radioTrafficStats);
         if (ret != RETURN_OK) {

--- a/source/stats/wifi_stats_vap.c
+++ b/source/stats/wifi_stats_vap.c
@@ -1,0 +1,172 @@
+/************************************************************************************
+  If not stated otherwise in this file or this component's LICENSE file the
+  following copyright and licenses apply:
+
+  Copyright 2018 RDK Management
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ **************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "wifi_monitor.h"
+#include "wifi_ctrl.h"
+#include "wifi_util.h"
+
+int validate_vap_args(wifi_mon_stats_args_t *args)  
+{
+    wifi_platform_property_t *wifi_prop = get_wifi_hal_cap_prop();
+    if (args == NULL) {
+        wifi_util_error_print(WIFI_MON, "%s:%d input arguments are NULL args : %p\n",__func__,__LINE__, args);
+        return RETURN_ERR;
+    }
+
+    if (args->vap_index >= wifi_prop->numRadios * MAX_NUM_VAP_PER_RADIO) {
+        wifi_util_error_print(WIFI_MON,"RDK_LOG_ERROR, %s Input apIndex = %d not found, Out of range\n", __FUNCTION__, args->vap_index);
+        return RETURN_ERR;
+    }
+
+    if (args->radio_index >= getNumberRadios()) {
+        wifi_util_error_print(WIFI_MON, "%s:%d invalid radio index : %d\n",__func__,__LINE__, args->radio_index);
+        return RETURN_ERR;
+    }
+
+    return RETURN_OK;
+}
+
+int generate_vap_clctr_stats_key(wifi_mon_stats_args_t *args, char *key_str, size_t key_len)  
+{  
+    if ((args == NULL) || (key_str == NULL)) {  
+        wifi_util_error_print(WIFI_MON, "%s:%d input arguments are NULL args : %p key = %p\n", __func__, __LINE__, args, key_str);  
+        return RETURN_ERR;  
+    }  
+    memset(key_str, 0, key_len);  
+    snprintf(key_str, key_len, "%02d-%02d", mon_stats_type_vap_stats, args->vap_index);  
+    wifi_util_dbg_print(WIFI_MON, "%s:%d collector stats key: %s\n", __func__, __LINE__, key_str);  
+    return RETURN_OK;  
+}
+
+int generate_vap_provider_stats_key(wifi_mon_stats_config_t *config, char *key_str, size_t key_len)  
+{  
+    if ((config == NULL) || (key_str == NULL)) {  
+        wifi_util_error_print(WIFI_MON, "%s:%d input arguments are NULL config : %p key = %p\n", __func__, __LINE__, config, key_str);  
+        return RETURN_ERR;  
+    }  
+    memset(key_str, 0, key_len);  
+    snprintf(key_str, key_len, "%04d-%02d-%02d-%08d", config->inst, mon_stats_type_vap_stats,  
+            config->args.vap_index, config->args.app_info);  
+    wifi_util_dbg_print(WIFI_MON, "%s:%d: provider stats key: %s\n", __func__, __LINE__, key_str);  
+    return RETURN_OK;  
+}
+
+
+int execute_vap_stats_api(wifi_mon_collector_element_t *c_elem, wifi_monitor_t *mon_data,  
+                          unsigned long task_interval_ms)  
+{  
+    wifi_mon_stats_args_t *args;  
+    vap_traffic_stats_t *vap_stats;
+    unsigned int vap_array_index;
+   
+    if ((c_elem == NULL) || (mon_data == NULL) || (c_elem->args == NULL)) {  
+        wifi_util_error_print(WIFI_MON, "%s:%d invalid arguments\n", __func__, __LINE__);  
+        return RETURN_ERR;  
+    }  
+    args = c_elem->args;  
+    vap_stats = (vap_traffic_stats_t *)calloc(1, sizeof(vap_traffic_stats_t));  
+    if (vap_stats == NULL) {  
+        wifi_util_error_print(WIFI_MON, "%s:%d calloc failed\n", __func__, __LINE__);
+        return RETURN_ERR;  
+    }
+
+    /*
+    if (wifi_getxxx(args->vap_index, vap_stats) != RETURN_OK) {  
+        wifi_util_error_print(WIFI_MON, "%s:%d wifi_getxxx failed for vap_index %d\n",  
+            __func__, __LINE__, args->vap_index);  
+        free(vap_stats);  
+        return RETURN_ERR;  
+    } */
+    getVAPArrayIndexFromVAPIndex(args->vap_index, &vap_array_index);
+
+    pthread_mutex_lock(&mon_data->data_lock);  
+    memcpy(&mon_data->bssid_data[vap_array_index].vap_traffic, vap_stats, sizeof(vap_traffic_stats_t));
+    pthread_mutex_unlock(&mon_data->data_lock);  
+  
+    if (c_elem->stats_clctr.is_event_subscribed == true &&  
+        (c_elem->stats_clctr.stats_type_subscribed & 1 << mon_stats_type_vap_stats)) {
+        vap_traffic_stats_t *copy = (vap_traffic_stats_t *)malloc(sizeof(vap_traffic_stats_t));  
+        if (copy == NULL) {  
+            wifi_util_error_print(WIFI_MON, "%s:%d malloc copy failed\n", __func__, __LINE__);  
+            free(vap_stats);  
+            return RETURN_ERR;  
+        }
+        memcpy(copy, vap_stats, sizeof(vap_traffic_stats_t));  
+  
+        wifi_provider_response_t *collect_stats = (wifi_provider_response_t *)malloc(sizeof(wifi_provider_response_t));  
+        if (collect_stats == NULL) {  
+            wifi_util_error_print(WIFI_MON, "%s:%d malloc response failed\n", __func__, __LINE__);  
+            free(copy);  
+            free(vap_stats);  
+            return RETURN_ERR;  
+        }  
+        collect_stats->data_type = mon_stats_type_vap_stats;  
+        collect_stats->args.vap_index = args->vap_index;
+        collect_stats->args.radio_index = args->radio_index;  
+        collect_stats->stat_pointer = copy;
+        collect_stats->stat_array_size = 1;  
+  
+        wifi_util_dbg_print(WIFI_MON, "%s:%d sending VAP stats for vap_index %d\n", __func__, __LINE__, args->vap_index);  
+        push_monitor_response_event_to_ctrl_queue(collect_stats, sizeof(wifi_provider_response_t),  
+            wifi_event_type_monitor, wifi_event_type_collect_stats, NULL);  
+        free(copy);  
+        free(collect_stats);
+    }
+
+    free(vap_stats);  
+    wifi_util_dbg_print(WIFI_MON, "%s:%d executed VAP stats for vap_index %d\n", __func__, __LINE__, args->vap_index);  
+    return RETURN_OK;  
+}
+
+int copy_vap_stats_from_cache(wifi_mon_provider_element_t *p_elem, void **stats,  
+                              unsigned int *stat_array_size, wifi_monitor_t *mon_cache)  
+{
+    vap_traffic_stats_t *out;
+    unsigned int vap_array_index;
+    if ((p_elem == NULL) || (mon_cache == NULL) || (p_elem->mon_stats_config == NULL)) {  
+        wifi_util_error_print(WIFI_MON, "%s:%d invalid arguments\n", __func__, __LINE__);  
+        return RETURN_ERR;  
+    }
+
+    wifi_util_dbg_print(WIFI_MON, "%s:%d copy_vap_stats_from_cache for vap index: %d\n", __func__, __LINE__, 
+    p_elem->mon_stats_config->args.vap_index);
+
+    pthread_mutex_lock(&mon_cache->data_lock);  
+    out = calloc(1, sizeof(vap_traffic_stats_t));  
+    if (out == NULL) {  
+        pthread_mutex_unlock(&mon_cache->data_lock);  
+        return RETURN_ERR;  
+    }
+
+    getVAPArrayIndexFromVAPIndex(p_elem->mon_stats_config->args.vap_index, &vap_array_index);
+    memcpy(out, &mon_cache->bssid_data[vap_array_index].vap_traffic, sizeof(vap_traffic_stats_t));
+    pthread_mutex_unlock(&mon_cache->data_lock);  
+
+    *stats = out;
+    *stat_array_size = 1;  
+    return RETURN_OK;
+}

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -6608,6 +6608,19 @@ webconfig_error_t decode_em_ap_metrics_report_object(const cJSON *em_ap_report_o
     wifi_util_dbg_print(WIFI_WEBCONFIG, "%s:%d: Radio Index: %d\n", __func__, __LINE__,
         radio_report->radio_index);
 
+    // Decode Radio Metrics
+    param_obj = cJSON_GetObjectItem(em_ap_report_obj, "Radio Metrics");
+    if (param_obj != NULL && cJSON_IsObject(param_obj)) {
+        decode_param_integer(param_obj, "Radio.Noise", value_object);
+        radio_report->radio_metrics.noise = value_object->valueint;
+        decode_param_integer(param_obj, "Radio.Transmit", value_object);
+        radio_report->radio_metrics.transmit = value_object->valueint;
+        decode_param_integer(param_obj, "Radio.ReceiveSelf", value_object);
+        radio_report->radio_metrics.receive_self = value_object->valueint;
+        decode_param_integer(param_obj, "Radio.ReceiveOther", value_object);
+        radio_report->radio_metrics.receive_other = value_object->valueint;
+    }
+
     // Decode Vap Info
     param_arr = cJSON_GetObjectItem(em_ap_report_obj, "Vap Info");
     if (param_arr == NULL || !cJSON_IsArray(param_arr)) {
@@ -6633,6 +6646,31 @@ webconfig_error_t decode_em_ap_metrics_report_object(const cJSON *em_ap_report_o
 
             decode_param_integer(param_obj, "Channel Util", value_object);
             radio_report->vap_reports[j].vap_metrics.channel_util = value_object->valueint;
+            decode_param_bool(param_obj, "Params BE", value_object);
+            radio_report->vap_reports[j].vap_metrics.inc_esp_ac_be = (value_object->type & cJSON_True) ? true:false;
+            decode_param_bool(param_obj, "Params BK", value_object);
+            radio_report->vap_reports[j].vap_metrics.inc_esp_ac_bk = (value_object->type & cJSON_True) ? true:false;
+            decode_param_bool(param_obj, "Params VI", value_object);
+            radio_report->vap_reports[j].vap_metrics.inc_esp_ac_vi = (value_object->type & cJSON_True) ? true:false;
+            decode_param_bool(param_obj, "Params VO", value_object);
+            radio_report->vap_reports[j].vap_metrics.inc_esp_ac_vo = (value_object->type & cJSON_True) ? true:false;
+
+            if(radio_report->vap_reports[j].vap_metrics.inc_esp_ac_be) {
+                decode_param_integer(param_obj, "AC BE", value_object);
+                radio_report->vap_reports[j].vap_metrics.esp_ac_be = value_object->valueint;
+            }
+            if(radio_report->vap_reports[j].vap_metrics.inc_esp_ac_bk) {
+                decode_param_integer(param_obj, "AC BK", value_object);
+                radio_report->vap_reports[j].vap_metrics.esp_ac_bk = value_object->valueint;
+            }
+            if(radio_report->vap_reports[j].vap_metrics.inc_esp_ac_vi) {
+                decode_param_integer(param_obj, "AC VI", value_object);
+                radio_report->vap_reports[j].vap_metrics.esp_ac_vi = value_object->valueint;
+            }
+            if(radio_report->vap_reports[j].vap_metrics.inc_esp_ac_vo) {
+                decode_param_integer(param_obj, "AC VO", value_object);
+                radio_report->vap_reports[j].vap_metrics.esp_ac_vo = value_object->valueint;
+            }
 
             decode_param_integer(param_obj, "Number of Associated STAs", value_object);
             radio_report->vap_reports[j].sta_cnt =
@@ -6649,7 +6687,19 @@ webconfig_error_t decode_em_ap_metrics_report_object(const cJSON *em_ap_report_o
             radio_report->vap_reports[j].vap_metrics.unicast_bytes_sent = value_object->valueint;
 
             decode_param_integer(param_obj, "BSS.UnicastBytesReceived", value_object);
-            radio_report->vap_reports[j].vap_metrics.unicast_bytes_sent = value_object->valueint;
+            radio_report->vap_reports[j].vap_metrics.unicast_bytes_rcvd = value_object->valueint;
+
+            decode_param_integer(param_obj, "BSS.MulticastBytesSent", value_object);
+            radio_report->vap_reports[j].vap_metrics.multicast_bytes_sent = value_object->valueint;
+
+            decode_param_integer(param_obj, "BSS.MulticastBytesReceived", value_object);
+            radio_report->vap_reports[j].vap_metrics.multicast_bytes_rcvd = value_object->valueint;
+
+            decode_param_integer(param_obj, "BSS.BroadcastBytesSent", value_object);
+            radio_report->vap_reports[j].vap_metrics.broadcast_bytes_sent = value_object->valueint;
+
+            decode_param_integer(param_obj, "BSS.BroadcastBytesReceived", value_object);
+            radio_report->vap_reports[j].vap_metrics.broadcast_bytes_rcvd = value_object->valueint;
         }
 
         radio_report->vap_reports[j].sta_traffic_stats = NULL;

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -1160,7 +1160,9 @@ webconfig_error_t translate_ap_metrics_report_to_easy_mesh_bss_info(webconfig_su
     em_vap_metrics_t *ap_metrics = NULL;
     em_radio_info_t *radio_info = NULL;
     em_sta_info_t *em_sta_dev_info = NULL;
+    radio_metrics_t *radio_metrics = NULL;
     mac_addr_str_t bss_str;
+    uint32_t v;
 
     wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: translate_ap_metrics_report_to_easy_mesh_bss_info enter\n", __func__, __LINE__);
     decoded_params = &data->u.decoded;
@@ -1189,14 +1191,36 @@ webconfig_error_t translate_ap_metrics_report_to_easy_mesh_bss_info(webconfig_su
 
     for (unsigned int i = 0; i < em_ap_report->radio_count; i++) {
         radio_index = decoded_params->em_ap_metrics_report.radio_reports[i].radio_index;
+        radio_metrics = &decoded_params->em_ap_metrics_report.radio_reports[i].radio_metrics;
+
         radio = &decoded_params->radios[radio_index];
         vap_map = &radio->vaps.vap_map;
+
+        radio_info = proto->get_radio_info(proto->data_model, radio_index);
+        if (radio_info) {
+            radio_info->noise =  radio_metrics->noise;
+            radio_info->transmit =  radio_metrics->transmit;
+            radio_info->receive_self =  radio_metrics->receive_self;
+            radio_info->receive_other =  radio_metrics->receive_other;
+        }
 
         for (j = 0; j < radio->vaps.num_vaps; j++) {
             //Get the corresponding vap
             vap = &vap_map->vap_array[j];
-            ap_metrics = &em_ap_report->radio_reports[i].vap_reports[j];
-            if ((vap->vap_mode != wifi_vap_mode_ap) || (strncmp(ap_metrics->vap_metrics.bssid, vap->u.bss_info.bssid, sizeof(bssid_t)) != 0)) {
+            if ((vap->vap_mode != wifi_vap_mode_ap) ) {
+                continue;
+            }
+
+            int found = 0;
+            for (int k = 0; k < MAX_NUM_VAP_PER_RADIO; k++) {
+                ap_metrics = &em_ap_report->radio_reports[i].vap_reports[k];
+                if (strncmp(ap_metrics->vap_metrics.bssid, vap->u.bss_info.bssid, sizeof(bssid_t)) == 0) {
+                    found = 1;
+                    break;
+                }
+            }
+            if (!found) {
+                wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d vap cannot found\n", __func__, __LINE__);
                 continue;
             }
 
@@ -1206,14 +1230,54 @@ webconfig_error_t translate_ap_metrics_report_to_easy_mesh_bss_info(webconfig_su
                 continue;
             }
             em_bss_info->numberofsta = ap_metrics->sta_cnt;
+            em_bss_info->channel_util = ap_metrics->vap_metrics.channel_util;
+
+            em_bss_info->unicast_bytes_sent = ap_metrics->vap_metrics.unicast_bytes_sent;
+            em_bss_info->unicast_bytes_rcvd = ap_metrics->vap_metrics.unicast_bytes_rcvd;
+            em_bss_info->multicast_bytes_sent = ap_metrics->vap_metrics.multicast_bytes_sent;
+            em_bss_info->multicast_bytes_rcvd = ap_metrics->vap_metrics.multicast_bytes_rcvd;
+            em_bss_info->broadcast_bytes_sent = ap_metrics->vap_metrics.broadcast_bytes_sent;
+            em_bss_info->broadcast_bytes_rcvd = ap_metrics->vap_metrics.broadcast_bytes_rcvd;
+
+            em_bss_info->inc_esp_ac_be = ap_metrics->vap_metrics.inc_esp_ac_be;
+            em_bss_info->inc_esp_ac_bk = ap_metrics->vap_metrics.inc_esp_ac_bk;
+            em_bss_info->inc_esp_ac_vo = ap_metrics->vap_metrics.inc_esp_ac_vo;
+            em_bss_info->inc_esp_ac_vi = ap_metrics->vap_metrics.inc_esp_ac_vi;
+
+            if(em_bss_info->inc_esp_ac_be) {
+                v = (uint32_t)ap_metrics->vap_metrics.esp_ac_be;
+                em_bss_info->est_svc_params_be[0] = (v >> 16) & 0xFF;
+                em_bss_info->est_svc_params_be[1] = (v >> 8)  & 0xFF;
+                em_bss_info->est_svc_params_be[2] =  v        & 0xFF;
+            }
+            if (em_bss_info->inc_esp_ac_bk) {
+                v = (uint32_t)ap_metrics->vap_metrics.esp_ac_bk;
+                em_bss_info->est_svc_params_bk[0] = (v >> 16) & 0xFF;
+                em_bss_info->est_svc_params_bk[1] = (v >> 8)  & 0xFF;
+                em_bss_info->est_svc_params_bk[2] =  v        & 0xFF;
+            }
+
+            if (em_bss_info->inc_esp_ac_vo) {
+                v = (uint32_t)ap_metrics->vap_metrics.esp_ac_vo;
+                em_bss_info->est_svc_params_vo[0] = (v >> 16) & 0xFF;
+                em_bss_info->est_svc_params_vo[1] = (v >> 8)  & 0xFF;
+                em_bss_info->est_svc_params_vo[2] =  v        & 0xFF;
+            }
+
+            if (em_bss_info->inc_esp_ac_vi) {
+                v = (uint32_t)ap_metrics->vap_metrics.esp_ac_vi;
+                em_bss_info->est_svc_params_vi[0] = (v >> 16) & 0xFF;
+                em_bss_info->est_svc_params_vi[1] = (v >> 8)  & 0xFF;
+                em_bss_info->est_svc_params_vi[2] =  v        & 0xFF;
+            }
+
+            if (radio_info == NULL) {
+                wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: Cannot find radio info for index %d\n", __func__, __LINE__, radio_index);
+                continue;
+            }
 
             per_sta_metrics_t *sta_stats = NULL;
             for (unsigned int count = 0; count < em_bss_info->numberofsta; count++) {
-                radio_info = proto->get_radio_info(proto->data_model, radio_index);
-                if (radio_info == NULL) {
-                    wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: Cannot find radio info for index %d\n", __func__, __LINE__, vap->vap_index);
-                    continue;
-                }
                 //wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Assoc Sta count %d\n", __func__, __LINE__, em_bss_info->numberofsta);
                 sta_stats = &ap_metrics->sta_link_metrics[count];
                 if (sta_stats == NULL) {
@@ -1228,6 +1292,7 @@ webconfig_error_t translate_ap_metrics_report_to_easy_mesh_bss_info(webconfig_su
                         snprintf(em_sta_dev_info->sta_client_type, sizeof(em_sta_dev_info->sta_client_type), "%s", sta_stats->client_type);
                         em_sta_dev_info->last_ul_rate             = sta_stats->assoc_sta_ext_link_metrics.assoc_sta_ext_link_metrics_data[0].last_data_uplink_rate;
                         em_sta_dev_info->last_dl_rate             = sta_stats->assoc_sta_ext_link_metrics.assoc_sta_ext_link_metrics_data[0].last_data_downlink_rate;
+                        em_sta_dev_info->delta_ms                 = sta_stats->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].time_delta;
                         em_sta_dev_info->est_ul_rate              = sta_stats->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].est_mac_rate_up;
                         em_sta_dev_info->est_dl_rate              = sta_stats->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].est_mac_rate_down;
                         em_sta_dev_info->rcpi                     = sta_stats->assoc_sta_link_metrics.assoc_sta_link_metrics_data[0].rcpi;
@@ -1243,7 +1308,7 @@ webconfig_error_t translate_ap_metrics_report_to_easy_mesh_bss_info(webconfig_su
                         em_sta_dev_info->bytes_rx                 = ap_metrics->sta_traffic_stats[count].bytes_rcvd;
                         em_sta_dev_info->errors_tx                = ap_metrics->sta_traffic_stats[count].tx_packtes_errs;
                         em_sta_dev_info->errors_rx                = ap_metrics->sta_traffic_stats[count].rx_packtes_errs;
-                        em_sta_dev_info->retrans_count            = ap_metrics->sta_traffic_stats[count].rx_packtes_errs;
+                        em_sta_dev_info->retrans_count            = ap_metrics->sta_traffic_stats[count].retrans_cnt;
                     }
                 }
             }

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -3437,6 +3437,11 @@ webconfig_error_t encode_em_ap_metrics_report_object(rdk_wifi_radio_t *radio,
             continue;
         }
 
+        if ((vap->vap_mode != wifi_vap_mode_ap)) {
+            continue;
+        }
+
+        vap_arr_index = -1;
         for (int k = 0; k < MAX_NUM_VAP_PER_RADIO; k++) {
             ap_metrics = &radio_report->vap_reports[k];
             if (strncmp(vap->u.bss_info.bssid, ap_metrics->vap_metrics.bssid,
@@ -3473,6 +3478,24 @@ webconfig_error_t encode_em_ap_metrics_report_object(rdk_wifi_radio_t *radio,
         cJSON_AddNumberToObject(temp_obj, "Number of Associated STAs",
             ap_metrics->vap_metrics.num_of_assoc_stas);
 
+        cJSON_AddBoolToObject(temp_obj, "Params BE", ap_metrics->vap_metrics.inc_esp_ac_be);
+        cJSON_AddBoolToObject(temp_obj, "Params BK", ap_metrics->vap_metrics.inc_esp_ac_bk);
+        cJSON_AddBoolToObject(temp_obj, "Params VI", ap_metrics->vap_metrics.inc_esp_ac_vi);
+        cJSON_AddBoolToObject(temp_obj, "Params VO", ap_metrics->vap_metrics.inc_esp_ac_vo);
+
+        if(ap_metrics->vap_metrics.inc_esp_ac_be) {
+            cJSON_AddNumberToObject(temp_obj, "AC BE", ap_metrics->vap_metrics.esp_ac_be);
+        }
+        if(ap_metrics->vap_metrics.inc_esp_ac_bk) {
+            cJSON_AddNumberToObject(temp_obj, "AC BK", ap_metrics->vap_metrics.esp_ac_bk);
+        }
+        if(ap_metrics->vap_metrics.inc_esp_ac_vi) {
+            cJSON_AddNumberToObject(temp_obj, "AC VI", ap_metrics->vap_metrics.esp_ac_vi);
+        }
+        if(ap_metrics->vap_metrics.inc_esp_ac_vo) {
+            cJSON_AddNumberToObject(temp_obj, "AC VO", ap_metrics->vap_metrics.esp_ac_vo);
+        }
+
         // Create AP Extended Metrics array
         temp_obj = cJSON_CreateObject();
         if ((temp_obj == NULL)) {
@@ -3485,7 +3508,14 @@ webconfig_error_t encode_em_ap_metrics_report_object(rdk_wifi_radio_t *radio,
             ap_metrics->vap_metrics.unicast_bytes_sent);
         cJSON_AddNumberToObject(temp_obj, "BSS.UnicastBytesReceived",
             ap_metrics->vap_metrics.unicast_bytes_rcvd);
-
+        cJSON_AddNumberToObject(temp_obj, "BSS.MulticastBytesSent",
+            ap_metrics->vap_metrics.multicast_bytes_sent);
+        cJSON_AddNumberToObject(temp_obj, "BSS.MulticastBytesReceived",
+            ap_metrics->vap_metrics.multicast_bytes_rcvd);
+        cJSON_AddNumberToObject(temp_obj, "BSS.BroadcastBytesSent",
+            ap_metrics->vap_metrics.broadcast_bytes_sent);
+        cJSON_AddNumberToObject(temp_obj, "BSS.BroadcastBytesReceived",
+            ap_metrics->vap_metrics.broadcast_bytes_rcvd);
         // check sta link metrics and traffic stats
         if (ap_metrics->is_sta_traffic_stats_enabled == true) {
             encode_em_sta_traffic_stats_object(ap_metrics->sta_cnt,

--- a/source/webconfig/wifi_webconfig_em_ap_metrics_report.c
+++ b/source/webconfig/wifi_webconfig_em_ap_metrics_report.c
@@ -191,6 +191,7 @@ webconfig_error_t decode_em_ap_metrics_report_subdoc(webconfig_t *config, webcon
             return webconfig_error_decode;
         }
     }
+    params->em_ap_metrics_report.radio_count = i;
 
     return webconfig_error_none;
 }


### PR DESCRIPTION
New Features
- Add mon_stats_type_vap_stats pipeline: vap_traffic_stats_t struct, wifi_stats_vap.c collector, per-VAP monitor task configuration
- Add wifi_associated_dev3_timestamp_t wrapper to track per-STA measurement time; compute time_delta using CLOCK_MONOTONIC
- Add em_app_event_type_vap_stats_periodic event type

Radio & BSS Metrics
- Fix receive_other to use ch_utilization_busy_ext instead of 0
- Change channel stats scan_mode ONCHAN→NONE; add early-return path
- Add ESP AC BE/BK/VI/VO encoding/decoding and 24-bit unpack into em_bss_info byte arrays
- Add multicast/broadcast byte counters to AP metrics encoder/decoder
- Fix VAP lookup in translator to use BSSID matching; skip non-AP VAPs
- Propagate radio metrics (noise/transmit/receive_self/receive_other) into em_radio_info via translator

Bug Fixes
- Fix unicast_bytes_rcvd overwritten with unicast_bytes_sent in decoder
- Fix retrans_count mapped to rx_packtes_errs instead of retrans_cnt
- Fix em_ap_metrics_report.radio_count not set after subdoc decode
- Add missing return RETURN_OK in prepare_sta_traffic_stats_data()
- Change assoc_sta_traffic_stats_t and assoc_sta_link_metrics_data_t fields from int to ULONG/unsigned int

Known Limitations
- VAP traffic stats return zero values HAL API integration pending