### PR TITLE
RDKB-63382: [MLO] Implement standard TR-181 DM for MLO (#1021)

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -1907,6 +1907,12 @@ INSTMSMT_PH2 -->
                     </functions>
                     <parameters>
                         <parameter>
+                            <name>MLDUnit</name>
+                            <type>int[-1:24]</type>
+                            <syntax>int</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
                             <name>Enable</name>
                             <type>boolean</type>
                             <syntax>bool</syntax>

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -5397,10 +5397,28 @@ SSID_GetParamIntValue
     )
 {
     /* check the parameter name and return the corresponding value */
-    UNREFERENCED_PARAMETER(hInsContext);
-    UNREFERENCED_PARAMETER(ParamName);
-    UNREFERENCED_PARAMETER(pInt);
+    wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
 
+    if (pcfg == NULL)
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Null pointer get fail\n", __FUNCTION__,__LINE__);
+        return FALSE;
+    }
+
+    if( AnscEqualString(ParamName, "MLDUnit", TRUE))
+    {
+        if (isVapSTAMesh(pcfg->vap_index)) {
+            wifi_util_dbg_print(WIFI_DMCLI,"%s:%d VAP %d is sta\n", __FUNCTION__,__LINE__, pcfg->vap_index);
+            *pInt = -1;
+            return TRUE;
+        }
+        if (pcfg->u.bss_info.mld_info.common_info.mld_enable == FALSE) {
+            *pInt = -1;
+        } else {
+            *pInt = pcfg->u.bss_info.mld_info.common_info.mld_id;
+        }
+        return TRUE;
+    }
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
     return FALSE;
 }
@@ -5894,8 +5912,53 @@ SSID_SetParamIntValue
         int                         iValue
     )
 {
-    /* check the parameter name and set the corresponding value */
+    wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
 
+    if (pcfg == NULL)
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Null pointer get fail\n", __FUNCTION__,__LINE__);
+        return FALSE;
+    }
+
+    uint8_t instance_number = (uint8_t)convert_vap_name_to_index(&((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop, pcfg->vap_name) +1;
+    wifi_vap_info_t *vapInfo = (wifi_vap_info_t *) get_dml_cache_vap_info(instance_number-1);
+
+    if (vapInfo == NULL)
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Unable to get VAP info for instance_number:%d\n", __FUNCTION__,__LINE__,instance_number);
+        return FALSE;
+    }
+    /* check the parameter name and set the corresponding value */
+    if( AnscEqualString(ParamName, "MLDUnit", TRUE))
+    {
+        BOOL tmp_mld_enable = FALSE;
+
+        if (isVapSTAMesh(pcfg->vap_index)) {
+            wifi_util_error_print(WIFI_DMCLI,"%s:%d VAP is sta VAP\n", __FUNCTION__, __LINE__);
+            return FALSE;
+        }
+        if (iValue < -1 || iValue >= MLD_UNIT_COUNT) {
+            wifi_util_error_print(WIFI_DMCLI,"%s:%d Invalid MLDUnit value %d\n", __FUNCTION__,__LINE__,iValue);
+            return FALSE;
+        }
+        wifi_util_info_print(WIFI_DMCLI,"%s:%d MLD Unit %d\n", __FUNCTION__, __LINE__, iValue);
+        tmp_mld_enable = (iValue == -1) ? FALSE : TRUE;
+        if (vapInfo->u.bss_info.mld_info.common_info.mld_enable == tmp_mld_enable) {
+            if (!tmp_mld_enable && vapInfo->u.bss_info.mld_info.common_info.mld_id == UNDEFINED_MLD_ID)
+                return TRUE;
+            if (tmp_mld_enable && vapInfo->u.bss_info.mld_info.common_info.mld_id == (UINT)iValue)
+                return TRUE;
+        }
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Updating MLD Unit to value %d\n", __FUNCTION__, __LINE__, iValue);
+        vapInfo->u.bss_info.mld_info.common_info.mld_enable = tmp_mld_enable;
+        if (vapInfo->u.bss_info.mld_info.common_info.mld_enable)
+            vapInfo->u.bss_info.mld_info.common_info.mld_id = iValue;
+        else
+            vapInfo->u.bss_info.mld_info.common_info.mld_id = UNDEFINED_MLD_ID;
+
+        set_dml_cache_vap_config_changed(instance_number - 1);
+        return TRUE;
+    }
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
     return FALSE;
 }


### PR DESCRIPTION
Reason for change: ImplementTR-181 standard DataModel for MLO configuration: Device.WiFi.SSID.{i}.MLDUnit

Test Procedure: Configure MLO via TR-181 DataModel Device.WiFi.SSID.{i}.MLDUnit,
	verify the MLO configuration in driver,
	verify MLO Wifi connectivity of clients

Risks: Low
Priority: P1