### PR TITLE
RDKBWIFI-349: Easymesh - Enable MLO for all backhaul VAPs

### DIFF
--- a/config/openwrt/banana-pi/InterfaceMap.json
+++ b/config/openwrt/banana-pi/InterfaceMap.json
@@ -14,6 +14,21 @@
                             "vlanId": 0,
                             "vapIndex": 16,
                             "vapName": "private_ssid_6g"
+                        },
+                        {
+                            "InterfaceName": "wifi2.1",
+                            "MldName": "mld1",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 22,
+                            "vapName": "mesh_backhaul_6g"
+                        },
+                        {
+                            "InterfaceName": "wifi2.2",
+                            "Bridge": "br-lan",
+                            "vlanId": 0,
+                            "vapIndex": 17,
+                            "vapName": "iot_ssid_6g"
                         }
                     ]
                 },
@@ -31,6 +46,7 @@
                         },
                         {
                             "InterfaceName": "wifi1.1",
+                            "MldName": "mld1",
                             "Bridge": "br-lan",
                             "vlanId": 0,
                             "vapIndex": 13,
@@ -66,6 +82,7 @@
                         },
                         {
                             "InterfaceName": "wifi0.1",
+                            "MldName": "mld1",
                             "Bridge": "br-lan",
                             "vlanId": 0,
                             "vapIndex": 12,

--- a/config/openwrt/banana-pi/wifi_interface_down.sh
+++ b/config/openwrt/banana-pi/wifi_interface_down.sh
@@ -9,9 +9,10 @@ ifconfig wifi1.1 down
 ifconfig wifi1.2 down
 ifconfig wifi1.3 down
 ifconfig wifi2 down
-#ifconfig wifi2.1 down
-#ifconfig wifi2.2 down
+ifconfig wifi2.1 down
+ifconfig wifi2.2 down
 ifconfig mld0 down
+ifconfig mld1 down
 
 #delete the interfaces
 iw dev wifi0 del
@@ -22,6 +23,7 @@ iw dev wifi1.1 del
 iw dev wifi1.2 del
 iw dev wifi1.3 del
 iw dev wifi2 del
-#iw dev wifi2.1 del
-#iw dev wifi2.2 del
+iw dev wifi2.1 del
+iw dev wifi2.2 del
 iw dev mld0 del
+iw dev mld1 del

--- a/config/openwrt/banana-pi/wifi_interface_up.sh
+++ b/config/openwrt/banana-pi/wifi_interface_up.sh
@@ -10,9 +10,10 @@ iw phy phy0 interface add wifi1.1 type __ap
 iw phy phy0 interface add wifi1.2 type __ap
 iw phy phy0 interface add wifi1.3 type __ap
 iw phy phy0 interface add wifi2 type __ap
-#iw phy phy0 interface add wifi2.1 type __ap
-#iw phy phy0 interface add wifi2.2 type __ap
+iw phy phy0 interface add wifi2.1 type __ap
+iw phy phy0 interface add wifi2.2 type __ap
 iw phy phy0 interface add mld0 type __ap radios all
+iw phy phy0 interface add mld1 type __ap radios all
 
 #Derive the initial wifi mac address from eth0 or erouter0 address
 #as they are unique for each Banana PI
@@ -58,11 +59,11 @@ wifi1_3_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
 mac_incr=$(($primary_wifi_mac + 32))
 wifi2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
 #Increment again by 1 to get wifi2.1 address
-#mac_incr=$(($mac_incr + 1))
-#wifi2_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+mac_incr=$(($mac_incr + 1))
+wifi2_1_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
 #Increment again by 1 to get wifi2.2 address
-#mac_incr=$(($mac_incr + 1))
-#wifi2_2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
+mac_incr=$(($mac_incr + 1))
+wifi2_2_mac=$(printf "%012x" $mac_incr | sed 's/../&:/g;s/:$//')
 #print the mac address
 echo $wifi0_mac
 echo $wifi0_1_mac
@@ -72,8 +73,8 @@ echo $wifi1_1_mac
 echo $wifi1_2_mac
 echo $wifi1_3_mac
 echo $wifi2_mac
-#echo $wifi2_1_mac
-#echo $wifi2_2_mac
+echo $wifi2_1_mac
+echo $wifi2_2_mac
 
 #Update the mac address using ip link command
 ifconfig wifi0 down
@@ -84,8 +85,8 @@ ifconfig wifi1.1 down
 ifconfig wifi1.2 down
 ifconfig wifi1.3 down
 ifconfig wifi2 down
-#ifconfig wifi2.1 down
-#ifconfig wifi2.2 down
+ifconfig wifi2.1 down
+ifconfig wifi2.2 down
 ip link set dev wifi0 address $wifi0_mac
 ip link set dev wifi0.1 address $wifi0_1_mac
 ip link set dev wifi0.2 address $wifi0_2_mac
@@ -94,8 +95,8 @@ ip link set dev wifi1.1 address $wifi1_1_mac
 ip link set dev wifi1.2 address $wifi1_2_mac
 ip link set dev wifi1.3 address $wifi1_3_mac
 ip link set dev wifi2 address $wifi2_mac
-#ip link set dev wifi2.1 address $wifi2_1_mac
-#ip link set dev wifi2.2 address $wifi2_2_mac
+ip link set dev wifi2.1 address $wifi2_1_mac
+ip link set dev wifi2.2 address $wifi2_2_mac
 ifconfig wifi0 up
 ifconfig wifi0.1 up
 ifconfig wifi0.2 up
@@ -104,18 +105,28 @@ ifconfig wifi1.1 up
 ifconfig wifi1.2 up
 ifconfig wifi1.3 up
 ifconfig wifi2 up
-#ifconfig wifi2.1 up
-#ifconfig wifi2.2 up
+ifconfig wifi2.1 up
+ifconfig wifi2.2 up
 
-# Set MLD interface address as wifi2 MAC address + 1
-prefix="${wifi2_mac%:*}"
-last_byte="${wifi2_mac##*:}"
+# Set MLD interface address as wifi2.2 MAC address + 1
+prefix_mld0="${wifi2_2_mac%:*}"
+last_byte_mld0="${wifi2_2_mac##*:}"
 
-new_byte=$(printf "%02X" $(( (0x$last_byte + 1) & 0xFF )))
-new_mac="$prefix:$new_byte"
+new_byte_mld0=$(printf "%02X" $(( (0x$last_byte_mld0 + 1) & 0xFF )))
+new_mac_mld0="$prefix_mld0:$new_byte_mld0"
 
 ip link set dev "mld0" down
-ip link set dev "mld0" address "$new_mac"
+ip link set dev "mld0" address "$new_mac_mld0"
+
+# Set MLD interface address as mld0 MAC address + 1
+prefix_mld1="${new_mac_mld0%:*}"
+last_byte_mld1="${new_mac_mld0##*:}"
+
+new_byte_mld1=$(printf "%02X" $(( (0x$last_byte_mld1 + 1) & 0xFF )))
+new_mac_mld1="$prefix_mld1:$new_byte_mld1"
+
+ip link set dev "mld1" down
+ip link set dev "mld1" address "$new_mac_mld1"
 
 #Copy configuration file to nvram
 mkdir -p /nvram


### PR DESCRIPTION
RDKBWIFI-349: Easymesh - Enable MLO for all backhaul VAPs

Reason for change: Added mld1 interface for enabling backhaul MLO. Also enabled 6GHz iot and mesh_backhaul VAPs in OpenWRT build.
Test Procedure: Ensure BE mode enabled for backhaul vaps and extender connections works in MLO.
Risks: Medium
Priority: P1