### PR TITLE
RDKCOM-5528: RDKBDEV-3377: [Easymesh] Skip onewifi VAP creation in EasyMesh colocated mode (#901)

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -702,7 +702,8 @@ void bus_get_vap_init_parameter(const char *name, unsigned int *ret_val)
     }
 
 #if defined EASY_MESH_NODE
-   if (ctrl->network_mode == rdk_dev_mode_type_em_node ) {
+   if (ctrl->network_mode == rdk_dev_mode_type_em_node ||
+       ctrl->network_mode == rdk_dev_mode_type_em_colocated_node ) {
             wifi_util_dbg_print(WIFI_CTRL, "%s:%d Don't need to proceed for DML fetch for RemoteAgent case, NetworkMode: %d\n",
                 __func__, __LINE__, ctrl->network_mode);
             return;
@@ -905,10 +906,11 @@ int start_wifi_services(void)
             start_extender_vaps(radio_index);
         }
     } else if (ctrl->network_mode == rdk_dev_mode_type_em_colocated_node) {
-        wifi_util_info_print(WIFI_CTRL, "%s:%d start em_colocated mode\n",__func__, __LINE__);
+        wifi_util_info_print(WIFI_CTRL, "%s:%d start em_colocated mode, VAPs will be created by EasyMesh\n",__func__, __LINE__);
         for (unsigned int radio_index = 0; radio_index < getNumberRadios(); radio_index++) {
             start_radios(rdk_dev_mode_type_gw, radio_index);
-            start_gateway_vaps(radio_index);
+            /* Skip VAP creation - EasyMesh controller will configure and create VAPs */
+            /* start_gateway_vaps(radio_index); */
         }
     }
 


### PR DESCRIPTION
Reason for change: In EasyMesh colocated deployments, VAPs (private, public, mesh) should not be automatically created during OneWiFi initialization. The EasyMesh controller will provide proper configuration via Multi-AP protocol and trigger VAP creation at the appropriate time.
This change skips start_gateway_vaps() in rdk_dev_mode_type_em_colocated_node mode, similar to the existing extender mode logic. Radios are still initialized, and all services remain ready to handle configuration updates.

Test procedure: verify all VAPs creted properly during init
Signed-off-by: Vladislav Safonov <vsafonov@maxlinear.com>

Risk: Low
Priority: P2