### PR TITLE
RDKB-62466: Fix bitrate values for 80211be

### DIFF
--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -1854,12 +1854,13 @@ void update_dml_radio_default() {
         radio_cfg[i].MCS = 0;
         radio_cfg[i].DFSTimer = 30;
         if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_2_4_BAND) {
-            radio_cfg[i].MaxBitRate = 1147;
             strncpy(radio_cfg[i].ChannelsInUse,"1",sizeof(radio_cfg[i].ChannelsInUse)-1);
 #ifdef CONFIG_IEEE80211BE
             strncpy(radio_cfg[i].SupportedStandards,"g,n,ax,be",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 1377;
 #else
             strncpy(radio_cfg[i].SupportedStandards,"g,n,ax",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 1147;
 #endif /* CONFIG_IEEE80211BE */
 
 #if defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
@@ -1868,12 +1869,13 @@ void update_dml_radio_default() {
             radio_cfg[i].AmsduTid[0] = 1;
 #endif
         } else if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_5_BAND) {
-            radio_cfg[i].MaxBitRate = 4804;
             strncpy(radio_cfg[i].ChannelsInUse,"44",sizeof(radio_cfg[i].ChannelsInUse)-1);
 #ifdef CONFIG_IEEE80211BE
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax,be",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 5765;
 #else
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 4804;
 #endif /* CONFIG_IEEE80211BE */
 #if defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
             memset(radio_cfg[i].AmsduTid, 1, sizeof(BOOL) * 4);
@@ -1881,12 +1883,13 @@ void update_dml_radio_default() {
             radio_cfg[i].AmsduTid[0] = 1;
 #endif
         } else if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_5L_BAND) {
-            radio_cfg[i].MaxBitRate = 4804;
             strncpy(radio_cfg[i].ChannelsInUse,"44",sizeof(radio_cfg[i].ChannelsInUse)-1);
 #ifdef CONFIG_IEEE80211BE
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax,be",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 5765;
 #else
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 4804;
 #endif /* CONFIG_IEEE80211BE */
 #if defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
             memset(radio_cfg[i].AmsduTid, 1, sizeof(BOOL) * 4);
@@ -1894,12 +1897,13 @@ void update_dml_radio_default() {
             radio_cfg[i].AmsduTid[0] = 1;
 #endif
         } else if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_5H_BAND) {
-            radio_cfg[i].MaxBitRate = 4804;
             strncpy(radio_cfg[i].ChannelsInUse,"149",sizeof(radio_cfg[i].ChannelsInUse)-1);
 #ifdef CONFIG_IEEE80211BE
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax,be",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 5765;
 #else
             strncpy(radio_cfg[i].SupportedStandards,"a,n,ac,ax",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 4804;
 #endif /* CONFIG_IEEE80211BE */
 #if defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
             memset(radio_cfg[i].AmsduTid, 1, sizeof(BOOL) * 4);
@@ -1907,13 +1911,13 @@ void update_dml_radio_default() {
             radio_cfg[i].AmsduTid[0] = 1;
 #endif
         } else if (radio_cfg[i].SupportedFrequencyBands == WIFI_FREQUENCY_6_BAND) {
-            radio_cfg[i].MaxBitRate = 9608;
             strncpy(radio_cfg[i].ChannelsInUse,"181",sizeof(radio_cfg[i].ChannelsInUse)-1);
 #ifdef CONFIG_IEEE80211BE
             strncpy(radio_cfg[i].SupportedStandards,"ax,be",sizeof(radio_cfg[i].SupportedStandards)-1);
-            radio_cfg[i].MaxBitRate = 9608; //TODO: what is the rate for 11be? where it's using?
+            radio_cfg[i].MaxBitRate = 11529;
 #else
             strncpy(radio_cfg[i].SupportedStandards,"ax",sizeof(radio_cfg[i].SupportedStandards)-1);
+            radio_cfg[i].MaxBitRate = 9608;
 #endif /* CONFIG_IEEE80211BE */
 #if defined(_XB10_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
             memset(radio_cfg[i].AmsduTid, (BOOL)1, sizeof(BOOL) * 5);


### PR DESCRIPTION
Reson for change: Align values with the MSC tables ones.

Test Procedure: verify new values with these commands:
- dmcli eRT getv Device.WiFi.Radio.1.MaxBitRate
- dmcli eRT getv Device.WiFi.Radio.2.MaxBitRate
- dmcli eRT getv Device.WiFi.Radio.3.MaxBitRate

Risks: None

Priority: P1

Signed-off-by: Pavlo Uvarov <Pavlo_Uvarov@comcast.com>