### PR TITLE
XER10-2609: SelfHeal shouldn't enable LnF VAPs in sky environment

### DIFF
--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -225,6 +225,15 @@ onewifi_conn_clients_count() {
 
 check_lnf_status()
 {
+    #if LnF is not enabled and wl0.4/wl1.4 are not enabled, dmcli call will
+    #create extra log in the cloud, which we want to avoid
+    lnf_2g_enabled="$(nvram get wl0.4_bss_enabled)"
+    lnf_5g_enabled="$(nvram get wl1.4_bss_enabled)"
+    if [ "$lnf_2g_enabled" = "0" ] && [ "$lnf_5g_enabled" = "0" ]; then
+        echo_t "Selfheal 2g&5g LNFs disabled, won't check and bring lnf up" >> /rdklogs/logs/wifi_selfheal.txt
+        return
+    fi
+    echo_t "Selfheal doing LNF" >> /rdklogs/logs/wifi_selfheal.txt
     radio_status_2g=`dmcli eRT retv Device.WiFi.Radio.$radio_2g_instance.Enable`
     if [ "$radio_status_2g" == "true" ]; then
         if ! ovs-vsctl list-ifaces br106 | grep -q "wl0.4"; then
@@ -529,8 +538,17 @@ do
 
     # Check if OneWifi process RSS memory usage exceeds threshold, if does restart OneWifi.
     onewifi_mem_restart
-    if [ "$MODEL_NUM" != "SR213" ] && [ "$MODEL_NUM" != "GR-EXT02A-CTS" ] && [ "$MODEL_NUM" != "SR203" ] && [ "$MODEL_NUM" != "$TG4" ]; then
+    # Check LnF vaps, but only on XB7/8 and XB10
+    if [ "$MODEL_NUM" = "CGM601TCOM" ] || [ "$MODEL_NUM" = "CGM43" ] || [ "$MODEL_NUM" = "CGM49" ] || [ "$MODEL_NUM" = "SG417DBCT" ]; then
+        customerId="$(syscfg get PartnerID | tr '[:upper:]' '[:lower:]')"
+        case "$customerId" in
+            sky*)
+                :
+                ;;
+            *)
         check_lnf_status
+                ;;
+        esac
     fi
     sleep 5m
     ((check_count++))

--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -230,10 +230,8 @@ check_lnf_status()
     lnf_2g_enabled="$(nvram get wl0.4_bss_enabled)"
     lnf_5g_enabled="$(nvram get wl1.4_bss_enabled)"
     if [ "$lnf_2g_enabled" = "0" ] && [ "$lnf_5g_enabled" = "0" ]; then
-        echo_t "Selfheal 2g&5g LNFs disabled, won't check and bring lnf up" >> /rdklogs/logs/wifi_selfheal.txt
         return
     fi
-    echo_t "Selfheal doing LNF" >> /rdklogs/logs/wifi_selfheal.txt
     radio_status_2g=`dmcli eRT retv Device.WiFi.Radio.$radio_2g_instance.Enable`
     if [ "$radio_status_2g" == "true" ]; then
         if ! ovs-vsctl list-ifaces br106 | grep -q "wl0.4"; then


### PR DESCRIPTION
Cherry pick from branch release/8.4_p1b , PR#993
Sky environment does not use LnF vaps. However Selfheal script did not discriminate between customers and tried to bring up LnF vaps regardles..
This adds check to prevent such actions in Sky.