### PR TITLE
RDKB-65811: Update DML cache if HAL params change

### DIFF
--- a/source/core/services/vap_svc.c
+++ b/source/core/services/vap_svc.c
@@ -79,40 +79,6 @@ int svc_init(vap_svc_t *svc, vap_svc_type_t type)
     return 0;
 }
 
-int update_global_cache(wifi_vap_info_map_t *tgt_vap_map, rdk_wifi_vap_info_t *rdk_vap_info)
-{
-    uint8_t j = 0;
-    rdk_wifi_vap_info_t *rdk_vaps;
-    wifi_vap_info_map_t *vap_map = NULL;
-    uint8_t i = 0, vap_index = 0;
-
-    for (i = 0; i < tgt_vap_map->num_vaps; i++) {
-        vap_index = tgt_vap_map->vap_array[i].vap_index;
-        vap_map = (wifi_vap_info_map_t *)get_wifidb_vap_map(tgt_vap_map->vap_array[i].radio_index);
-        if (vap_map == NULL) {
-            wifi_util_error_print(WIFI_CTRL,"%s:%d global vap_map null radio_index:%d\n", __func__, __LINE__,
-                tgt_vap_map->vap_array[i].radio_index);
-            return RETURN_ERR;
-        }
-        rdk_vaps = get_wifidb_rdk_vaps(tgt_vap_map->vap_array[i].radio_index);
-        if (rdk_vaps == NULL) {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d failed to get rdk vaps for radio index: %d\n",
-                __func__, __LINE__, tgt_vap_map->vap_array[i].radio_index);
-            return RETURN_ERR;
-        }
-        for (j = 0; j < vap_map->num_vaps; j++) {
-            if (vap_map->vap_array[j].vap_index == vap_index) {
-                memcpy((unsigned char *)&vap_map->vap_array[j], (unsigned char *)&tgt_vap_map->vap_array[i],
-                    sizeof(wifi_vap_info_t));
-                memcpy(&rdk_vaps[j], &rdk_vap_info[i], sizeof(rdk_wifi_vap_info_t));
-                break;
-            }
-        }
-    }
-
-    return RETURN_OK;
-}
-
 int update_acl_entries(wifi_vap_info_map_t *tgt_vap_map)
 {
     rdk_wifi_vap_info_t *vap_info;
@@ -225,6 +191,10 @@ int vap_svc_start_stop(vap_svc_t *svc, unsigned int radio_index, bool enable)
     rdk_wifi_vap_info_t tgt_rdk_vaps[MAX_NUM_VAP_PER_RADIO], *rdk_vaps;
     wifi_vap_info_map_t *vap_map = NULL;
     wifi_vap_info_map_t *tgt_vap_map = (wifi_vap_info_map_t*)calloc(1, sizeof(wifi_vap_info_map_t));
+#if defined(_PLATFORM_BANANAPI_R4_)
+    bool dml_cache_update_needed = false;
+    webconfig_subdoc_data_t *dml_cache_update_subdoc = NULL;
+#endif
 
     if (!tgt_vap_map)
     {
@@ -310,11 +280,58 @@ int vap_svc_start_stop(vap_svc_t *svc, unsigned int radio_index, bool enable)
 
         wifi_util_info_print(WIFI_CTRL, "%s:%d wifi vaps create success for radio index: %d\n",
             __func__, __LINE__, i);
+#if defined(_PLATFORM_BANANAPI_R4_)
+        uint8_t vap_index = 0;
+        for (int idx = 0; idx < tgt_vap_map->num_vaps; idx++) {
+            vap_index = tgt_vap_map->vap_array[idx].vap_index;
+            for (j = 0; j < vap_map->num_vaps; j++) {
+                if (dml_cache_update_needed == true) {
+                    break;
+                }
+
+                if (vap_map->vap_array[j].vap_index == vap_index) {
+                    if (memcmp(&vap_map->vap_array[j], &tgt_vap_map->vap_array[idx],
+                            sizeof(wifi_vap_info_t)) != 0) {
+                        wifi_util_info_print(WIFI_CTRL,
+                            "%s:%d: VAP config changed for vap_index %d\n", __func__, __LINE__,
+                            vap_index);
+                        dml_cache_update_needed = true;
+                        break;
+                    }
+                }
+            }
+
+            if (dml_cache_update_needed == true) {
+                break;
+            }
+        }
+#endif
         update_global_cache(tgt_vap_map, tgt_rdk_vaps);
         update_acl_entries(tgt_vap_map);
 
         update_vap_hal_prop_bridge_name(svc, tgt_vap_map);
     }
+
+#if defined(_PLATFORM_BANANAPI_R4_)
+    if (dml_cache_update_needed) {
+        dml_cache_update_subdoc = (webconfig_subdoc_data_t *)malloc(
+            sizeof(webconfig_subdoc_data_t));
+        if (dml_cache_update_subdoc == NULL) {
+            wifi_util_error_print(WIFI_CTRL,
+                "%s:%d: malloc failed to allocate webconfig_subdoc_data_t, size %zu\n", __func__,
+                __LINE__, sizeof(webconfig_subdoc_data_t));
+            free(tgt_vap_map);
+            return -1;
+        }
+        webconfig_init_subdoc_data(dml_cache_update_subdoc);
+        if (update_dml_cache((wifi_ctrl_t *)svc->ctrl, dml_cache_update_subdoc) == RETURN_ERR) {
+            free(dml_cache_update_subdoc);
+            free(tgt_vap_map);
+            return -1;
+        }
+    }
+    free(dml_cache_update_subdoc);
+#endif
 
     free(tgt_vap_map);
 

--- a/source/core/services/vap_svc_private.c
+++ b/source/core/services/vap_svc_private.c
@@ -92,7 +92,11 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
     unsigned int i;
     wifi_vap_info_map_t *p_tgt_vap_map = NULL;
     int ret;
-    
+#if defined(_PLATFORM_BANANAPI_R4_)
+    bool dml_cache_update_needed = false;
+    webconfig_subdoc_data_t *dml_cache_update_subdoc = NULL;
+#endif
+
     p_tgt_vap_map = (wifi_vap_info_map_t *) malloc( sizeof(wifi_vap_info_map_t) );
     if (p_tgt_vap_map == NULL) {
         wifi_util_error_print(WIFI_CTRL,"%s:%d Failed to allocate memory.\n", __FUNCTION__,__LINE__);
@@ -110,6 +114,7 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
         enabled = p_tgt_vap_map->vap_array[0].u.bss_info.enabled;
         if (configure_lnf_psk_radius_from_hotspot(&p_tgt_vap_map->vap_array[0]) != RETURN_OK) {
             wifi_util_error_print(WIFI_CTRL, "%s:%d configure_lnf_psk_radius_from_hotspot failed\n", __FUNCTION__, __LINE__);
+            free(p_tgt_vap_map);
             return -1;
         }
 #if defined(_WNXL11BWL_PRODUCT_REQ_)
@@ -141,7 +146,15 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
         }
 
         p_tgt_vap_map->vap_array[0].u.bss_info.enabled = enabled;
-        
+#if defined(_PLATFORM_BANANAPI_R4_)
+        if (memcmp(&map->vap_array[i], &p_tgt_vap_map->vap_array[0], sizeof(wifi_vap_info_t)) !=
+            0) {
+            wifi_util_info_print(WIFI_CTRL, "%s:%d: VAP config changed for vap_index %d\n",
+                __func__, __LINE__, p_tgt_vap_map->vap_array[0].vap_index);
+            dml_cache_update_needed = true;
+        }
+#endif
+
         wifi_util_info_print(WIFI_CTRL,"%s: wifi vap create success: radio_index:%d vap_index:%d\n",__FUNCTION__,
                                                 radio_index, map->vap_array[i].vap_index);
         get_wifidb_obj()->desc.print_fn("%s: wifi vap create success: radio_index:%d vap_index:%d\n",__FUNCTION__,
@@ -156,6 +169,7 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
             if (lnf_vap_info == NULL) {
                 wifi_util_error_print(WIFI_CTRL, "%s:%d LnF VAP info not found for vap_index=%d\n",
                     __FUNCTION__, __LINE__, map->vap_array[i].vap_index);
+                free(p_tgt_vap_map);
                 return -1;
             }
             if (lnf_vap_info->u.bss_info.mdu_enabled) {
@@ -168,6 +182,9 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
                     sizeof(lnf_vap_info->u.bss_info.security.repurposed_radius));
             }
         }
