### PR TITLE
DTMESH-760: OneWiFi error logging "Failed to get AP Associated Device…

### DIFF
--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3692,8 +3692,15 @@ static void process_monitor_init_command(void)
         //for each vap push the event to monitor queue
         for (vapArrayIndex = 0; vapArrayIndex < getNumberVAPsPerRadio(radio_index); vapArrayIndex++) {
             data->u.mon_stats_config.args.vap_index = wifi_mgr->radio_config[radio_index].vaps.rdk_vap_array[vapArrayIndex].vap_index;
+#if defined(_GREXT02ACTS_PRODUCT_REQ_)
+            if (!isVapSTAMesh(data->u.mon_stats_config.args.vap_index)) {
+                wifi_util_dbg_print(WIFI_CTRL, "%s:%d pushing the event to collect client diag on vap %d\n", __func__, __LINE__, data->u.mon_stats_config.args.vap_index);    
+                push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
+            }
+#else
             wifi_util_dbg_print(WIFI_CTRL, "%s:%d pushing the event to collect client diag on vap %d\n", __func__, __LINE__, data->u.mon_stats_config.args.vap_index);
             push_event_to_monitor_queue(data, wifi_event_monitor_data_collection_config, &route);
+#endif
         }
     }
     free(data);

--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -59,7 +59,12 @@ int validate_assoc_client_args(wifi_mon_stats_args_t *args)
         wifi_util_error_print(WIFI_MON,"RDK_LOG_ERROR, %s Input apIndex = %d not found, Out of range\n", __FUNCTION__, args->vap_index);
         return RETURN_ERR;
     }
-
+#if defined(_GREXT02ACTS_PRODUCT_REQ_)
+    if (isVapSTAMesh(args->vap_index)) {
+        wifi_util_error_print(WIFI_MON, "%s:%d input vap_index %d is STA mesh interface\n",__func__,__LINE__, args->vap_index);
+        return RETURN_ERR;
+    }
+#endif
     return RETURN_OK;
 }
 


### PR DESCRIPTION
…s statistics (#915)

DTMESH-760: OneWiFi error logging "Failed to get AP Associated Devices statistics"

Reason for change: we don't need to collect ClientsList for STA vap Test Procedure:
Risks: Medium
Priority: P1

* Revert "DTMESH-760: OneWiFi error logging "Failed to get AP Associated Devices statistics""

This reverts commit 2172ed3f93eb43245e50c2a5fa06a1df74bf9003.

* Revert "BCOMB-3289 wifi_getApAssociatedDeviceDiagnosticResult3 failed for station vaps (#836)"

This reverts commit b8ef64a9af45ab0fad239167e9b75f00cfa7a52e.

* DTMESH-760: Enable STA check on _GREXT02ACTS_PRODUCT_REQ_ product

Reason for change:
Test Procedure:
Risks: Medium
Priority: P1



---------