### PR TITLE
RDKB-63637 Decoupling Amenities network from the Secure Hotspot (#922) (#1023)

### DIFF
--- a/source/core/services/vap_svc_private.c
+++ b/source/core/services/vap_svc_private.c
@@ -54,7 +54,7 @@ int vap_svc_private_stop(vap_svc_t *svc, unsigned int radio_index, wifi_vap_info
 
 static int configure_lnf_psk_radius_from_hotspot(wifi_vap_info_t *vap_info)
 {
-    int band;
+  int band;
     wifi_vap_info_t *hotspot_vap_info = NULL;
     int rIdx = 0;
     if (!vap_info) {
@@ -71,13 +71,12 @@ static int configure_lnf_psk_radius_from_hotspot(wifi_vap_info_t *vap_info)
                              __FUNCTION__, __LINE__, vap_info->vap_index);
         return -1;
     }
-
-    if (band == WIFI_FREQUENCY_2_4_BAND) {
-        convert_freq_band_to_radio_index(WIFI_FREQUENCY_5_BAND, &rIdx);
-        hotspot_vap_info = get_wifidb_vap_parameters(getApFromRadioIndex(rIdx, VAP_PREFIX_HOTSPOT_SECURE));
-    } else {
-        hotspot_vap_info = get_wifidb_vap_parameters(getApFromRadioIndex(vap_info->radio_index, VAP_PREFIX_HOTSPOT_SECURE));
+    
+    if (convert_freq_band_to_radio_index(WIFI_FREQUENCY_5_BAND, &rIdx) != RETURN_OK) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to convert freq to band\n", __FUNCTION__, __LINE__);
+        return -1;
     }
+    hotspot_vap_info = get_wifidb_vap_parameters(getApFromRadioIndex(rIdx, VAP_PREFIX_HOTSPOT_SECURE));
 
     if (hotspot_vap_info == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to get hotspot_vap_info for vap_index=%d\n", 

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -816,13 +816,15 @@ void process_xfinity_vaps(wifi_hotspot_action_t param, bool hs_evt)
     vap_svc_t  *pub_svc = NULL;
     wifi_ctrl_t *ctrl;
     ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
-    wifi_vap_info_t *lnf_2g_vap = NULL, *lnf_vap_info = NULL, hotspot_5g_vap_info = { 0 };
+    wifi_vap_info_t *lnf_2g_vap = NULL, *lnf_6g_vap = NULL, *lnf_vap_info = NULL, hotspot_5g_vap_info = { 0 };
     wifi_platform_property_t *wifi_prop = (&(get_wifimgr_obj())->hal_cap.wifi_prop);
     uint8_t num_radios = getNumberRadios();
     bool open_2g_enabled = false, open_5g_enabled = false, open_6g_enabled = false,sec_2g_enabled = false,sec_5g_enabled = false, sec_6g_enabled = false;
     wifi_rfc_dml_parameters_t *rfc_param = (wifi_rfc_dml_parameters_t *)get_wifi_db_rfc_parameters();
     pub_svc = get_svc_by_type(ctrl, vap_svc_type_public);
     wifi_vap_info_map_t *tmp_vap_map = NULL;
+
+    bool hotspot_5g_found = false;
 
     tmp_vap_map = (wifi_vap_info_map_t *)malloc(sizeof(wifi_vap_info_map_t));
     if (tmp_vap_map == NULL) {
@@ -836,6 +838,9 @@ void process_xfinity_vaps(wifi_hotspot_action_t param, bool hs_evt)
         lnf_vap_info = (wifi_vap_info_t *)get_wifidb_vap_parameters(getApFromRadioIndex(radio_indx, VAP_PREFIX_LNF_PSK));
         if (lnf_vap_info && strstr(lnf_vap_info->vap_name, NAME_FREQUENCY_2_4_G) != NULL) {
             lnf_2g_vap = lnf_vap_info;
+        }
+        if (lnf_vap_info && strstr(lnf_vap_info->vap_name, NAME_FREQUENCY_6_G) != NULL) {
+            lnf_6g_vap = lnf_vap_info;
         }
         for(unsigned int j = 0; j < wifi_vap_map->num_vaps; ++j) {
             if(strstr(wifi_vap_map->vap_array[j].vap_name, "hotspot") == NULL) {
@@ -891,6 +896,7 @@ void process_xfinity_vaps(wifi_hotspot_action_t param, bool hs_evt)
             if (isVapHotspotSecure5g(wifi_vap_map->vap_array[j].vap_index))
             {
                 memcpy((unsigned char *)&hotspot_5g_vap_info, (unsigned char *)&tmp_vap_map->vap_array[0], sizeof(wifi_vap_info_t));
+                hotspot_5g_found = true;
             }
             if(pub_svc->update_fn(pub_svc,radio_indx, tmp_vap_map, rdk_vap_info) != RETURN_OK) {
                 wifi_util_error_print(WIFI_CTRL, "%s:%d Unable to create vaps\n", __func__,__LINE__);
@@ -910,9 +916,9 @@ void process_xfinity_vaps(wifi_hotspot_action_t param, bool hs_evt)
                     tmp_vap_map = NULL;
                     return;
                 }
-                if (!strstr(lnf_vap_info->vap_name, NAME_FREQUENCY_2_4_G) && should_process_hotspot_config_change(lnf_vap_info, &tmp_vap_map->vap_array[0])) {
+                if (!strstr(lnf_vap_info->vap_name, NAME_FREQUENCY_2_4_G) && !strstr(lnf_vap_info->vap_name, NAME_FREQUENCY_6_G) && should_process_hotspot_config_change(lnf_vap_info, &tmp_vap_map->vap_array[0])) {
                     if (update_vap_params_to_hal_and_db(lnf_vap_info, tmp_vap_map->vap_array[0].u.bss_info.enabled) == -1) {
-                        wifi_util_error_print(WIFI_CTRL, "%s:%d Unable to update LnF vaps as per Hotspot VAPs\n", __func__,__LINE__);
+                        wifi_util_error_print(WIFI_CTRL, "%s:%d Unable to update LnF VAP RADIUS config from Hotspot 5G\n", __func__,__LINE__);
                         free(tmp_vap_map);
                         tmp_vap_map = NULL;
                         return;
@@ -935,14 +941,17 @@ void process_xfinity_vaps(wifi_hotspot_action_t param, bool hs_evt)
     if (!lnf_2g_vap)
     {
         wifi_util_error_print(WIFI_CTRL,"%s:%d LnF 2.4GHz VAP is NULL\n", __func__,__LINE__);
-        return;
-    }
-    if (should_process_hotspot_config_change(lnf_2g_vap, &hotspot_5g_vap_info)) {
-        if (update_vap_params_to_hal_and_db(lnf_2g_vap, hotspot_5g_vap_info.u.bss_info.enabled) == -1)
-        {
-            wifi_util_info_print(WIFI_CTRL, "%s:%d Unable to update LnF vaps as per Hotspot VAPs\n", __func__,__LINE__);
+    } else if (hotspot_5g_found && should_process_hotspot_config_change(lnf_2g_vap, &hotspot_5g_vap_info)) {
+        if (update_vap_params_to_hal_and_db(lnf_2g_vap, lnf_2g_vap->u.bss_info.enabled) == -1) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d Unable to update LnF 2G vaps\n", __func__,__LINE__);
         }
-        wifi_util_info_print(WIFI_CTRL,"%s:%d LnF VAP %s config changed as per %s event\n",__func__,__LINE__,lnf_vap_info->vap_name ,wifi_hotspot_action_to_string(param));
+        wifi_util_info_print(WIFI_CTRL,"%s:%d LnF VAP %s RADIUS config updated from Hotspot 5G\n",__func__,__LINE__,lnf_2g_vap->vap_name);
+    }
+    if (hotspot_5g_found && lnf_6g_vap && should_process_hotspot_config_change(lnf_6g_vap, &hotspot_5g_vap_info)) {
+        if (update_vap_params_to_hal_and_db(lnf_6g_vap, lnf_6g_vap->u.bss_info.enabled) == -1){
+            wifi_util_error_print(WIFI_CTRL, "%s:%d Unable to update LnF 6g vaps\n", __func__,__LINE__);
+        }
+        wifi_util_info_print(WIFI_CTRL,"%s:%d LnF VAP %s RADIUS config updated from Hotspot 5G\n",__func__,__LINE__,lnf_6g_vap->vap_name);
     }
 }
 

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -2523,40 +2523,30 @@ void webconfig_analytic_event_data_to_hal_apply(webconfig_subdoc_data_t *data)
 
 void process_managed_wifi_enable()
 {
-    wifi_vap_info_t *hotspot5g_vap_info = NULL;
-    for (UINT rIdx = 1; rIdx < getNumberRadios(); rIdx++) {
+   /* Use Hotspot Secure 5G VAP as the RADIUS source for all LnF bands.*/
+    int r5g = 0;
+    if (convert_freq_band_to_radio_index(WIFI_FREQUENCY_5_BAND, &r5g) != RETURN_OK) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to get 5G radio index\n", __func__, __LINE__);
+        return;
+    }
+    UINT hotspot5g_ap = getApFromRadioIndex(r5g, VAP_PREFIX_HOTSPOT_SECURE);
+    wifi_vap_info_t *hotspot5g_vap_info = get_wifidb_vap_parameters(hotspot5g_ap);
+    if (!hotspot5g_vap_info) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Hotspot 5G Secure VAP info not found\n", __func__, __LINE__);
+        return;
+    }
+
+    for (UINT rIdx = 0; rIdx < getNumberRadios(); rIdx++) {
         UINT lnf_ap_index = getApFromRadioIndex(rIdx, VAP_PREFIX_LNF_PSK);
-        UINT hotspot_ap_index = getApFromRadioIndex(rIdx, VAP_PREFIX_HOTSPOT_SECURE);
-
         wifi_vap_info_t *lnf_vap_info = get_wifidb_vap_parameters(lnf_ap_index);
-        wifi_vap_info_t *hotspot_vap_info = get_wifidb_vap_parameters(hotspot_ap_index);
-
-        if (!lnf_vap_info || !hotspot_vap_info) {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to get LNF or Hotspot VAP info for radio %u\n", __func__, __LINE__, rIdx);
+        if (!lnf_vap_info) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to get LNF VAP info for radio %u\n", __func__, __LINE__, rIdx);
             continue;
         }
-        if (isVapHotspotSecure5g(hotspot_ap_index)) {
-            hotspot5g_vap_info = hotspot_vap_info;
+        if (should_process_hotspot_config_change(lnf_vap_info, hotspot5g_vap_info)) {
+            update_vap_params_to_hal_and_db(lnf_vap_info, lnf_vap_info->u.bss_info.enabled);
+            wifi_util_info_print(WIFI_CTRL,"%s:%d LnF VAP %s RADIUS config updated from Hotspot 5G\n",__func__,__LINE__,lnf_vap_info->vap_name);
         }
-        if (should_process_hotspot_config_change(lnf_vap_info, hotspot_vap_info)) {
-            update_vap_params_to_hal_and_db(lnf_vap_info, hotspot_vap_info->u.bss_info.enabled);
-            wifi_util_info_print(WIFI_CTRL,"%s:%d LnF VAP %s config changed as per %s event\n",__func__,__LINE__,lnf_vap_info->vap_name, hotspot_vap_info->u.bss_info.enabled?"Hotspot VAP Up":"Hotspot VAP Down");
-        }
-    }
-
-    UINT lnf_ap_index_0 = getApFromRadioIndex(0, VAP_PREFIX_LNF_PSK);
-    wifi_vap_info_t *lnf_vap_info_0 = get_wifidb_vap_parameters(lnf_ap_index_0);
-    if (!lnf_vap_info_0) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to get LNF VAP info for index %u\n", __func__, __LINE__, lnf_ap_index_0);
-        return;
-    }
-    if (!hotspot5g_vap_info) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d Hotspot 5G Secure VAP info not found, cannot update LNF radio 0\n", __func__, __LINE__);
-        return;
-    }
-    if (should_process_hotspot_config_change(lnf_vap_info_0, hotspot5g_vap_info)) {
-        update_vap_params_to_hal_and_db(lnf_vap_info_0, hotspot5g_vap_info->u.bss_info.enabled);
-        wifi_util_info_print(WIFI_CTRL,"%s:%d LnF VAP %s config changed as per %s event\n",__func__,__LINE__,lnf_vap_info_0->vap_name, hotspot5g_vap_info->u.bss_info.enabled?"Hotspot VAP Up":"Hotspot VAP Down");
     }
 }
 

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -2290,22 +2290,22 @@ bool should_process_hotspot_config_change(const wifi_vap_info_t *lnf_vap_info,
                                          const wifi_vap_info_t *hotspot_vap_info)
 {
     wifi_util_dbg_print(WIFI_CTRL, "%s: Entry\n", __func__);
-    
+
     if (!lnf_vap_info || !hotspot_vap_info) {
         wifi_util_error_print(WIFI_CTRL, "%s: NULL pointer check failed - lnf_vap_info=%p, hotspot_vap_info=%p\n", 
                              __func__, lnf_vap_info, hotspot_vap_info);
         return false;
     }
-    
+
     wifi_util_dbg_print(WIFI_CTRL, "%s: lnf_vap_name=%s, hotspot_vap_name=%s\n", 
                        __func__, 
                        lnf_vap_info->vap_name ? lnf_vap_info->vap_name : "NULL",
                        hotspot_vap_info->vap_name ? hotspot_vap_info->vap_name : "NULL");
-    
+
     bool is_mdu_enabled = lnf_vap_info->u.bss_info.mdu_enabled;
     wifi_util_dbg_print(WIFI_CTRL, "%s: is_mdu_enabled=%s\n", 
                        __func__, is_mdu_enabled ? "true" : "false");
-    
+
     bool is_secure_hotspot = !strncmp(hotspot_vap_info->vap_name, 
                                      VAP_PREFIX_HOTSPOT_SECURE,
                                      strlen(VAP_PREFIX_HOTSPOT_SECURE));
@@ -2314,39 +2314,28 @@ bool should_process_hotspot_config_change(const wifi_vap_info_t *lnf_vap_info,
                        is_secure_hotspot ? "true" : "false",
                        hotspot_vap_info->vap_name ? hotspot_vap_info->vap_name : "NULL",
                        VAP_PREFIX_HOTSPOT_SECURE);
-    
-    bool lnf_enabled = lnf_vap_info->u.bss_info.enabled;
-    bool hotspot_enabled = hotspot_vap_info->u.bss_info.enabled;
-    bool vap_enabled_changed = (lnf_enabled != hotspot_enabled);
-    wifi_util_dbg_print(WIFI_CTRL, "%s: vap_enabled_changed=%s (lnf_enabled=%s, hotspot_enabled=%s)\n", 
-                       __func__, 
-                       vap_enabled_changed ? "true" : "false",
-                       lnf_enabled ? "true" : "false",
-                       hotspot_enabled ? "true" : "false");
-    
+
     bool radius_config_changed = wifi_radius_config_changed(
         &lnf_vap_info->u.bss_info.security.repurposed_radius,
         &hotspot_vap_info->u.bss_info.security.u.radius);
     wifi_util_dbg_print(WIFI_CTRL, "%s: radius_config_changed=%s\n", 
                        __func__, radius_config_changed ? "true" : "false");
-    
+
     bool result = (is_mdu_enabled &&
                   is_secure_hotspot &&
-                  (vap_enabled_changed || radius_config_changed));
-    
-    wifi_util_info_print(WIFI_CTRL, "%s: Hotspot vap_name is %s & LnF vap_name is %s and bool is %d:%d:%d:%d:%d - result=%s\n", 
+                  radius_config_changed);
+
+    wifi_util_info_print(WIFI_CTRL, "%s: Hotspot vap_name is %s & LnF vap_name is %s and bool is %d:%d:%d - result=%s\n", 
                         __func__,
                         hotspot_vap_info->vap_name ? hotspot_vap_info->vap_name : "NULL",
                         lnf_vap_info->vap_name ? lnf_vap_info->vap_name : "NULL",
                         is_mdu_enabled ? 1 : 0,
                         is_secure_hotspot ? 1 : 0,
-                        vap_enabled_changed ? 1 : 0,
                         radius_config_changed ? 1 : 0,
-                        (vap_enabled_changed || radius_config_changed) ? 1 : 0,
                         result ? "true" : "false");
-    
+
     wifi_util_dbg_print(WIFI_CTRL, "%s: Exit - returning %s\n", __func__, result ? "true" : "false");
-    
+
     return result;
 }
 


### PR DESCRIPTION
RDKB-63637 Decoupling Amenities network from the Secure Hotspot Reason for change: Amenities network SSIDs are not enabled without the Secure Hotspot SSIDs being enabled

Test Procedure:

check if Secure Hotspot is disabled
Push LNF blob to enable it
verify that the interfaces wl0.4, wl1.4, wl2.4 are present. Check the repurposed RADIUS IP and confirm it matches the 5G RADIUS server IP. Confirm that the client is able to connect lnf VAP

Priority: P1
Risks: Low
Signed-off-by: Sneha Kannansneha_kannan@comcast.com

Signed-off-by: Sneha Kannansneha_kannan@comcast.com