+#if defined(_PLATFORM_BANANAPI_R4_)
+        update_global_cache(p_tgt_vap_map, &rdk_vap_info[i]);
+#endif
         memcpy((unsigned char *)&map->vap_array[i], (unsigned char *)&p_tgt_vap_map->vap_array[0],
                     sizeof(wifi_vap_info_t));
         get_wifidb_obj()->desc.update_wifi_vap_info_fn(getVAPName(map->vap_array[i].vap_index), &map->vap_array[i],
@@ -178,6 +195,26 @@ int vap_svc_private_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_in
                 &map->vap_array[i].u.bss_info.security);
 
     }
+#if defined(_PLATFORM_BANANAPI_R4_)
+    if (dml_cache_update_needed) {
+        dml_cache_update_subdoc = (webconfig_subdoc_data_t *)malloc(
+            sizeof(webconfig_subdoc_data_t));
+        if (dml_cache_update_subdoc == NULL) {
+            wifi_util_error_print(WIFI_CTRL,
+                "%s:%d: malloc failed to allocate webconfig_subdoc_data_t, size %zu\n", __func__,
+                __LINE__, sizeof(webconfig_subdoc_data_t));
+            free(p_tgt_vap_map);
+            return -1;
+        }
+        webconfig_init_subdoc_data(dml_cache_update_subdoc);
+        if (update_dml_cache((wifi_ctrl_t *)svc->ctrl, dml_cache_update_subdoc) == RETURN_ERR) {
+            free(dml_cache_update_subdoc);
+            free(p_tgt_vap_map);
+            return -1;
+        }
+    }
+    free(dml_cache_update_subdoc);
+#endif
     free(p_tgt_vap_map);
 
     return 0;

