### PR TITLE
RDKB-65030 : rxprobereq count does not match the value in wl -i wlx.y counters

### DIFF
--- a/scripts/OneWiFi_Selfheal.sh
+++ b/scripts/OneWiFi_Selfheal.sh
@@ -94,7 +94,7 @@ print_wifi_2g_txprobe_cnt()
 
 sync_all_wifi_2g_txprobe_cnt()
 {
-    pre_rxprobe_req_2g_cnt=`wl -i wl0.1 counters | grep  -m 1 "rxprobereq " | cut -d ":" -f2-7 | awk '{print $6}'`
+    pre_rxprobe_req_2g_cnt=`wl -i wl0.1 counters | grep -o "rxprobereq [0-9]*" | awk '{print $2}'`
     cur_rxprobe_req_2g_cnt=$pre_rxprobe_req_2g_cnt
 
     pre_txprobe_resp_2g_cnt=`wl -i wl0.1 counters | grep  -m 1 "txprobersp " | cut -d ":" -f2-7 | awk '{print $8}'`
@@ -107,7 +107,7 @@ check_wifi_2g_stuck_status()
         sync_all_wifi_2g_txprobe_cnt
         print_wifi_2g_txprobe_cnt
     else
-        cur_rxprobe_req_2g_cnt=`wl -i wl0.1 counters | grep  -m 1 "rxprobereq " | cut -d ":" -f2-7 | awk '{print $6}'`
+        cur_rxprobe_req_2g_cnt=`wl -i wl0.1 counters | grep -o "rxprobereq [0-9]*" | awk '{print $2}'`
         if [ $cur_rxprobe_req_2g_cnt -gt $pre_rxprobe_req_2g_cnt ]; then
             cur_txprobe_resp_2g_cnt=`wl -i wl0.1 counters | grep  -m 1 "txprobersp " | cut -d ":" -f2-7 | awk '{print $8}'`
             if [ $cur_txprobe_resp_2g_cnt -eq $pre_txprobe_resp_2g_cnt ]; then
@@ -134,7 +134,7 @@ print_wifi_5g_txprobe_cnt()
 
 sync_all_wifi_5g_txprobe_cnt()
 {
-    pre_rxprobe_req_5g_cnt=`wl -i wl1.1 counters | grep  -m 1 "rxprobereq " | cut -d ":" -f2-7 | awk '{print $6}'`
+    pre_rxprobe_req_5g_cnt=`wl -i wl1.1 counters | grep -o "rxprobereq [0-9]*" | awk '{print $2}'`
     cur_rxprobe_req_5g_cnt=$pre_rxprobe_req_5g_cnt
 
     pre_txprobe_resp_5g_cnt=`wl -i wl1.1 counters | grep  -m 1 "txprobersp " | cut -d ":" -f2-7 | awk '{print $8}'`
@@ -147,7 +147,7 @@ check_wifi_5g_stuck_status()
         sync_all_wifi_5g_txprobe_cnt
         print_wifi_5g_txprobe_cnt
     else
-        cur_rxprobe_req_5g_cnt=`wl -i wl1.1 counters | grep  -m 1 "rxprobereq " | cut -d ":" -f2-7 | awk '{print $6}'`
+        cur_rxprobe_req_5g_cnt=`wl -i wl1.1 counters | grep -o "rxprobereq [0-9]*" | awk '{print $2}'`
         if [ $cur_rxprobe_req_5g_cnt -gt $pre_rxprobe_req_5g_cnt ]; then
             cur_txprobe_resp_5g_cnt=`wl -i wl1.1 counters | grep  -m 1 "txprobersp " | cut -d ":" -f2-7 | awk '{print $8}'`
             if [ $cur_txprobe_resp_5g_cnt -eq $pre_txprobe_resp_5g_cnt ]; then


### PR DESCRIPTION
RDKB-65030 : pre_rx_probe_2g_req_cnt, pre_rx_probe_5g_req_cnt, cur_rx_probe_2g_req_cnt, cur_rx_probe_5g_req_cnt is not reported correctly

Reason for Change:

Existing command used awk '{print $6} depends on exact position of the field. 6th field in wl -i wlx.y counters output is rxauth_req_denied value and not rxprobereq. If Broadcom adds any new counter before rxprobereq in the output, the position shifts and it breaks again

New command grep -o "rxprobereq" [0-9]*" searches by name rxprobereq not by position. So even if Broadcom adds new fields before or after it will always find the right value and is platform independent

Unit Test:

1. Loaded the Image having the fix on CBRv2 and TXB7 (OneWiFi_SelfHeal.sh prints rxprobereqcnt values only for CBRv2 and TXB7 models)

2. tail /rdklogs/logs/wifi_selfheal.txt and wait for approx 20 - 25 mins

3. Check the pre_rx_probe_2g_req_cnt, pre_rx_probe_5g_req_cnt, cur_rx_probe_2g_req_cnt, cur_rx_probe_5g_req_cnt values

UT Logs:

[fix_rxprobereqcnt_stable2_cbrv2_UT_logs.txt](https://github.com/user-attachments/files/28581798/fix_rxprobereqcnt_stable2_cbrv2_UT_logs.txt)
[fix_rxprobereqcnt_stable2_txb7_UT_logs.txt](https://github.com/user-attachments/files/28581801/fix_rxprobereqcnt_stable2_txb7_UT_logs.txt)


Risks: Low
Priority: P1