### PR TITLE
RDKB-64275:OneWiFi continuously restarting after software upgrade to 8.3 from 6.7/7.6 

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4916,29 +4916,7 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
                 }
             }
         }
-#ifdef CONFIG_IEEE80211BE
-        if (g_wifidb->db_version < ONEWIFI_DB_VERSION_ENCR_GCMP_FLAG) {
-            wifi_vap_security_t *sec = NULL;
-            if (!isVapSTAMesh(config->vap_array[i].vap_index)) {
-                sec = &config->vap_array[i].u.bss_info.security;
-            } else {
-                sec = &config->vap_array[i].u.sta_info.security;
-            }
 
-            if (sec->encr == wifi_encryption_aes &&
-                (sec->mode == wifi_security_mode_enhanced_open ||
-                    sec->mode == wifi_security_mode_wpa3_enterprise ||
-                    sec->mode == wifi_security_mode_wpa3_personal ||
-                    sec->mode == wifi_security_mode_wpa3_compatibility ||
-                    sec->mode == wifi_security_mode_wpa3_transition)) {
-                sec->encr = wifi_encryption_aes_gcmp256;
-                is_vap_sec_upgrade_needed = true;
-                wifi_util_info_print(WIFI_DB,
-                    "%s:%d force change encryption type to AES+GCMP for vap:%s\r\n",
-                    __func__, __LINE__, config->vap_array[i].vap_name);
-            }
-        }
-#endif /* CONFIG_IEEE80211BE */
         if (is_vap_info_upgrade_needed) {
             int ret = wifidb_update_wifi_vap_info(config->vap_array[i].vap_name,
                         &config->vap_array[i], &rdk_config[i]);

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -4770,6 +4770,8 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
     unsigned int i;
     wifi_ctrl_t *ctrl = get_wifictrl_obj();
     wifi_mgr_t *g_wifidb = get_wifimgr_obj();
+    bool is_vap_info_upgrade_needed = false;
+    bool is_vap_sec_upgrade_needed = false;
 
     if (g_wifidb->db_version == 0) {
         return;
@@ -4779,11 +4781,12 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
         __LINE__, g_wifidb->db_version);
 
     for (i = 0; i < config->num_vaps; i++) {
+        is_vap_info_upgrade_needed = false;
+        is_vap_sec_upgrade_needed = false;
         if (g_wifidb->db_version < ONEWIFI_DB_VERSION_EXISTS_FLAG) {
             if (ctrl->network_mode != rdk_dev_mode_type_ext) {
                 rdk_config[i].exists = true;
-                wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
-                    &rdk_config[i]);
+                is_vap_info_upgrade_needed = true;
             }
         }
 #if !defined(_WNXL11BWL_PRODUCT_REQ_) && !defined(_PP203X_PRODUCT_REQ_) && !defined(_GREXT02ACTS_PRODUCT_REQ_)
@@ -4807,8 +4810,7 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
             !isVapSTAMesh(config->vap_array[i].vap_index)) {
             config->vap_array[i].u.bss_info.mbo_enabled = !isVapPrivate(
                 config->vap_array[i].vap_index);
-            wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
-                &rdk_config[i]);
+            is_vap_info_upgrade_needed = true;
         }
         if (g_wifidb->db_version < ONEWIFI_DB_VERSION_TCM_FLAG) {
             wifi_util_info_print(WIFI_DB, "%s:%d upgrade vap config, db version %d\n", __func__,
@@ -4831,11 +4833,9 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
                     config->vap_array[i].u.bss_info.security.mfp = wifi_mfp_cfg_required;
                 }
 #endif /* CONFIG_IEEE80211BE */			
-                wifi_util_info_print(WIFI_DB, "%s Update security mode:%d mfp:%d \n", __func__,
-                    config->vap_array[i].u.bss_info.security.mode,
-                    config->vap_array[i].u.bss_info.security.mfp);
-                wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
-                    &rdk_config[i]);
+                wifi_util_info_print(WIFI_DB, "%s Update security mode:%d mfp:%d \n", __func__, config->vap_array[i].u.bss_info.security.mode,
+                        config->vap_array[i].u.bss_info.security.mfp);
+                is_vap_info_upgrade_needed = true;
             }
         }
 
@@ -4849,8 +4849,7 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
                     "%s:%d Update hostap_mgt_frame_ctrl:%d for vap_index:%d \n", __func__, __LINE__,
                     config->vap_array[i].u.bss_info.hostap_mgt_frame_ctrl,
                     config->vap_array[i].vap_index);
-                wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
-                    &rdk_config[i]);
+                is_vap_info_upgrade_needed = true;
             }
 #endif // defined(_XB7_PRODUCT_REQ_) || defined(_XB8_PRODUCT_REQ_) || defined(_XB10_PRODUCT_REQ_) ||
        // defined(_SCER11BEL_PRODUCT_REQ_) || defined(_CBR2_PRODUCT_REQ_) ||
@@ -4864,8 +4863,7 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
                 "%s:%d Update interop_ctrl:%d inum_sta:%d for vap_index:%d \n", __func__, __LINE__,
                 config->vap_array[i].u.bss_info.interop_ctrl,config->vap_array[i].u.bss_info.inum_sta,
                 config->vap_array[i].vap_index);