--- a/source/core/services/vap_svc_public.c
+++ b/source/core/services/vap_svc_public.c
@@ -159,11 +159,15 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
 {
     bool enabled;
     unsigned int i;
-    wifi_vap_info_map_t *p_tgt_vap_map, *p_tgt_created_vap_map;
+    wifi_vap_info_map_t *p_tgt_vap_map;
     bool greylist_rfc = false;
     bool rfc_passpoint_enable = false;
     wifi_ctrl_t *ctrl;
     wifi_mgr_t *mgr = (wifi_mgr_t *)get_wifimgr_obj();
+#if defined(_PLATFORM_BANANAPI_R4_)
+    bool dml_cache_update_needed = false;
+    webconfig_subdoc_data_t *dml_cache_update_subdoc = NULL;
+#endif
 
     ctrl = &mgr->ctrl;
 
@@ -172,14 +176,6 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
         wifi_util_error_print(WIFI_CTRL,"%s:%d Failed to allocate memory.\n", __func__,__LINE__);
         return -1;
     }
-    p_tgt_created_vap_map = (wifi_vap_info_map_t *) malloc( sizeof(wifi_vap_info_map_t) );
-    if (p_tgt_created_vap_map == NULL) {
-        wifi_util_error_print(WIFI_CTRL,"%s:%d Failed to allocate memory.\n", __func__,__LINE__);
-        free(p_tgt_vap_map);
-        return -1;
-    }
-    memset((unsigned char *)p_tgt_created_vap_map, 0, sizeof(wifi_vap_info_map_t));
-    p_tgt_created_vap_map->num_vaps = 0;
     wifi_rfc_dml_parameters_t *rfc_info = (wifi_rfc_dml_parameters_t *)get_wifi_db_rfc_parameters();
     if (rfc_info) {
         greylist_rfc = rfc_info->radiusgreylist_rfc;
@@ -227,6 +223,14 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
             continue;
         }
         p_tgt_vap_map->vap_array[0].u.bss_info.enabled = enabled;
