### PR TITLE
RDKB-64763: Support of MLO VIFs and clients in OVSM

### DIFF
--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -3066,14 +3066,14 @@ webconfig_error_t  translate_sta_vap_info_to_vif_state_common(const wifi_vap_inf
     }
 
 #if defined(CONFIG_IEEE80211BE)
-    if (vap->u.bss_info.mld_info.common_info.mld_enable && vap->u.bss_info.mld_info.common_info.mld_id != UNDEFINED_MLD_ID) {
+    if (vap->u.sta_info.mld_info.common_info.mld_enable && vap->u.sta_info.mld_info.common_info.mld_id != UNDEFINED_MLD_ID) {
         // MLD_Addr
-        to_mac_str((unsigned char*)vap->u.bss_info.mld_info.common_info.mld_addr, vap_row->mld_addr);
+        to_mac_str((unsigned char*)vap->u.sta_info.mld_info.common_info.mld_addr, vap_row->mld_addr);
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_addr to %s\n", __func__, __LINE__, vap_row->mld_addr);
 
         // mld_if_name
         if (get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name))) {
-            wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
+            wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.sta_info.mld_info.common_info.mld_id);
         } else {
             wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: Couldn't find vap. vap_name = %s.\n", __func__, __LINE__, vap->vap_name);
         }

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -2845,8 +2845,12 @@ webconfig_error_t translate_vap_info_to_vif_state_common(const wifi_vap_info_t *
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_addr to %s\n", __func__, __LINE__, vap_row->mld_addr);
 
         // mld_if_name
-        get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name));
-        wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
+
+        if (get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name))) {
+            wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
+        } else {
+            wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: Couldn't find vap. vap_name = %s.\n", __func__, __LINE__, vap->vap_name);
+        }
     }
 #endif
 
@@ -3068,8 +3072,11 @@ webconfig_error_t  translate_sta_vap_info_to_vif_state_common(const wifi_vap_inf
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_addr to %s\n", __func__, __LINE__, vap_row->mld_addr);
 
         // mld_if_name
-        get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name));
-        wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
+        if (get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name))) {
+            wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
+        } else {
+            wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: Couldn't find vap. vap_name = %s.\n", __func__, __LINE__, vap->vap_name);
+        }
     }
 #endif
 

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -44,6 +44,7 @@
 #include "schema.h"
 #include "schema_gen.h"
 #include "webconfig_external_proto.h"
+#include "wifi_base.h"
 
 #define BLASTER_STATE_LEN    10
 #define INVALID_INDEX        256
@@ -2837,6 +2838,16 @@ webconfig_error_t translate_vap_info_to_vif_state_common(const wifi_vap_info_t *
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: No vif_radio_idx_conversion warning for %d\n", __func__, __LINE__, vap->vap_index);
     }
 
+    if (vap->u.bss_info.mld_info.common_info.mld_enable && vap->u.bss_info.mld_info.common_info.mld_id != UNDEFINED_MLD_ID) {
+        // MLD_Addr
+        to_mac_str((unsigned char*)vap->u.bss_info.mld_info.common_info.mld_addr, vap_row->mld_addr);
+        wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_addr to %s\n", __func__, __LINE__, vap_row->mld_addr);
+
+        // mld_if_name
+        get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name));
+        wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
+    }
+
     // Unset all unused parameters
     vap_row->wds_exists = false;
     vap_row->ft_mobility_domain_exists=false;
@@ -3046,6 +3057,16 @@ webconfig_error_t  translate_sta_vap_info_to_vif_state_common(const wifi_vap_inf
                                                     vap->u.sta_info.bssid[2], vap->u.sta_info.bssid[3],
                                                     vap->u.sta_info.bssid[4], vap->u.sta_info.bssid[5]);
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: vap_row->parent=%s\n", __func__, __LINE__, vap_row->parent);
+    }
+
+    if (vap->u.bss_info.mld_info.common_info.mld_enable && vap->u.bss_info.mld_info.common_info.mld_id != UNDEFINED_MLD_ID) {
+        // MLD_Addr
+        to_mac_str((unsigned char*)vap->u.bss_info.mld_info.common_info.mld_addr, vap_row->mld_addr);
+        wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_addr to %s\n", __func__, __LINE__, vap_row->mld_addr);
+
+        // mld_if_name
+        get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name));
+        wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
     }
 
     vap_row->vlan_id = iface_map->vlan_id;
