### PR TITLE
XB10-2312: Add check on radio BE mode for MLD related DML (#1046)

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -3221,6 +3221,17 @@ UINT getNumberVAPsPerRadio(UINT radioIndex)
     return wifi_mgr->radio_config[radioIndex].vaps.num_vaps;
 }
 
+BOOL isRadioBeEnabled(UINT radio_index)
+{
+#ifdef CONFIG_IEEE80211BE
+    wifi_radio_operationParam_t *radio_param = getRadioOperationParam(radio_index);
+
+    if (radio_param != NULL && radio_param->variant & WIFI_80211_VARIANT_BE) {
+        return TRUE;
+    }
+#endif /* CONFIG_IEEE80211BE */
+    return FALSE;
+}
 
 void get_subdoc_name_from_vap_index(uint8_t vap_index, int* subdoc)
 {

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -355,6 +355,7 @@ UINT getTotalNumberVAPs();
 UINT getNumberRadios();
 UINT getMaxNumberVAPsPerRadio(UINT radioIndex);
 UINT getNumberVAPsPerRadio(UINT radioIndex);
+BOOL isRadioBeEnabled(UINT radio_index);
 //getVAPArrayIndexFromVAPIndex() need to be used in case of VAPS considered as single array (from 0 to MAX_VAP)
 //In case of to get vap array index per radio, use convert_vap_index_to_vap_array_index()
 int getVAPArrayIndexFromVAPIndex(unsigned int apIndex, unsigned int *vap_array_index);

--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -155,6 +155,11 @@ void update_apmld_map()
     memset(mld_id_to_idx, -1, sizeof(mld_id_to_idx));
 
     for (unsigned int r_idx = 0; r_idx < num_radios; r_idx++) {
+        if (isRadioBeEnabled(r_idx) != TRUE) {
+            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Radio %d does not have BE mode enabled, skip\n", __func__, __LINE__, r_idx);
+            continue;
+        }
+
         mgr_vap_info_map = get_wifidb_vap_map(r_idx);
         if (mgr_vap_info_map == NULL) {
             wifi_util_error_print(WIFI_DMCLI, "%s:%d get_wifidb_vap_map failed for radio: %d\n", __func__, __LINE__, r_idx);

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -5412,7 +5412,8 @@ SSID_GetParamIntValue
             *pInt = -1;
             return TRUE;
         }
-        if (pcfg->u.bss_info.mld_info.common_info.mld_enable == FALSE) {
+        if (pcfg->u.bss_info.mld_info.common_info.mld_enable == FALSE ||
+            !isRadioBeEnabled(pcfg->radio_index)) {
             *pInt = -1;
         } else {
             *pInt = pcfg->u.bss_info.mld_info.common_info.mld_id;
@@ -5943,6 +5944,14 @@ SSID_SetParamIntValue
         }
         wifi_util_info_print(WIFI_DMCLI,"%s:%d MLD Unit %d\n", __FUNCTION__, __LINE__, iValue);
         tmp_mld_enable = (iValue == -1) ? FALSE : TRUE;
+
+        if (tmp_mld_enable == TRUE && !isRadioBeEnabled(pcfg->radio_index)) {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d Cannot set MLDUnit on VAP %d: radio %d has no BE mode\n", __FUNCTION__,
+                __LINE__, pcfg->vap_index, pcfg->radio_index);
+            return FALSE;
+        }
+
         if (vapInfo->u.bss_info.mld_info.common_info.mld_enable == tmp_mld_enable) {
             if (!tmp_mld_enable && vapInfo->u.bss_info.mld_info.common_info.mld_id == UNDEFINED_MLD_ID)
                 return TRUE;
@@ -6766,7 +6775,11 @@ AccessPoint_GetParamBoolValue
     if( AnscEqualString(ParamName, "MLD_Enable", TRUE))
     {
         /* collect value */
-        *pBool = pcfg->u.bss_info.mld_info.common_info.mld_enable;
+        if (!isRadioBeEnabled(pcfg->radio_index)) {
+            *pBool = FALSE;
+        } else {
+            *pBool = pcfg->u.bss_info.mld_info.common_info.mld_enable;
+        }
         return TRUE;
     }
 
@@ -7134,7 +7147,11 @@ AccessPoint_GetParamUlongValue
 
     if( AnscEqualString(ParamName, "MLD_ID", TRUE))
     {
-        *puLong = pcfg->u.bss_info.mld_info.common_info.mld_id;
+        if (!isRadioBeEnabled(pcfg->radio_index)) {
+            *puLong = UNDEFINED_MLD_ID;
+        } else {
+            *puLong = pcfg->u.bss_info.mld_info.common_info.mld_id;
+        }
         return TRUE;
     }
 
@@ -7293,37 +7310,23 @@ AccessPoint_GetParamStringValue
 
     }
 
-    if( AnscEqualString(ParamName, "MLD_Addr", TRUE))
-    {
-        char buff[24] = {0};
+    if (AnscEqualString(ParamName, "MLD_Addr", TRUE)) {
+        unsigned char *mac;
+        mac_address_t zero_mac = { 0 };
+
         if (isVapSTAMesh(pcfg->vap_index)) {
-            _ansc_sprintf
-            (
-                buff,
-                "%02X:%02X:%02X:%02X:%02X:%02X",
-                0x0,
-                0x0,
-                0x0,
-                0x0,
-                0x0,
-                0x0
-            );
+            mac = zero_mac;
+        } else if (isRadioBeEnabled(pcfg->radio_index)) {
+            mac = pcfg->u.bss_info.mld_info.common_info.mld_addr;
         } else {
-            _ansc_sprintf
-            (
-                buff,
-                "%02X:%02X:%02X:%02X:%02X:%02X",
-                pcfg->u.bss_info.mld_info.common_info.mld_addr[0],
-                pcfg->u.bss_info.mld_info.common_info.mld_addr[1],
-                pcfg->u.bss_info.mld_info.common_info.mld_addr[2],
-                pcfg->u.bss_info.mld_info.common_info.mld_addr[3],
-                pcfg->u.bss_info.mld_info.common_info.mld_addr[4],
-                pcfg->u.bss_info.mld_info.common_info.mld_addr[5]
-            );
+            mac = pcfg->u.bss_info.bssid;
         }
-        memcpy(pValue, buff, strlen(buff)+1);
+
+        snprintf(pValue, *pUlSize, "%02X:%02X:%02X:%02X:%02X:%02X",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
         return 0;
-     }
+    }
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
     return -1;
 }
@@ -7452,6 +7455,14 @@ AccessPoint_SetParamBoolValue
 
     if( AnscEqualString(ParamName, "MLD_Enable", TRUE))
     {
+        if (bValue && !isRadioBeEnabled(pcfg->radio_index))
+        {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d Cannot enable MLD on VAP %s: radio %d has no BE mode\n", __FUNCTION__,
+                __LINE__, pcfg->vap_name, pcfg->radio_index);
+            return FALSE;
+        }
+
         if ( vapInfo->u.bss_info.mld_info.common_info.mld_enable == bValue )
         {
             return TRUE;
@@ -7898,6 +7909,11 @@ AccessPoint_SetParamUlongValue
         if (isVapSTAMesh(pcfg->vap_index)) {
             wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
             return TRUE;
+        }
+        if (!isRadioBeEnabled(pcfg->radio_index)) {
+            wifi_util_error_print(WIFI_DMCLI,"%s:%d Cannot set MLD_ID on VAP %s: radio %d has no BE mode\n",
+                __FUNCTION__, __LINE__, pcfg->vap_name, pcfg->radio_index);
+            return FALSE;
         }
         if ( vapInfo->u.bss_info.mld_info.common_info.mld_id == (unsigned int)uValue )
         {

--- a/source/platform/common/data_model/wifi_dml_cb.c
+++ b/source/platform/common/data_model/wifi_dml_cb.c
@@ -2217,6 +2217,11 @@ bool ssid_get_param_int_value(void *obj_ins_context, char *param_name, int *outp
     if (STR_CMP(param_name, "MLDUnit")) {
         wifi_mld_common_info_t *mld_common_info = NULL;
 
+        if (!isRadioBeEnabled(pcfg->radio_index)) {
+            *output_value = -1;
+            return true;
+        }
+
         if (isVapSTAMesh(pcfg->vap_index)) {
             mld_common_info = &pcfg->u.sta_info.mld_info.common_info;
         } else {
@@ -2496,6 +2501,14 @@ bool ssid_set_param_int_value(void *obj_ins_context, char *param_name, int input
         }
         wifi_util_info_print(WIFI_DMCLI,"%s:%d MLD Unit %d\n", __FUNCTION__, __LINE__, input_value);
         tmp_mld_enable = (input_value == -1) ? false : true;
+
+        if (tmp_mld_enable == true && !isRadioBeEnabled(pcfg->radio_index)) {
+            wifi_util_error_print(WIFI_DMCLI,
+                "%s:%d Cannot set MLDUnit on VAP %d: radio %d has no BE mode\n", __FUNCTION__,
+                __LINE__, pcfg->vap_index, pcfg->radio_index);
+            return false;
+        }
+
         if (vapInfo->u.bss_info.mld_info.common_info.mld_enable == tmp_mld_enable) {
             if (tmp_mld_enable == false && vapInfo->u.bss_info.mld_info.common_info.mld_id == UNDEFINED_MLD_ID) {
                 return true;


### PR DESCRIPTION
Reason for change: Incorrect Data Model values after disabling 802.11be on a radio Test Procedure: 1. Disable 802.11be on a radio (e.g. 2GHz)
                2. Check Data Model values for MLD related parameters for VAPs on that radio,
                they should be if MLD is disabled (-1 for MLDUnit, 255 for MLD_ID, FALSE for MLDEnable, BSSID for MLD_Addr)
                3. Check WFA DML. (Device.WiFi.DataElements.Network.Device.1.APMLD.)
Risk: Low
Priority: P2


(cherry picked from commit a589215b5ea478d0b07b54c5de391f1c9c5aa5aa)