### PR TITLE
RDKB-63321: RPI build to apply hostap telemetry enhancement patch

### DIFF
--- a/build/linux/rpi/makefile
+++ b/build/linux/rpi/makefile
@@ -420,6 +420,7 @@ ifdef EM_APP
                 $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_em_ap_metrics_report.c
 endif
 	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_link_report.c
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_ignite.c
 
 COBJECTS = $(CSOURCES:.c=.o)  # expands to list of object files
 

--- a/build/linux/rpi/setup.sh
+++ b/build/linux/rpi/setup.sh
@@ -45,6 +45,9 @@ patch_filenames="hostap-patches/0001-OneWifi-related-hostap-patch-for-2.10-based
 echo "Applying patches ..."
 git am $patch_filenames
 
+#Apply additional patches
+patch -p3 --no-backup-if-mismatch < hostap-patches/xfi-tel-complete_2_10.patch
+
 #Delete the hostap-patches directory after applying
 rm -rf hostap-patches
 

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -1227,7 +1227,6 @@ typedef struct {
     float link_quality_threshold;
 } alarm_report_policy_t;
 
-
 typedef struct {
     int interval;
     marker_name managed_client_marker;
@@ -1266,6 +1265,7 @@ typedef struct {
 } radio_metrics_policies_t;
 
 typedef struct {
+    alarm_report_policy_t alarm_report_policy;
     ap_metrics_policy_t ap_metric_policy;
     steering_disallowed_policy_t local_steering_dslw_policy;
     steering_disallowed_policy_t btm_steering_dslw_policy;


### PR DESCRIPTION
Reason for change: rdk-wifi-hal recent changes require this patch to be applied for compilation. Adding this patch for 2.10 compilation

This change is required to resolve the RPI build error. Dependent change to merge before this - rdkcentral/hostap-patches#17