@@ -3331,15 +3352,6 @@ webconfig_error_t translate_vap_object_to_ovsdb_associated_clients(const rdk_wif
         assoc_dev_data = hash_map_get_first(rdk_vap_info->associated_devices_map);
 
         while (assoc_dev_data != NULL) {
-            if (assoc_dev_data->dev_stats.cli_MLDEnable && !assoc_dev_data->association_link) {
-                /* Notify MLD client only on assoc link to be aligned with WebUI
-                 * This is backward compatibility alignment before final MLD client support in WebUI/ovsdb*/
-                wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: MLO STA - Skipping non assoc link, vap_name '%s'\n",
-                    __func__, __LINE__, rdk_vap_info->vap_name);
-                assoc_dev_data = hash_map_get_next(rdk_vap_info->associated_devices_map, assoc_dev_data);
-                continue;
-            }
-
             if (associated_client_count >= WEBCONFIG_MAX_ASSOCIATED_CLIENTS) {
                 wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: Exceeded max number of associated clients %d, vap_name '%s'\n", __func__, __LINE__, WEBCONFIG_MAX_ASSOCIATED_CLIENTS, rdk_vap_info->vap_name);
                 break;
@@ -3349,10 +3361,14 @@ webconfig_error_t translate_vap_object_to_ovsdb_associated_clients(const rdk_wif
                 wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: client row empty for the client number %d\n", __func__, __LINE__, associated_client_count);
                 return webconfig_error_translate_to_ovsdb;
             }
-            snprintf(client_row->mac, sizeof(client_row->mac), "%02x:%02x:%02x:%02x:%02x:%02x", assoc_dev_data->dev_stats.cli_MACAddress[0], assoc_dev_data->dev_stats.cli_MACAddress[1],
-                    assoc_dev_data->dev_stats.cli_MACAddress[2], assoc_dev_data->dev_stats.cli_MACAddress[3], assoc_dev_data->dev_stats.cli_MACAddress[4],
-                    assoc_dev_data->dev_stats.cli_MACAddress[5]);
 
+            if (assoc_dev_data->dev_stats.cli_MLDEnable) {
+                /* This is MLO client. Add mld_addr to the row. Use Link assdress for mac*/
+                to_mac_str(assoc_dev_data->dev_stats.cli_MACAddress, client_row->mld_addr);
+                to_mac_str(assoc_dev_data->link_address, client_row->mac);
+            } else {
+                to_mac_str(assoc_dev_data->dev_stats.cli_MACAddress, client_row->mac);
+            }
             if (assoc_dev_data->dev_stats.cli_Active == true) {
                 snprintf(client_row->state, sizeof(client_row->state), "active");
             } else {

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -2838,6 +2838,7 @@ webconfig_error_t translate_vap_info_to_vif_state_common(const wifi_vap_info_t *
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: No vif_radio_idx_conversion warning for %d\n", __func__, __LINE__, vap->vap_index);
     }
 
+ #if defined(CONFIG_IEEE80211BE)
     if (vap->u.bss_info.mld_info.common_info.mld_enable && vap->u.bss_info.mld_info.common_info.mld_id != UNDEFINED_MLD_ID) {
         // MLD_Addr
         to_mac_str((unsigned char*)vap->u.bss_info.mld_info.common_info.mld_addr, vap_row->mld_addr);
@@ -2847,6 +2848,7 @@ webconfig_error_t translate_vap_info_to_vif_state_common(const wifi_vap_info_t *
         get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name));
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
     }
+#endif
 
     // Unset all unused parameters
     vap_row->wds_exists = false;
@@ -3059,6 +3061,7 @@ webconfig_error_t  translate_sta_vap_info_to_vif_state_common(const wifi_vap_inf
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: vap_row->parent=%s\n", __func__, __LINE__, vap_row->parent);
     }
 
+#if defined(CONFIG_IEEE80211BE)
     if (vap->u.bss_info.mld_info.common_info.mld_enable && vap->u.bss_info.mld_info.common_info.mld_id != UNDEFINED_MLD_ID) {
         // MLD_Addr
         to_mac_str((unsigned char*)vap->u.bss_info.mld_info.common_info.mld_addr, vap_row->mld_addr);
@@ -3068,6 +3071,7 @@ webconfig_error_t  translate_sta_vap_info_to_vif_state_common(const wifi_vap_inf
         get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name));
         wifi_util_dbg_print(WIFI_WEBCONFIG,"%s:%d: Updating mld_if_name to %s. mld_id=%d.\n", __func__, __LINE__, vap_row->mld_if_name, vap->u.bss_info.mld_info.common_info.mld_id);
     }
+#endif
 
     vap_row->vlan_id = iface_map->vlan_id;
 
@@ -3362,11 +3366,14 @@ webconfig_error_t translate_vap_object_to_ovsdb_associated_clients(const rdk_wif
                 return webconfig_error_translate_to_ovsdb;
             }
 
+#if defined(CONFIG_IEEE80211BE)
             if (assoc_dev_data->dev_stats.cli_MLDEnable) {
                 /* This is MLO client. Add mld_addr to the row. Use Link assdress for mac*/
                 to_mac_str(assoc_dev_data->dev_stats.cli_MACAddress, client_row->mld_addr);
                 to_mac_str(assoc_dev_data->link_address, client_row->mac);
-            } else {
+            } else
+#endif
+            {
                 to_mac_str(assoc_dev_data->dev_stats.cli_MACAddress, client_row->mac);
             }
             if (assoc_dev_data->dev_stats.cli_Active == true) {


### PR DESCRIPTION
Reason for change: Support of MLO in Wifi_VIF_State and
Wifi_Associated_Clients tables
Test Procedure: 1. Check if fields mld_addr and mld_if_name are preset
in the Wifi_VIF_State table.
    2. Connect mlo capable client.
    3. Cehck the fields mac and mld_addr in the
       Wifi_Associated_Clients_Table

Risks: Medium
Priority: P1