### PR TITLE
DTMESH-808: Set encryption mode while translating OVSDB to VAP config

### DIFF
--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -2026,24 +2026,33 @@ typedef struct {
     const char keys[16][MAX_SEC_LEN];
     int len;
     wifi_security_modes_t mode;
+    wifi_encryption_method_t encryption;
 } security_mapping_table_t;
 
 static const security_mapping_table_t security_map[] = {
-    { .keys = { "wpa-psk" },        .len = 1, .mode = wifi_security_mode_wpa_personal },
-    { .keys = { "wpa2-psk" },       .len = 1, .mode = wifi_security_mode_wpa2_personal },
-    { .keys = { "wpa2-eap" },       .len = 1, .mode = wifi_security_mode_wpa2_enterprise },
-    { .keys = { "sae" },            .len = 1, .mode = wifi_security_mode_wpa3_personal },
-    { .keys = { "aes" },            .len = 1, .mode = wifi_security_mode_wpa3_enterprise },
-    { .keys = { "enhanced-open" },  .len = 1, .mode = wifi_security_mode_enhanced_open },
-    { .keys = { "wpa-eap" },        .len = 1, .mode = wifi_security_mode_wpa_enterprise },
-    { .keys = { "wpa-eap", "wpa2-eap" },    .len = 2, .mode = wifi_security_mode_wpa_wpa2_enterprise },
-    { .keys = { "wpa2-psk", "sae" },        .len = 2, .mode = wifi_security_mode_wpa3_transition },
-    { .keys = { "wpa-psk", "wpa2-psk" },    .len = 2, .mode = wifi_security_mode_wpa_wpa2_personal },
-    { .keys = { "wpa2-psk", "sae", "rsno" },    .len = 3, .mode = wifi_security_mode_wpa3_compatibility }
+    { .keys = { "wpa-psk" },                 .len = 1, .mode = wifi_security_mode_wpa_personal,         .encryption = wifi_encryption_tkip },
+    { .keys = { "wpa-eap" },                 .len = 1, .mode = wifi_security_mode_wpa_enterprise,       .encryption = wifi_encryption_tkip },
+    { .keys = { "wpa2-psk" },                .len = 1, .mode = wifi_security_mode_wpa2_personal,        .encryption = wifi_encryption_aes },
+    { .keys = { "wpa2-eap" },                .len = 1, .mode = wifi_security_mode_wpa2_enterprise,      .encryption = wifi_encryption_aes },
+#ifdef CONFIG_IEEE80211BE
+    { .keys = { "sae" },                     .len = 1, .mode = wifi_security_mode_wpa3_personal,        .encryption = wifi_encryption_aes_gcmp256 },
+    { .keys = { "aes" },                     .len = 1, .mode = wifi_security_mode_wpa3_enterprise,      .encryption = wifi_encryption_aes_gcmp256 },
+    { .keys = { "wpa2-psk", "sae" },         .len = 2, .mode = wifi_security_mode_wpa3_transition,      .encryption = wifi_encryption_aes_gcmp256 },
+    { .keys = { "wpa2-psk", "sae", "rsno" }, .len = 3, .mode = wifi_security_mode_wpa3_compatibility,   .encryption = wifi_encryption_aes_gcmp256 },
+    { .keys = { "enhanced-open" },           .len = 1, .mode = wifi_security_mode_enhanced_open,        .encryption = wifi_encryption_aes_gcmp256 },
+#else
+    { .keys = { "sae" },                     .len = 1, .mode = wifi_security_mode_wpa3_personal,        .encryption = wifi_encryption_aes },
+    { .keys = { "aes" },                     .len = 1, .mode = wifi_security_mode_wpa3_enterprise,      .encryption = wifi_encryption_aes },
+    { .keys = { "wpa2-psk", "sae" },         .len = 2, .mode = wifi_security_mode_wpa3_transition,      .encryption = wifi_encryption_aes },
+    { .keys = { "wpa2-psk", "sae", "rsno" }, .len = 3, .mode = wifi_security_mode_wpa3_compatibility,   .encryption = wifi_encryption_aes },
+    { .keys = { "enhanced-open" },           .len = 1, .mode = wifi_security_mode_enhanced_open,        .encryption = wifi_encryption_aes },
+#endif
+    { .keys = { "wpa-eap", "wpa2-eap" },     .len = 2, .mode = wifi_security_mode_wpa_wpa2_enterprise,  .encryption = wifi_encryption_aes_tkip },
+    { .keys = { "wpa-psk", "wpa2-psk" },     .len = 2, .mode = wifi_security_mode_wpa_wpa2_personal,    .encryption = wifi_encryption_aes_tkip }
 };
 
 int key_mgmt_conversion(wifi_security_modes_t *enum_sec, int *sec_len, unsigned int conv_type,
-    int wpa_key_mgmt_len, char (*wpa_key_mgmt)[MAX_SEC_LEN])
+    int wpa_key_mgmt_len, char (*wpa_key_mgmt)[MAX_SEC_LEN], wifi_encryption_method_t *enum_encr)
 {
     int i, j = 0;
     int num_key_found = 0;
@@ -2071,6 +2080,8 @@ int key_mgmt_conversion(wifi_security_modes_t *enum_sec, int *sec_len, unsigned 
             }
             if (num_key_found == wpa_key_mgmt_len) {
                 *enum_sec = security_map[i].mode;
+                if (enum_encr)
+                    *enum_encr = security_map[i].encryption;
                 return RETURN_OK;
             }
         }

