### PR TITLE
RDKB-64839 Fix memory leaks in bus_insert_elem_node on duplicate elem…

### DIFF
--- a/source/platform/common/bus_common.c
+++ b/source/platform/common/bus_common.c
@@ -231,7 +231,7 @@ elem_node_map_t* bus_insert_elem_node(elem_node_map_t* root, bus_mux_data_elem_t
     elem_node_map_t* current_node = root;
     elem_node_map_t* temp_node    = NULL;
     elem_node_map_t* next_node    = NULL;
-    int  ret = 0, create_child   = 0;
+    int  create_child             = 0;
     char buff[256];
 
     if(current_node == NULL || elem == NULL)
@@ -343,15 +343,14 @@ elem_node_map_t* bus_insert_elem_node(elem_node_map_t* root, bus_mux_data_elem_t
         }
         token = strtok_r(NULL, ".", &saveptr);
     }
-    if(ret != 0)
-    {
-
-        BUS_MUX_UNLOCK(get_bus_mux_mutex());
-        return NULL;
-    }
 
     current_node->type           = elem->type;
     current_node->node_data_type = elem->node_data_type;
+    if (current_node->node_elem_data != NULL) {
+        free(current_node->node_elem_data);
+        current_node->node_elem_data = NULL;
+        current_node->node_elem_data_len = 0;
+    }
     current_node->node_elem_data = malloc(elem->cfg_data_len);
     if(current_node->node_elem_data == NULL)
     {
@@ -362,13 +361,16 @@ elem_node_map_t* bus_insert_elem_node(elem_node_map_t* root, bus_mux_data_elem_t
     memcpy(current_node->node_elem_data, elem->cfg_data, elem->cfg_data_len);
     current_node->node_elem_data_len = elem->cfg_data_len;
 
-    if(elem->type == bus_element_type_table)
+    if(elem->type == bus_element_type_table && current_node->child == NULL)
     {
         elem_node_map_t* rowTemplate = get_empty_elem_node();
         if(rowTemplate == NULL)
         {
             wifi_util_error_print(WIFI_BUS, "Failed to create node [%s]\n",
                  elem->full_name);
+            free(current_node->node_elem_data);
+            current_node->node_elem_data = NULL;
+            current_node->node_elem_data_len = 0;
             BUS_MUX_UNLOCK(get_bus_mux_mutex());
             return NULL;
         }


### PR DESCRIPTION
…ent insertion

Reason for change: Memory leak in onewifi process
Test Procedure: Debug
Priority: P1
Risks: Low