### PR TITLE
RDKBACCL-1611: [TDK][AUTO][BPI][DML]Device.WiFi.Radio.<i>.X_CISCO_COM_TxRate value is empty

### DIFF
--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -1822,6 +1822,7 @@ void update_dml_radio_default() {
         radio_cfg[i].DCSSupported = TRUE;
         radio_cfg[i].ExtensionChannel = 3;
         radio_cfg[i].BasicRate = WIFI_BITRATE_DEFAULT;
+        radio_cfg[i].TxRate = WIFI_TXRATE_Auto;
         radio_cfg[i].ThresholdRange = 100;
         radio_cfg[i].ThresholdInUse = -99;
         radio_cfg[i].ReverseDirectionGrant = 0;

--- a/source/dml/dml_webconfig/dml_onewifi_api.h
+++ b/source/dml/dml_webconfig/dml_onewifi_api.h
@@ -29,6 +29,21 @@ extern "C" {
 
 #define WIFI_XHS_LNF_FLAG_FILE_NAME "/nvram/.bcmwifi_xhs_lnf_enabled"
 
+typedef  enum
+_WIFI_TXRATE
+{
+    WIFI_TXRATE_Auto               = 1,
+    WIFI_TXRATE_6M,
+    WIFI_TXRATE_9M,
+    WIFI_TXRATE_12M,
+    WIFI_TXRATE_18M,
+    WIFI_TXRATE_24M,
+    WIFI_TXRATE_36M,
+    WIFI_TXRATE_48M,
+    WIFI_TXRATE_54M
+}
+WIFI_TXRATE, *PWIFI_TXRATE;
+
 typedef struct {
     void    *acl_vap_context;
     queue_t* new_entry_queue[MAX_NUM_RADIOS][MAX_NUM_VAP_PER_RADIO];
@@ -107,6 +122,7 @@ typedef struct {
     INT     MulticastRate;
     INT     MCS;
     ULONG   DFSTimer;
+    WIFI_TXRATE   TxRate;
 } dml_radio_default;
 
 typedef struct {

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -2500,7 +2500,7 @@ Radio_GetParamUlongValue
     if( AnscEqualString(ParamName, "X_CISCO_COM_TxRate", TRUE))
     {
         /* collect value */
-        *puLong = pcfg->transmitPower;
+        *puLong = rcfg->TxRate;
         return TRUE;
     }
 


### PR DESCRIPTION
Reason for Change: Parameter is defined as string, but implementation returns integer(transmitPower), resulting in an empty value.
Test Procedure: Run "dmcli eRT getv Device.WiFi.Radio.<i>.X_CISCO_COM_TxRate" and verify it's value should be non-empty
Risks: Low