--- a/source/utils/wifi_util.h
+++ b/source/utils/wifi_util.h
@@ -365,7 +365,7 @@ int key_mgmt_conversion_legacy(wifi_security_modes_t *mode_enum,
     wifi_encryption_method_t *encryp_enum, char *str_mode, int mode_len, char *str_encryp,
     int encryp_len, unsigned int conv_type);
 int key_mgmt_conversion(wifi_security_modes_t *enum_sec, int *sec_len, unsigned int conv_type,
-    int wpa_key_mgmt_len, char (*wpa_key_mgmt)[MAX_SEC_LEN]);
+    int wpa_key_mgmt_len, char (*wpa_key_mgmt)[MAX_SEC_LEN], wifi_encryption_method_t *enum_encr);
 int get_radio_if_hw_type(unsigned int radio_index, char *str, int str_len);
 char *to_mac_str(mac_address_t mac, mac_addr_str_t key);
 int is_ssid_name_valid(char *ssid_name);

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -1288,7 +1288,7 @@ webconfig_error_t translate_sta_info_to_em_common(const wifi_vap_info_t *vap, co
     enum_sec = vap->u.sta_info.security.mode;
     
 
-    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->fronthaul_akm)) != RETURN_OK) {
+    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->fronthaul_akm, NULL)) != RETURN_OK) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d failed to convert key mgmt: "
                 "security mode 0x%x\n", __func__, __LINE__, vap->u.sta_info.security.mode);
         return webconfig_error_translate_to_easymesh;
@@ -1345,7 +1345,7 @@ webconfig_error_t translate_private_vap_info_to_em_bss_config(wifi_vap_info_t *v
 
     // convert akm to its equivalent string
     enum_sec = vap->u.bss_info.security.mode;
-    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->fronthaul_akm)) != RETURN_OK) {
+    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->fronthaul_akm, NULL)) != RETURN_OK) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d failed to convert key mgmt: "
                 "security mode 0x%x\n", __func__, __LINE__, vap->u.bss_info.security.mode);
         return webconfig_error_translate_to_easymesh;
@@ -1444,7 +1444,7 @@ webconfig_error_t translate_mesh_backhaul_vap_info_to_em_bss_config(wifi_vap_inf
     vap_row->backhaul_use = true;
 
     enum_sec = vap->u.bss_info.security.mode;
-    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->backhaul_akm)) != RETURN_OK) {
+    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->backhaul_akm, NULL)) != RETURN_OK) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d failed to convert key mgmt: "
                 "security mode 0x%x\n", __func__, __LINE__, vap->u.bss_info.security.mode);
         return webconfig_error_translate_to_easymesh;

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -2139,7 +2139,7 @@ static webconfig_error_t translate_vap_info_to_ovsdb_sec_new(wifi_vap_info_t *va
     }
 
     enum_sec = vap->u.bss_info.security.mode;
-    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->wpa_key_mgmt)) != RETURN_OK) {
+    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->wpa_key_mgmt, NULL)) != RETURN_OK) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d failed to convert key mgmt: "
             "security mode 0x%x\n", __func__, __LINE__, vap->u.bss_info.security.mode);
         return webconfig_error_translate_to_ovsdb;
@@ -2467,7 +2467,7 @@ webconfig_error_t translate_sta_vap_info_to_ovsdb_config_personal_sec(const wifi
         } else {
             int len = 0, wpa_psk_index = 0;
             wifi_security_modes_t enum_sec = vap->u.sta_info.security.mode;
-            if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->wpa_key_mgmt)) != RETURN_OK) {
+            if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->wpa_key_mgmt, NULL)) != RETURN_OK) {
                 wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: key mgmt conversion failed. security mode 0x%x\n",
                     __func__, __LINE__, vap->u.sta_info.security.mode);
                 return webconfig_error_translate_to_ovsdb;
@@ -2927,7 +2927,7 @@ static webconfig_error_t translate_vap_info_to_vif_state_sec_new(wifi_vap_info_t
     }
 
     enum_sec = vap->u.bss_info.security.mode;
