### PR TITLE
RDKBACCL-1330: Updated current tx_power hal api call in OneWifi

### DIFF
--- a/source/apps/em/wifi_em.c
+++ b/source/apps/em/wifi_em.c
@@ -2278,6 +2278,25 @@ void handle_em_command_event(wifi_app_t *app, wifi_event_t *event)
     switch (event->sub_type) {
     case wifi_event_type_notify_monitor_done:
         is_monitor_done = TRUE;
+        {
+            wifi_mgr_t *wifi_mgr = get_wifimgr_obj();
+            unsigned int num_radios = getNumberRadios();
+            for (unsigned int i = 0; i < num_radios; i++) {
+                ULONG curr_txpower = 0;
+                if (wifi_hal_getRadioTransmitPower((INT)i, &curr_txpower) == RETURN_OK && curr_txpower != 0) {
+
+                    pthread_mutex_lock(&wifi_mgr->data_cache_lock);
+                    wifi_mgr->radio_config[i].oper.transmitPower = (UINT)curr_txpower;
+                    pthread_mutex_unlock(&wifi_mgr->data_cache_lock);
+
+                    wifi_util_info_print(WIFI_EM, "%s:%d: radio_index=%u curr_txpower=%lu\n",
+                        __func__, __LINE__, i, curr_txpower);
+                } else {
+                    wifi_util_error_print(WIFI_EM, "%s:%d: failed or zero tx power for radio_index=%u\n",
+                        __func__, __LINE__, i);
+                }
+            }
+        }
         break;
 
     case wifi_event_type_start_channel_scan:

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -79,7 +79,6 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
     wifi_radio_feature_param_t Fcfg;
     memset(&Fcfg,0,sizeof(Fcfg));
     memset(&cfg,0,sizeof(cfg));
-    ULONG curr_txpower = 0;
 
     wifi_radio_capabilities_t radio_capab = g_wifidb->hal_cap.wifi_prop.radiocap[radio_index];
 
@@ -191,12 +190,7 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
     }
     cfg.fragmentationThreshold = 2346;
 
-    if (wifi_hal_getRadioTransmitPower(radio_index, &curr_txpower) != RETURN_OK) {
-        wifi_util_error_print(WIFI_DB,"%s:%d: Failed to fetch TX power for radio_index=%d\n",
-                            __func__, __LINE__, radio_index);
-        curr_txpower = 100;
-    }
-    cfg.transmitPower = curr_txpower;
+    cfg.transmitPower = 100;
     cfg.rtsThreshold = 2347;
     cfg.guardInterval = wifi_guard_interval_auto;
     cfg.ctsProtection = false;

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -365,7 +365,6 @@ webconfig_error_t translate_radio_object_to_easymesh_for_radio(webconfig_subdoc_
             em_op_class_info->id.type = em_op_class_type_capability;
             em_op_class_info->id.op_class = oper_param->operatingClasses[i].opClass;
             em_op_class_info->op_class = oper_param->operatingClasses[i].opClass;
-            em_op_class_info->tx_power = oper_param->transmitPower;
             em_op_class_info->max_tx_power = oper_param->operatingClasses[i].maxTxPower;
             em_op_class_info->num_channels = oper_param->operatingClasses[i].numberOfNonOperChan;
             for(int k = 0; k < oper_param->operatingClasses[i].numberOfNonOperChan; k++) {


### PR DESCRIPTION
Earlier this `wifi_hal_getRadioTransmitPower` was in the init function which was too early and reported the current txpower as 0 for each radio.

Corrected the hal api call, now getting correct tx power for all the radios.

Test Result:
Operating Channel Report TLV populted correct tx power