### PR TITLE
RDKB-62903 TCM RFC update request - configuration by VAP

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -8289,7 +8289,6 @@ void init_wifidb_data()
     wifi_rfc_dml_parameters_t *rfc_param = get_wifi_db_rfc_parameters();
     ignite_config_t *ignite_cfg;
     char country_code[COUNTRY_CODE_LEN] = {0};
-	bool update_rfc_config = false;
 
     wifi_util_info_print(WIFI_DB,"%s:%d No of radios %d\n",__func__, __LINE__,getNumberRadios());
 

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4876,6 +4876,7 @@ static void wifidb_global_config_upgrade()
     char strValue[256] = { 0 };
     wifi_mgr_t *g_wifidb = get_wifimgr_obj();
     wifi_ccsp_desc_t *p_ccsp_desc = &get_wificcsp_obj()->desc;
+	wifi_rfc_dml_parameters_t *rfc_param = get_wifi_db_rfc_parameters();
 
     if (g_wifidb->db_version == 0) {
         return;
@@ -4957,6 +4958,17 @@ static void wifidb_global_config_upgrade()
             DEFAULT_HEAPWALK_INTERVAL;
         g_wifidb->global_config.global_parameters.memwraptool.enable = true;
     }
+	 if (g_wifidb->db_version < ONEWIFI_DB_VERSION_TCM_PER_VAP_FLAG) {
+		  wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade tcm config, old db version %d \n", __func__,
+            __LINE__, g_wifidb->db_version);
+                rfc_param->tcm_open_2g_rfc = true;
+                rfc_param->tcm_open_5g_rfc = true;
+                rfc_param->tcm_open_6g_rfc = true;
+                rfc_param->tcm_secure_2g_rfc = true;
+                rfc_param->tcm_secure_5g_rfc = true;
+                rfc_param->tcm_secure_6g_rfc = true;
+            }
+	
 }
 
 /************************************************************************************
@@ -8364,21 +8376,9 @@ void init_wifidb_data()
         wifi_util_info_print(WIFI_DB,"%s:%d FactoryReset done. wifidb updated with default values.\n",__func__, __LINE__);
     }
     else {
+        dbwritten = true;
         if (wifidb_get_rfc_config(0,rfc_param) != 0) {
             wifi_util_error_print(WIFI_DB,"%s:%d: Error getting RFC config\n",__func__, __LINE__);
-        } else {
-            if (g_wifidb->db_version < ONEWIFI_DB_VERSION_TCM_PER_VAP_FLAG) {
-                rfc_param->tcm_open_2g_rfc = true;
-                rfc_param->tcm_open_5g_rfc = true;
-                rfc_param->tcm_open_6g_rfc = true;
-                rfc_param->tcm_secure_2g_rfc = true;
-                rfc_param->tcm_secure_5g_rfc = true;
-                rfc_param->tcm_secure_6g_rfc = true;
-                update_rfc_config = true;
-            }
-        }
-        if (update_rfc_config == true) {
-            wifidb_update_rfc_config(0, rfc_param);
         }
 #ifdef ALWAYS_ENABLE_AX_2G
         wifidb_update_rfc_config(0, rfc_param);

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4958,17 +4958,17 @@ static void wifidb_global_config_upgrade()
             DEFAULT_HEAPWALK_INTERVAL;
         g_wifidb->global_config.global_parameters.memwraptool.enable = true;
     }
-	 if (g_wifidb->db_version < ONEWIFI_DB_VERSION_TCM_PER_VAP_FLAG) {
-		  wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade tcm config, old db version %d \n", __func__,
+    if (g_wifidb->db_version < ONEWIFI_DB_VERSION_TCM_PER_VAP_FLAG) {
+        wifi_util_dbg_print(WIFI_DB, "%s:%d upgrade tcm config, old db version %d \n", __func__,
             __LINE__, g_wifidb->db_version);
-                rfc_param->tcm_open_2g_rfc = true;
-                rfc_param->tcm_open_5g_rfc = true;
-                rfc_param->tcm_open_6g_rfc = true;
-                rfc_param->tcm_secure_2g_rfc = true;
-                rfc_param->tcm_secure_5g_rfc = true;
-                rfc_param->tcm_secure_6g_rfc = true;
-            }
-	
+        rfc_param->tcm_open_2g_rfc = true;
+        rfc_param->tcm_open_5g_rfc = true;
+        rfc_param->tcm_open_6g_rfc = true;
+        rfc_param->tcm_secure_2g_rfc = true;
+        rfc_param->tcm_secure_5g_rfc = true;
+        rfc_param->tcm_secure_6g_rfc = true;
+    }
+
 }
 
 /************************************************************************************

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -8368,7 +8368,6 @@ void init_wifidb_data()
             wifi_util_error_print(WIFI_DB,"%s:%d: Error getting RFC config\n",__func__, __LINE__);
         } else {
             if (g_wifidb->db_version < ONEWIFI_DB_VERSION_TCM_PER_VAP_FLAG) {
-                wifi_util_info_print(WIFI_DB,"%s:%d: TCM per-VAP migration: db_version=%d, setting all per-VAP TCM RFC flags to true\n",__func__, __LINE__, g_wifidb->db_version);
                 rfc_param->tcm_open_2g_rfc = true;
                 rfc_param->tcm_open_5g_rfc = true;
                 rfc_param->tcm_open_6g_rfc = true;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -8380,7 +8380,6 @@ void init_wifidb_data()
         if (update_rfc_config == true) {
             wifidb_update_rfc_config(0, rfc_param);
         }
-        dbwritten = true;
 #ifdef ALWAYS_ENABLE_AX_2G
         wifidb_update_rfc_config(0, rfc_param);
 #endif

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4876,7 +4876,7 @@ static void wifidb_global_config_upgrade()
     char strValue[256] = { 0 };
     wifi_mgr_t *g_wifidb = get_wifimgr_obj();
     wifi_ccsp_desc_t *p_ccsp_desc = &get_wificcsp_obj()->desc;
-	wifi_rfc_dml_parameters_t *rfc_param = get_wifi_db_rfc_parameters();
+    wifi_rfc_dml_parameters_t *rfc_param = get_wifi_db_rfc_parameters();
 
     if (g_wifidb->db_version == 0) {
         return;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -8364,11 +8364,11 @@ void init_wifidb_data()
         wifi_util_info_print(WIFI_DB,"%s:%d FactoryReset done. wifidb updated with default values.\n",__func__, __LINE__);
     }
     else {
-        dbwritten = true;
         if (wifidb_get_rfc_config(0,rfc_param) != 0) {
             wifi_util_error_print(WIFI_DB,"%s:%d: Error getting RFC config\n",__func__, __LINE__);
         } else {
             if (g_wifidb->db_version < ONEWIFI_DB_VERSION_TCM_PER_VAP_FLAG) {
+                wifi_util_info_print(WIFI_DB,"%s:%d: TCM per-VAP migration: db_version=%d, setting all per-VAP TCM RFC flags to true\n",__func__, __LINE__, g_wifidb->db_version);
                 rfc_param->tcm_open_2g_rfc = true;
                 rfc_param->tcm_open_5g_rfc = true;
                 rfc_param->tcm_open_6g_rfc = true;
@@ -8381,6 +8381,7 @@ void init_wifidb_data()
         if (update_rfc_config == true) {
             wifidb_update_rfc_config(0, rfc_param);
         }
+        dbwritten = true;
 #ifdef ALWAYS_ENABLE_AX_2G
         wifidb_update_rfc_config(0, rfc_param);
 #endif


### PR DESCRIPTION
RDKB-62903 - TCM RFC update request - configuration by VAP
Reason For Change : TCM RFC is configured at Device.WiFi.Tcm and applies to all VAPs.

Test Procedure: Enable TCM RFC per VAP via DMCLI, verify the update in OVSDB, and confirm TCM logic execution through logs.

dmcli eRT getv Device.WiFi.Tcm
dmcli eRT setv Device.WiFi.Tcm bool true
dmcli eRT getv Device.WiFi.TCM.Open2G
dmcli eRT getv Device.WiFi.TCM.Open5G ``dmcli eRT getv Device.WiFi.TCM.Open6G
dmcli eRT getv Device.WiFi.TCM.Secure2G
dmcli eRT getv Device.WiFi.TCM.Secure5G
dmcli eRT getv Device.WiFi.TCM.Secure6G
/usr/opensync/tools/ovsh s Wifi_Rfc_Config -c -d wifi
/nvram/wifiTCMDbg
wifiTransientClientMgmtCtrl

Priority: P1
Risks: Low
Signed-off-by: Sneha Kannan , sneha_kannan@comcast.com