-    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->wpa_key_mgmt)) != RETURN_OK) {
+    if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->wpa_key_mgmt, NULL)) != RETURN_OK) {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d failed to convert key mgmt: "
             "security mode 0x%x\n", __func__, __LINE__, vap->u.bss_info.security.mode);
         return webconfig_error_translate_to_ovsdb;
@@ -3204,7 +3204,7 @@ webconfig_error_t translate_sta_vap_info_to_ovsdb_state_personal_sec(const wifi_
             int len = 0, wpa_psk_index = 0;
             wifi_security_modes_t enum_sec = vap->u.sta_info.security.mode;
 
-            if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->wpa_key_mgmt)) != RETURN_OK) {
+            if ((key_mgmt_conversion(&enum_sec, &len, ENUM_TO_STRING, 0, (char(*)[])vap_row->wpa_key_mgmt, NULL)) != RETURN_OK) {
                 wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: key mgmt conversion failed\n", __func__, __LINE__);
                 return webconfig_error_translate_to_ovsdb;
             }
@@ -3809,21 +3809,25 @@ static webconfig_error_t translate_ovsdb_to_vap_info_sec_new(const struct
 {
     int len = 0;
     wifi_security_modes_t enum_sec;
+    wifi_encryption_method_t enum_encr;
 
     if (vap_row->wpa == false) {
         vap->u.bss_info.security.mode = wifi_security_mode_none;
+        vap->u.bss_info.security.encr = wifi_encryption_none;
     } else {
         if (vap_row->wpa_key_mgmt_len == 0)  {
             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d wpa_key_mgmt_len is 0\n", __func__, __LINE__);
             return webconfig_error_translate_from_ovsdb;
         }
 
-        if ((key_mgmt_conversion(&enum_sec, &len, STRING_TO_ENUM, vap_row->wpa_key_mgmt_len, (char(*)[])vap_row->wpa_key_mgmt)) != RETURN_OK) {
+        if ((key_mgmt_conversion(&enum_sec, &len, STRING_TO_ENUM,
+            vap_row->wpa_key_mgmt_len, (char(*)[])vap_row->wpa_key_mgmt, &enum_encr)) != RETURN_OK) {
             wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d failed to convert key mgmt: %s\n",
                 __func__, __LINE__, vap_row->wpa_key_mgmt[0] ? vap_row->wpa_key_mgmt[0] : "NULL");
             return webconfig_error_translate_from_ovsdb;
         }
         vap->u.bss_info.security.mode = enum_sec;
+        vap->u.bss_info.security.encr = enum_encr;
     }
 
     get_translator_config_wpa_mfp(vap);
@@ -4225,21 +4229,25 @@ webconfig_error_t translate_ovsdb_config_to_vap_info_personal_sec(const struct s
     } else {
         if (vap_row->wpa == false) {
             vap->u.sta_info.security.mode = wifi_security_mode_none;
+            vap->u.bss_info.security.encr = wifi_encryption_none;
         } else {
             int len = 0;
             wifi_security_modes_t enum_sec;
+            wifi_encryption_method_t enum_encr;
 
             if (vap_row->wpa_key_mgmt_len == 0)  {
                 wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: wpa_key_mgmt_len is 0\n", __func__, __LINE__);
                 return webconfig_error_translate_from_ovsdb;
             }
 
-            if ((key_mgmt_conversion(&enum_sec, &len, STRING_TO_ENUM, vap_row->wpa_key_mgmt_len, (char(*)[])vap_row->wpa_key_mgmt)) != RETURN_OK) {
+            if ((key_mgmt_conversion(&enum_sec, &len, STRING_TO_ENUM, vap_row->wpa_key_mgmt_len,
+                    (char(*)[])vap_row->wpa_key_mgmt, &enum_encr)) != RETURN_OK) {
                 wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: key mgmt conversion failed. wpa_key_mgmt '%s'\n",
                     __func__, __LINE__, (vap_row->wpa_key_mgmt[0]) ? vap_row->wpa_key_mgmt[0]: "NULL");
                 return webconfig_error_translate_from_ovsdb;
             }
             vap->u.sta_info.security.mode = enum_sec;
+            vap->u.bss_info.security.encr = enum_encr;
 
             if (vap_row->wpa_psks_len == 0)  {
                 wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: wpa_psks_len is 0\n", __func__, __LINE__);


### PR DESCRIPTION
Reason for change:
Add support for setting wifi_encryption_method_t during key_mgmt_conversion() when translating OVSDB configuration to VAP structures. Previously, only security mode was derived, and encryption type (e.g., AES/TKIP) was not explicitly set, leading to private_ssid encoding error.

Test Procedure:
1. Power On device
2. Wait untill controller pushes configuration
3. Check home-ap-24, home-ap-50 (private_ssid) are applied

Risks: Low
Priority: P0