### PR TITLE
RDKB-64317: Removal of debug messages in LinkQuality

### DIFF
--- a/source/apps/linkquality/wifi_linkquality.c
+++ b/source/apps/linkquality/wifi_linkquality.c
@@ -456,7 +456,6 @@ int exec_event_link_quality(wifi_app_t *apps, wifi_event_subtype_t sub_type, voi
 
 int exec_event_webconfig_event(wifi_app_t *apps, wifi_event_t *event)
 {
-    wifi_util_info_print(WIFI_APPS,"Enter %s:%d\n",__func__,__LINE__);
     switch (event->sub_type) {
         case wifi_event_exec_start:
             break;
@@ -476,7 +475,6 @@ int exec_event_webconfig_event(wifi_app_t *apps, wifi_event_t *event)
 }
 int exec_event_hal_ind(wifi_app_t *apps, wifi_event_subtype_t sub_type, void *arg, int len)
 {
-    wifi_util_info_print(WIFI_APPS,"Enter %s:%d\n",__func__,__LINE__);
     switch (sub_type) {
         case wifi_event_exec_start:
             break;

--- a/source/utils/quality_mgr/src/linkq.cpp
+++ b/source/utils/quality_mgr/src/linkq.cpp
@@ -69,7 +69,6 @@ static inline double apply_recovery(double norm,int remaining,
     double factor = 1.0;
     if (total <= 0 || remaining <= 0)
         return norm;
-    wifi_util_dbg_print(WIFI_APPS,"%s:%d,remaining=%d total=%d\n",__func__,__LINE__,remaining,total);
 
     double progress = (double)(total - remaining) / (double)total;
 


### PR DESCRIPTION
Reason for change: Removal of debug messages in LinkQuality
Test Procedure: Build and verified
Risks: Low