### PR TITLE
RDKB-62781 : Used memory increasing and crossed 560Mb

### DIFF
--- a/source/platform/rdkb/bus.c
+++ b/source/platform/rdkb/bus.c
@@ -1428,6 +1428,8 @@ bus_error_t bus_method_invoke(bus_handle_t *handle, void *paramName, char *event
     rbusObject_Init(&inParams, NULL);
     rbusValue_Init(&value);
 
+    wifi_util_info_print(WIFI_BUS, "%s:%d: rbus: rbus_method_invoke() is called for event:%s, paramName:%s\n",
+        __func__, __LINE__, event, (char *)paramName);
     if ((input_bus_data == BUS_METHOD_SET) || (input_bus_data == BUS_METHOD_SET_GET)) {
         if (input_data->data_type == bus_data_type_string) {
             if (false ==
@@ -1447,12 +1449,13 @@ bus_error_t bus_method_invoke(bus_handle_t *handle, void *paramName, char *event
 
     rbusProperty_Init(&prop, paramName, value);
     rbusObject_SetProperty(inParams, prop);
-    rbusProperty_Release(prop);
 
     rc = rbusMethod_Invoke(p_rbus_handle, event, inParams, &outParams);
     if (inParams) {
         rbusObject_Release(inParams);
     }
+    rbusProperty_Release(prop);
+    rbusValue_Release(value);
 
     if (outParams == NULL) {
         wifi_util_error_print(WIFI_BUS, "%s %d Out param is NULL\n", __func__, __LINE__);
@@ -1512,7 +1515,9 @@ bus_error_t bus_method_invoke(bus_handle_t *handle, void *paramName, char *event
         }
         memcpy(output_data->raw_data.bytes, ptr, len);
     }
-    rbusValue_Release(value);
+    if (outParams) {
+        rbusObject_Release(outParams);
+    }
     return convert_rbus_to_bus_error_code(rc);
 }
 


### PR DESCRIPTION
RDKB-62781 : Used memory increasing and crossed 560Mb

Reason for change: Fixing Rbus memory leaks
Test Procedure: Make sure that no memory spike been observed during frequent RBUS calls. Risks: Medium
Priority: P1
Signed-off-by:lavanya_chimmirivenkata@comcast.com