+#if defined(_PLATFORM_BANANAPI_R4_)
+        if (memcmp(&map->vap_array[i], &p_tgt_vap_map->vap_array[0], sizeof(wifi_vap_info_t)) !=
+            0) {
+            wifi_util_info_print(WIFI_CTRL, "%s:%d: VAP config changed for vap_index %d\n",
+                __func__, __LINE__, p_tgt_vap_map->vap_array[0].vap_index);
+            dml_cache_update_needed = true;
+        }
+#endif
         if (greylist_rfc || ((pcfg != NULL && pcfg->prefer_private))) {
 #ifdef NL80211_ACL
             wifi_hal_setApMacAddressControlMode(p_tgt_vap_map->vap_array[0].vap_index, 2);
@@ -253,9 +257,9 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
                 }
         }
         wifi_util_error_print(WIFI_CTRL,"%s: p_tgt_vap_map->passpoint.enable %d\n", __FUNCTION__,p_tgt_vap_map->vap_array[0].u.bss_info.interworking.passpoint.enable);
+        update_global_cache(p_tgt_vap_map, &rdk_vap_info[i]);
         memcpy((unsigned char *)&map->vap_array[i], (unsigned char *)&p_tgt_vap_map->vap_array[0],
-                    sizeof(wifi_vap_info_t));
-        memcpy((unsigned char *)&p_tgt_created_vap_map->vap_array[i], (unsigned char *)&p_tgt_vap_map->vap_array[0], sizeof(wifi_vap_info_t));
+            sizeof(wifi_vap_info_t));
         get_wifidb_obj()->desc.update_wifi_vap_info_fn(map->vap_array[i].vap_name, &map->vap_array[i],
             &rdk_vap_info[i]);
         get_wifidb_obj()->desc.update_wifi_interworking_cfg_fn(map->vap_array[i].vap_name,
@@ -273,11 +277,29 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
             scheduler_add_timer_task(ctrl->sched, FALSE, NULL, update_managementFramePower, NULL, MFPC_TIMER * 1000, 1, FALSE);
         }
     }
-    update_global_cache(p_tgt_created_vap_map, rdk_vap_info);
+#if defined(_PLATFORM_BANANAPI_R4_)
+    if (dml_cache_update_needed) {
+        dml_cache_update_subdoc = (webconfig_subdoc_data_t *)malloc(
+            sizeof(webconfig_subdoc_data_t));
+        if (dml_cache_update_subdoc == NULL) {
+            wifi_util_error_print(WIFI_CTRL,
+                "%s:%d: malloc failed to allocate webconfig_subdoc_data_t, size %zu\n", __func__,
+                __LINE__, sizeof(webconfig_subdoc_data_t));
+            free(p_tgt_vap_map);
+            return -1;
+        }
+        webconfig_init_subdoc_data(dml_cache_update_subdoc);
+        if (update_dml_cache((wifi_ctrl_t *)svc->ctrl, dml_cache_update_subdoc) == RETURN_ERR) {
+            free(dml_cache_update_subdoc);
+            free(p_tgt_vap_map);
+            return -1;
+        }
+    }
+    free(dml_cache_update_subdoc);
+#endif
     //Load all the Acl entries related to the created public vaps
     update_xfinity_acl_entries(p_tgt_vap_map->vap_array[0].vap_name);
     free(p_tgt_vap_map);
-    free(p_tgt_created_vap_map);
     return 0;
 }
 int update_xfinity_acl_entries(char* tgt_vap_name)

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -3816,3 +3816,57 @@ static int switch_dfs_channel(void *arg)
     free(arg);
     return TIMER_TASK_COMPLETE;
 }