-            wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
-                &rdk_config[i]);
+            is_vap_info_upgrade_needed = true;
         }
 
         if (g_wifidb->db_version < ONEWIFI_DB_VERSION_MANAGED_WIFI_FLAG) {
@@ -4874,8 +4872,7 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
             wifi_util_dbg_print(WIFI_DB, "%s:%d Update speed_tier:%d for vap_index:%d \n", __func__,
                 __LINE__, config->vap_array[i].u.bss_info.am_config.npc.speed_tier,
                 config->vap_array[i].vap_index);
-            wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
-                &rdk_config[i]);
+            is_vap_info_upgrade_needed = true;
         }
 
         if (g_wifidb->db_version < ONEWIFI_DB_VERSION_WPA3_T_DISABLE_FLAG) {
@@ -4889,10 +4886,10 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
 
             if (sec->wpa3_transition_disable != false) {
                 sec->wpa3_transition_disable = false;
-                int ret = wifidb_update_wifi_security_config(config->vap_array[i].vap_name, sec);
+                is_vap_sec_upgrade_needed = true;
                 wifi_util_info_print(WIFI_DB, "%s:%d force change wpa3 transition"
-                    " disable state to false for vap:%s ret:%d\r\n", __func__, __LINE__,
-                    config->vap_array[i].vap_name, ret);
+                    " disable state to false for vap:%s\r\n", __func__, __LINE__,
+                    config->vap_array[i].vap_name);
             }
         }
         if (g_wifidb->db_version < ONEWIFI_DB_VERSION_UPDATE_MLD_FLAG) {
@@ -4903,8 +4900,7 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
                 config->vap_array[i].u.bss_info.mld_info.common_info.mld_id = 255;
                 config->vap_array[i].u.bss_info.mld_info.common_info.mld_link_id = 255;
                 config->vap_array[i].u.bss_info.mld_info.common_info.mld_apply = 1;
-                wifidb_update_wifi_vap_info(config->vap_array[i].vap_name, &config->vap_array[i],
-                    &rdk_config[i]);
+                is_vap_info_upgrade_needed = true;
             }
         }
         if (g_wifidb->db_version < ONEWIFI_DB_VERSION_UPDATE_MULTI_MLD_UNIT_FLAG) {
@@ -4916,10 +4912,52 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
                         __func__, __LINE__, g_wifidb->db_version, config->vap_array[i].vap_name);
                     config->vap_array[i].u.bss_info.mld_info.common_info.mld_link_id =
                         config->vap_array[0].u.bss_info.mld_info.common_info.mld_link_id;
-                    wifidb_update_wifi_vap_info(config->vap_array[i].vap_name,
-                        &config->vap_array[i], &rdk_config[i]);
+                    is_vap_info_upgrade_needed = true;
                 }
             }
+        }
+#ifdef CONFIG_IEEE80211BE
+        if (g_wifidb->db_version < ONEWIFI_DB_VERSION_ENCR_GCMP_FLAG) {
+            wifi_vap_security_t *sec = NULL;
+            if (!isVapSTAMesh(config->vap_array[i].vap_index)) {
+                sec = &config->vap_array[i].u.bss_info.security;
+            } else {
+                sec = &config->vap_array[i].u.sta_info.security;
+            }
+
+            if (sec->encr == wifi_encryption_aes &&
+                (sec->mode == wifi_security_mode_enhanced_open ||
+                    sec->mode == wifi_security_mode_wpa3_enterprise ||
+                    sec->mode == wifi_security_mode_wpa3_personal ||
+                    sec->mode == wifi_security_mode_wpa3_compatibility ||
+                    sec->mode == wifi_security_mode_wpa3_transition)) {
+                sec->encr = wifi_encryption_aes_gcmp256;
+                is_vap_sec_upgrade_needed = true;
+                wifi_util_info_print(WIFI_DB,
+                    "%s:%d force change encryption type to AES+GCMP for vap:%s\r\n",
+                    __func__, __LINE__, config->vap_array[i].vap_name);
+            }
+        }
+#endif /* CONFIG_IEEE80211BE */
+        if (is_vap_info_upgrade_needed) {
+            int ret = wifidb_update_wifi_vap_info(config->vap_array[i].vap_name,
+                        &config->vap_array[i], &rdk_config[i]);
+            wifi_util_info_print(WIFI_DB, "%s:%d wifidb update wifi vap info"
+                " for vap:%s ret:%d\r\n", __func__, __LINE__,
+                config->vap_array[i].vap_name, ret);
+        }
+        if (is_vap_sec_upgrade_needed) {
+            wifi_vap_security_t *sec = NULL;
+            if (!isVapSTAMesh(config->vap_array[i].vap_index)) {
+                sec = &config->vap_array[i].u.bss_info.security;
+            } else {
+                sec = &config->vap_array[i].u.sta_info.security;
+            }
+
+            int ret = wifidb_update_wifi_security_config(config->vap_array[i].vap_name, sec);
+            wifi_util_info_print(WIFI_DB, "%s:%d wifidb update wifi vap sec"
+                " for vap:%s ret:%d\r\n", __func__, __LINE__,
+                config->vap_array[i].vap_name, ret);
         }
     }
 }


### PR DESCRIPTION
Reason for change: Optimized wifidb_vap_config_upgrade function. Test Procedure: 1. Load OneWifi 7.7 Image on XLE.
                2. Upgrade device with latest fixed OneWifi Image.
                3. Please check OneWifi process to verify this.

Risks: Low
Priority: P1
Signed-off-by: apatel599@cable.comcast.com