### PR TITLE
XF10-284 : Remove Unnecessary flags for XF10 (#734)

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -7751,7 +7751,7 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
              cfg->u.bss_info.enabled = true;
         }
 #endif
-#if defined(_SKY_HUB_COMMON_PRODUCT_REQ_)
+#if defined(_SKY_HUB_COMMON_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
 #if !defined(_SCER11BEL_PRODUCT_REQ_) && !defined(_SCXF11BFL_PRODUCT_REQ_)
         if (isVapXhs(vap_index)) {
             cfg->u.bss_info.enabled = false;
@@ -7780,7 +7780,7 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         } else {
             cfg->u.bss_info.bssMaxSta = BSS_MAX_NUM_STA_COMMON;
         }
-#endif //_SKY_HUB_COMMON_PRODUCT_REQ_
+#endif //_SKY_HUB_COMMON_PRODUCT_REQ_ || _SCXF11BFL_PRODUCT_REQ_
         wifi_util_dbg_print(WIFI_DB, "%s:%d vap_index:%d bssMaxSta:%d\n", __func__, __LINE__,
             vap_index, cfg->u.bss_info.bssMaxSta);
 

--- a/source/dml/tr_181/sbapi/webpa_interface.c
+++ b/source/dml/tr_181/sbapi/webpa_interface.c
@@ -421,7 +421,7 @@ char *getDeviceMac()
 #if defined(_COSA_BCM_MIPS_)
 #define CPE_MAC_NAMESPACE "Device.DPoE.Mac_address"
 #else
-#ifdef _SKY_HUB_COMMON_PRODUCT_REQ_
+#if defined(_SKY_HUB_COMMON_PRODUCT_REQ_) || defined(PON_GATEWAY)
 #define CPE_MAC_NAMESPACE "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #else
 #define CPE_MAC_NAMESPACE "Device.X_CISCO_COM_CableModem.MACAddress"

--- a/source/platform/common/data_model/wifi_dml_api.c
+++ b/source/platform/common/data_model/wifi_dml_api.c
@@ -1868,7 +1868,7 @@ char *getDeviceMac(void)
 #if defined(_COSA_BCM_MIPS_)
 #define CPE_MAC_NAMESPACE "Device.DPoE.Mac_address"
 #else
-#ifdef _SKY_HUB_COMMON_PRODUCT_REQ_
+#if defined(_SKY_HUB_COMMON_PRODUCT_REQ_) || defined(PON_GATEWAY)
 #define CPE_MAC_NAMESPACE "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"
 #else
 #define CPE_MAC_NAMESPACE "Device.X_CISCO_COM_CableModem.MACAddress"


### PR DESCRIPTION
Reason for change: Remove flags -DSKY -DBRCM_CMS_MSG -D_SKY_HUB_COMMON_PRODUCT_REQ and added flag PON_GATEWAY

Test Procedure:
WiFi should work as expected for XF10

Risks: none
Priority: P2