### PR TITLE
XB10-2684 Populate link address for MLO client's assoc events (#1129)

### DIFF
--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -2374,6 +2374,8 @@ void process_assoc_device_event(void *data)
                 assoc_data->ap_index = link_vap_index;
                 assoc_data->dev_stats.cli_RSSI = assoc_data->mld_info.cli_LinkInfo[link_idx].cli_RSSI;
                 assoc_data->association_link = assoc_data->mld_info.cli_LinkInfo[link_idx].cli_IsAssocLink;
+                memcpy(assoc_data->link_address, assoc_data->mld_info.cli_LinkInfo[link_idx].cli_LinkAddress,
+                    sizeof(assoc_data->link_address));
                 assoc_dev_event(assoc_data);
             }
         }

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1912,6 +1912,7 @@ void process_connect(unsigned int ap_index, auth_deauth_dev_t *dev)
                 }
                 sta->dev_stats.cli_RSSI = dev->mld_info.cli_LinkInfo[link_idx].cli_RSSI;
                 sta->assoc_link = dev->mld_info.cli_LinkInfo[link_idx].cli_IsAssocLink;
+                memcpy(sta->link_mac, dev->mld_info.cli_LinkInfo[link_idx].cli_LinkAddress, sizeof(sta->link_mac));
                 wifi_util_info_print(WIFI_MON, "%s:%d Added mld sta %p to vap_index %d\n", __func__, __LINE__, sta, ap_index);
             }
         }


### PR DESCRIPTION
Reason for change: LinkAddress is empty for MLO client's assoc events Test Procedure: Connect MLO client to AP and verify the link address is
                correctly populated in the stats and events.
Risks: Low
Priority: P1


(cherry picked from commit 9216d0d6a438669ba5c221399f792dfaadbd98e2)