### PR TITLE
RDKB-64347: Fixing coverity issues

### DIFF
--- a/lib/ds/ds_tree.c
+++ b/lib/ds/ds_tree.c
@@ -114,8 +114,8 @@ static inline ds_tree_node_t *ds_bst_rotate(ds_tree_t *root, ds_tree_node_t *nod
     }
     else
     {
-        int dir = (node == save->otn_parent->otn_child[1]);
-        save->otn_parent->otn_child[dir] = save;
+        int pdir = (node == save->otn_parent->otn_child[1]);
+        save->otn_parent->otn_child[pdir] = save;
     }
 
     return save;

--- a/source/core/wifi_ctrl_wifiapi_handlers.c
+++ b/source/core/wifi_ctrl_wifiapi_handlers.c
@@ -55,7 +55,12 @@ struct hal_api_info {
     {"wifi_getApAssociatedDeviceDiagnosticResult3",   1, "<vap index>"},
 };
 
-
+static char* to_sta_key(uint8_t *mac_address, sta_key_t sta_key) {
+    snprintf(sta_key, STA_KEY_LEN, "%02x:%02x:%02x:%02x:%02x:%02x",
+             mac_address[0], mac_address[1], mac_address[2],
+             mac_address[3], mac_address[4], mac_address[5]);
+    return sta_key;
+}
 
 void wifiapi_printradioconfig(char *buff, unsigned int buff_size, wifi_radio_operationParam_t *radio_config)
 {
@@ -626,12 +631,6 @@ static void wifiapi_handle_get_ApAssocDeviceDiagnosticResult(char **args, unsign
         snprintf(result_buf, result_buf_size, "Error: dev_array is NULL\n");
         return;
     }
-		char* to_sta_key(uint8_t *mac_address, sta_key_t sta_key) {
-    snprintf(sta_key, STA_KEY_LEN, "%02x:%02x:%02x:%02x:%02x:%02x",
-             mac_address[0], mac_address[1], mac_address[2],
-             mac_address[3], mac_address[4], mac_address[5]);
-    return sta_key;
-}
       snprintf(result_buf, result_buf_size, "diag result: number of devs: %d\n", num_devs);
       for (unsigned int i = 0; i < num_devs; i++) {
               snprintf(result_buf, result_buf_size,


### PR DESCRIPTION
 
Reason for change: Fixing Low priority coverity issues.
Test Procedure: Build should be successful and the regression test should also succeed.
 
Risks: Low
Priority: P1
Signed-off-by: Velpula_Bharathi@comcast.com