+
+int update_global_cache(wifi_vap_info_map_t *tgt_vap_map, rdk_wifi_vap_info_t *rdk_vap_info)
+{
+    uint8_t j = 0;
+    rdk_wifi_vap_info_t *rdk_vaps;
+    wifi_vap_info_map_t *vap_map = NULL;
+    uint8_t i = 0, vap_index = 0;
+
+    for (i = 0; i < tgt_vap_map->num_vaps; i++) {
+        vap_index = tgt_vap_map->vap_array[i].vap_index;
+        vap_map = (wifi_vap_info_map_t *)get_wifidb_vap_map(tgt_vap_map->vap_array[i].radio_index);
+        if (vap_map == NULL) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d global vap_map null radio_index:%d\n", __func__,
+                __LINE__, tgt_vap_map->vap_array[i].radio_index);
+            return RETURN_ERR;
+        }
+        rdk_vaps = get_wifidb_rdk_vaps(tgt_vap_map->vap_array[i].radio_index);
+        if (rdk_vaps == NULL) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d failed to get rdk vaps for radio index: %d\n",
+                __func__, __LINE__, tgt_vap_map->vap_array[i].radio_index);
+            return RETURN_ERR;
+        }
+        for (j = 0; j < vap_map->num_vaps; j++) {
+            if (vap_map->vap_array[j].vap_index == vap_index) {
+                memcpy((unsigned char *)&vap_map->vap_array[j],
+                    (unsigned char *)&tgt_vap_map->vap_array[i], sizeof(wifi_vap_info_t));
+                memcpy(&rdk_vaps[j], &rdk_vap_info[i], sizeof(rdk_wifi_vap_info_t));
+                break;
+            }
+        }
+    }
+
+    return RETURN_OK;
+}
+
+#if defined(_PLATFORM_BANANAPI_R4_)
+int update_dml_cache(wifi_ctrl_t *ctrl, webconfig_subdoc_data_t *dml_cache_update_subdoc)
+{
+    int ret = RETURN_OK;
+    ctrl->webconfig_state |= ctrl_webconfig_state_vap_all_cfg_rsp_pending;
+    if (webconfig_encode(&ctrl->webconfig, dml_cache_update_subdoc, webconfig_subdoc_type_dml) ==
+        webconfig_error_none) {
+        wifi_util_info_print(WIFI_CTRL, "%s:%d webconfig_encode success\n", __FUNCTION__, __LINE__);
+    } else {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d webconfig_encode failed ! DML cache may store incorrect values !\n",
+            __FUNCTION__, __LINE__);
+        ctrl->webconfig_state &= ~ctrl_webconfig_state_vap_all_cfg_rsp_pending;
+        ret = RETURN_ERR;
+    }
+    webconfig_data_free(dml_cache_update_subdoc);
+    return ret;
+}
+#endif

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -431,11 +431,14 @@ int publish_endpoint_enable(void);
 int get_mld_mac_from_link_mac(mac_address_t in_addr, mac_address_t mld_addr);
 void hotspot_timing_start(void);
 void hotspot_timing_stop(void);
-
 #if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
 unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
     char **vap_names, unsigned int vap_names_size, wifi_dbg_type_t log_type);
 #endif /* CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO */
+int update_global_cache(wifi_vap_info_map_t *tgt_vap_map, rdk_wifi_vap_info_t *rdk_vap_info);
+#if defined(_PLATFORM_BANANAPI_R4_)
+int update_dml_cache(wifi_ctrl_t *ctrl, webconfig_subdoc_data_t *dml_cache_update_subdoc);
+#endif
 
 #ifdef __cplusplus
 }

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -821,6 +821,7 @@ int webconfig_bus_apply_for_dml_thread_update(wifi_ctrl_t *ctrl,
     memset(&rdata, 0, sizeof(raw_data_t));
     rdata.data_type = bus_data_type_string;
     rdata.raw_data.bytes = (void *)data->raw;
+    rdata.raw_data_len = strlen(data->raw) + 1;
 
     rc = get_bus_descriptor()->bus_event_publish_fn(&ctrl->handle, WIFI_WEBCONFIG_INIT_DML_DATA,
         &rdata);


### PR DESCRIPTION
This is an initial fix rollout for BPi for stale DML cache in case of vap_info struct updates coming from HAL.

Using WebConfig we are synchronizing the current manager cache with DML cache if params that were passed down to createVAP() change after the funcion finalizes.

This is currently being done for private and public VAPs. mesh/lnf and others might require subtle changes, this is under investigation.
