### PR TITLE
RDKBWIFI-425: Support UNI-4 Band Channels

### DIFF
--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -3543,7 +3543,7 @@ int wifi_radio_operationParam_validation(wifi_hal_capability_t  *hal_cap, wifi_r
     int start_index = 0;
     int ch_count = 0;
     const void *hal_cap_channels = NULL;
-    int ref_ch_list_5g[] = {36,40,44,48,52,56,60,64,100,104,108,112,116,120,124,128,132,136,140,144,149,153,157,161,165};
+    int ref_ch_list_5g[] = {36,40,44,48,52,56,60,64,100,104,108,112,116,120,124,128,132,136,140,144,149,153,157,161,165,169,173,177};
     INT non_dfs_ch_hal_cap[MAX_CHANNELS] = {'\0'};
     INT hal_cap_channel_val;
 

--- a/source/utils/wifi_util.h
+++ b/source/utils/wifi_util.h
@@ -254,9 +254,9 @@ typedef struct {
 
 /* 5GHz radio */
 #define MIN_FREQ_MHZ_5G 5180
-#define MAX_FREQ_MHZ_5G 5825
+#define MAX_FREQ_MHZ_5G 5885
 #define MIN_CHANNEL_5G 36
-#define MAX_CHANNEL_5G 165
+#define MAX_CHANNEL_5G 177
 
 /* 5GHz Low radio */
 #define MIN_FREQ_MHZ_5GL 5180
@@ -266,9 +266,9 @@ typedef struct {
 
 /* 5GHz High radio */
 #define MIN_FREQ_MHZ_5GH 5500
-#define MAX_FREQ_MHZ_5GH 5825
+#define MAX_FREQ_MHZ_5GH 5885
 #define MIN_CHANNEL_5GH 100
-#define MAX_CHANNEL_5GH 165
+#define MAX_CHANNEL_5GH 177
 
 /* 6GHz radio */
 #define MIN_FREQ_MHZ_6G 5955


### PR DESCRIPTION
- Added UNI-4 band channels (169, 173, 177) to 5GHz channel list for E4 opclass support.
- No country-code specific changes made since UNI-4 channels are allowed under certain conditions
  in E1 (US) and E2 (Europe) operating class tables