### PR TITLE
RDKBWIFI-445: Fixed binary data comparison in webconfig

### DIFF
--- a/include/webconfig_external_proto_easymesh.h
+++ b/include/webconfig_external_proto_easymesh.h
@@ -47,7 +47,7 @@ typedef void (*ext_proto_update_ap_mld_info_t)(void *data_model, em_ap_mld_info_
 typedef void (*ext_proto_update_bsta_mld_info_t)(void *data_model, em_bsta_mld_info_t *bsta_mld_info);
 typedef void (*ext_proto_update_assoc_sta_mld_info_t)(void *data_model, em_assoc_sta_mld_info_t *assoc_sta_mld_info);
 typedef em_ap_mld_info_t * (*ext_proto_get_ap_mld_frm_bssid_t)(void *data_model, mac_address_t bss_id);
-typedef em_radio_cap_info_t * (*ext_proto_get_radio_cap_t)(void *data_model, int index);
+typedef em_radio_cap_info_t * (*ext_proto_get_radio_cap_t)(void *data_model, unsigned int radio_index);
 
 typedef struct {
     void *data_model; /* agent data model dm_easy_mesh_t */

--- a/source/webconfig/wifi_easymesh_translator.c
+++ b/source/webconfig/wifi_easymesh_translator.c
@@ -1653,7 +1653,7 @@ webconfig_error_t translate_ap_metrics_report_to_easy_mesh_bss_info(webconfig_su
             int found = 0;
             for (int k = 0; k < MAX_NUM_VAP_PER_RADIO; k++) {
                 ap_metrics = &em_ap_report->radio_reports[i].vap_reports[k];
-                if (strncmp(ap_metrics->vap_metrics.bssid, vap->u.bss_info.bssid, sizeof(bssid_t)) == 0) {
+                if (memcmp(ap_metrics->vap_metrics.bssid, vap->u.bss_info.bssid, sizeof(bssid_t)) == 0) {
                     found = 1;
                     break;
                 }

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -3751,7 +3751,7 @@ webconfig_error_t encode_em_ap_metrics_report_object(rdk_wifi_radio_t *radio,
         vap_arr_index = -1;
         for (int k = 0; k < MAX_NUM_VAP_PER_RADIO; k++) {
             ap_metrics = &radio_report->vap_reports[k];
-            if (strncmp(vap->u.bss_info.bssid, ap_metrics->vap_metrics.bssid,
+            if (memcmp(vap->u.bss_info.bssid, ap_metrics->vap_metrics.bssid,
                 sizeof(bssid_t)) == 0) {
                     vap_arr_index = k;
                     break;


### PR DESCRIPTION
Reason for change: AP metric report shows statistic for all VAP's from first VAP including the STA report
After investigation we found binary data comparing using strncmp, mac is starting with `0`, treaded as comparison of two 0-length strings and always returning true.
Also fixed signature of ext_proto_get_radio_cap_t callback, to use unsigned int type for radio_index

Test procedure: AP metric report should statistic for correct VAP
After STA connection statistic should be available only on one VAP
(without the patch it will be shown on all VAP's)
 
Priority: Critical
Risk: Low