### PR TITLE
RDKBWIFI-278: Refactor CACR add multi-STA support and received subdoc from UWM

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -1410,14 +1410,6 @@ typedef struct {
 } channel_scan_request_t;
 
 typedef struct {
-    bssid_t    bssid;
-    unsigned char assoc_control;
-    unsigned short validity_period;
-    unsigned char count;
-    mac_address_t sta_mac;
-} client_assoc_ctrl_req_t;
-
-typedef struct {
     bssid_t bssid;
     ssid_t ssid;
     CHAR signal_strength;

--- a/source/apps/em/wifi_em.c
+++ b/source/apps/em/wifi_em.c
@@ -40,6 +40,15 @@ static bool is_monitor_done = false;
 static bool g_btm_pending_valid = false;
 static em_btm_req_ctrl_msg_t g_pending_btm;
 
+// Structure to track pending block timers
+typedef struct pending_block_node {
+    kick_details_t *kick_details;
+    struct pending_block_node *next;
+} pending_block_node_t;
+
+static pending_block_node_t *pending_blocks_head = NULL;
+static pthread_mutex_t pending_blocks_lock = PTHREAD_MUTEX_INITIALIZER;
+
 typedef struct {
     em_policy_req_type_t policy_type;
     em_config_t policy_config;
@@ -130,6 +139,34 @@ static int em_get_radio_index_from_mac(mac_addr_t ruuid)
 
     return RETURN_ERR;
 }
+
+static int em_get_vap_index_from_bssid(mac_addr_t bssid)
+{
+    unsigned int num_of_radios = getNumberRadios();
+    wifi_vap_info_map_t *vap_map;
+    mac_addr_str_t bss_str, search_str;
+
+    to_mac_str(bssid, search_str);
+
+    for (int i = 0; i < num_of_radios; i++) {
+        vap_map = (wifi_vap_info_map_t *)get_wifidb_vap_map(i);
+        if (vap_map == NULL) {
+            continue;
+        }
+        for (int j = 0; j < vap_map->num_vaps; j++) {
+            to_mac_str(vap_map->vap_array[j].u.bss_info.bssid, bss_str);
+            if (memcmp(bssid, vap_map->vap_array[j].u.bss_info.bssid, sizeof(mac_addr_t)) == 0) {
+                //wifi_util_dbg_print(WIFI_EM, "%s:%d VAP Index: %d found for BSSID: %s\n", __func__, __LINE__, vap_map->vap_array[j].vap_index, bss_str);
+                return vap_map->vap_array[j].vap_index;
+            }
+        }
+    }
+
+    wifi_util_error_print(WIFI_EM, "%s:%d VAP Index not found for BSSID %s\n", __func__, __LINE__, bss_str);
+
+    return RETURN_ERR;
+}
+
 
 static int em_match_radio_index_to_policy_index(radio_metrics_policies_t *radio_metrics_policies,
     int radio_index)
@@ -2834,6 +2871,78 @@ bus_error_t start_channel_scan(char *name, raw_data_t *p_data)
     return bus_error_success;
 }
 
+// Helper function to add a pending block to the tracking list
+static void add_pending_block(kick_details_t *kick_details)
+{
+    pending_block_node_t *node = (pending_block_node_t *)malloc(sizeof(pending_block_node_t));
+    if (!node) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to allocate memory for pending block node\n", __func__, __LINE__);
+        return;
+    }
+    node->kick_details = kick_details;
+
+    pthread_mutex_lock(&pending_blocks_lock);
+    node->next = pending_blocks_head;
+    pending_blocks_head = node;
+    pthread_mutex_unlock(&pending_blocks_lock);
+}
+
+// Helper function to find and remove a pending block by vap_index and sta_mac
+static kick_details_t* find_and_remove_pending_block(int vap_index, const char *sta_mac)
+{
+    pthread_mutex_lock(&pending_blocks_lock);
+
+    pending_block_node_t *current = pending_blocks_head;
+    pending_block_node_t *prev = NULL;
+
+    while (current) {
+        if (current->kick_details->vap_index == vap_index &&
+            current->kick_details->kick_list &&
+            strcmp(current->kick_details->kick_list, sta_mac) == 0) {
+            // Found a match, remove from list
+            if (prev) {
+                prev->next = current->next;
+            } else {
+                pending_blocks_head = current->next;
+            }
+            kick_details_t *result = current->kick_details;
+            free(current);
+            pthread_mutex_unlock(&pending_blocks_lock);
+            return result;
+        }
+        prev = current;
+        current = current->next;
+    }
+    pthread_mutex_unlock(&pending_blocks_lock);
+    return NULL;
+}
+
+// Helper function to remove a pending block by pointer (when timer fires)
+static void remove_pending_block(kick_details_t *kick_details)
+{
+    pthread_mutex_lock(&pending_blocks_lock);
+
+    pending_block_node_t *current = pending_blocks_head;
+    pending_block_node_t *prev = NULL;
+
+    while (current) {
+        if (current->kick_details == kick_details) {
+            // Found a match, remove from list
+            if (prev) {
+                prev->next = current->next;
+            } else {
+                pending_blocks_head = current->next;
+            }
+            free(current);
+            pthread_mutex_unlock(&pending_blocks_lock);
+            return;
+        }
+        prev = current;
+        current = current->next;
+    }
+    pthread_mutex_unlock(&pending_blocks_lock);
+}
+
 static int del_acl_cb(void *arg)
 {
     if (!arg) {
@@ -2844,6 +2953,9 @@ static int del_acl_cb(void *arg)
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d Callback Del ACL, vap_index:%d, MAC: %s\n",
            __func__, __LINE__, d->vap_index,
            d->kick_list ? d->kick_list : "NULL");
+
+    // Remove from pending blocks list
+    remove_pending_block(d);
 
 #ifdef NL80211_ACL
     INT rc = wifi_hal_delApAclDevice(d->vap_index, d->kick_list);
@@ -2876,6 +2988,7 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
     wifi_ctrl_t *ctrl;
     ctrl = &p_wifi_mgr->ctrl;
     bus_error_t ret = bus_error_success;
+    int rc = RETURN_OK;
 
     if (strcmp(event_name, WIFI_EM_CLIENT_ASSOC_CTRL_REQ) != 0) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Not EasyMesh client assoc ctrl event, %s\n", __func__, __LINE__, event_name);
@@ -2902,7 +3015,7 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
 
     assoc_ctrl_req = (client_assoc_ctrl_req_t *)p_data->raw_data.bytes;
 
-    vap_index = em_get_radio_index_from_mac(assoc_ctrl_req->bssid);
+    vap_index = em_get_vap_index_from_bssid(assoc_ctrl_req->bssid);
     if (vap_index == RETURN_ERR) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid BSSID %s, unable to resolve vap index\n",
            __func__, __LINE__, to_mac_str(assoc_ctrl_req->bssid, bssid_mac_str));
@@ -2918,6 +3031,7 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
             goto cleanup;
         }
         memset(kick_details, 0, sizeof(kick_details_t));
+        kick_details->timer_id = -1;  // Initialize to invalid ID
 
         wifi_util_dbg_print(WIFI_CTRL, "%s:%d Blocking STAs %s on BSSID %s for %d seconds\n", __func__, __LINE__,
            to_mac_str(assoc_ctrl_req->sta_mac, sta_mac_str), to_mac_str(assoc_ctrl_req->bssid, bssid_mac_str), 
@@ -2970,7 +3084,19 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
         kick_details->vap_index = vap_index;
         kick_details->kick_list = strdup(sta_mac_str);
         if (!kick_details->kick_list) {
-	    // Restore filter mode if we changed it
+            // Roll back ACL add due to strdup failure
+            #ifdef NL80211_ACL
+            if (wifi_hal_delApAclDevice(vap_index, sta_mac_str) != RETURN_OK) {
+                wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to roll back ACL device on vap %d\n",
+                    __func__, __LINE__, vap_index);
+            }
+            #else
+            if (wifi_delApAclDevice(vap_index, sta_mac_str) != RETURN_OK) {
+                wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to roll back ACL device on vap %d\n",
+                    __func__, __LINE__, vap_index);
+            }
+            #endif
+            // Restore filter mode if we changed it
             if (kick_details->filter_mode_changed) {
                 wifi_hal_setApMacAddressControlMode(vap_index, kick_details->original_filter_mode);
             }
@@ -2978,8 +3104,9 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
             goto cleanup;
         }
 
-        if (scheduler_add_timer_task(ctrl->sched, TRUE, NULL, del_acl_cb, kick_details,
-            assoc_ctrl_req->validity_period * 1000, 1, FALSE) != 0) {
+        rc = scheduler_add_timer_task(ctrl->sched, TRUE, &kick_details->timer_id, del_acl_cb, kick_details,
+                assoc_ctrl_req->validity_period * 1000, 1, FALSE);
+        if (rc != RETURN_OK) {
 	    wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to schedule timer task for vap %d\n", __func__,
 	       __LINE__, vap_index);
 	    #ifdef NL80211_ACL
@@ -3004,12 +3131,29 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
             ret = bus_error_general;
             goto cleanup;
         }
+        // Add to pending blocks list for tracking
+        add_pending_block(kick_details);
     } else {
-        /* un-block; nothing to do at the moment */
+        /* un-block; cancel any pending timer for this STA */
         /* Convert STA MAC from bytes to string before deleting from ACL */
         to_mac_str(assoc_ctrl_req->sta_mac, sta_mac_str);
+
+        /* Look for and cancel any pending block timer for this STA */
+        kick_details_t *pending = find_and_remove_pending_block(vap_index, sta_mac_str);
+        if (pending) {
+            wifi_util_dbg_print(WIFI_CTRL, "%s:%d Cancelling pending block timer for STA %s on vap %d\n",
+                __func__, __LINE__, sta_mac_str, vap_index);
+            if (scheduler_cancel_timer_task(ctrl->sched, pending->timer_id) != 0) {
+                wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to cancel timer %d for STA %s on vap %d\n",
+                    __func__, __LINE__, pending->timer_id, sta_mac_str, vap_index);
+            } else {
+                free(pending->kick_list);
+                free(pending);
+            }
+        }
+
         #ifdef NL80211_ACL
-           //if sta already block then removed it from acl list
+            //if sta already block then removed it from acl list
             success = (wifi_hal_delApAclDevice(vap_index, sta_mac_str) == RETURN_OK);
         #else
             success = (wifi_delApAclDevice(vap_index, sta_mac_str) == RETURN_OK);
@@ -3109,6 +3253,9 @@ int em_init(wifi_app_t *app, unsigned int create_flag)
     policy_config->local_steering_dslw_policy.sta_count = 0;
     policy_config->radio_metrics_policies.radio_count = 0;
 
+    // Initialize pending blocks list mutex
+    pthread_mutex_init(&pending_blocks_lock, NULL);
+
     if (app_init(app, create_flag) != 0) {
         return RETURN_ERR;
     }
@@ -3186,6 +3333,9 @@ int em_deinit(wifi_app_t *app)
             t_sta_data);
     }
     hash_map_destroy(client_type_info.sta_client_type.client_type_map);
+
+    // Destroy pending blocks list mutex
+    pthread_mutex_destroy(&pending_blocks_lock);
 
     return RETURN_OK;
 }

--- a/source/apps/em/wifi_em.c
+++ b/source/apps/em/wifi_em.c
@@ -35,6 +35,8 @@
 #define EM_DEF_LINK_METRICS_COLLECT_INTERVAL_MSEC 10000 // 10 Seconds
 #define EM_BSS_COLOR_DEFAULT        0x3F
 #define EM_SCAN_TYPE_ACTIVE          1
+#define MAX_STA_COUNT_JSON 30   // Maximum STAs per block request
+#define MAC_ADDR_STR_LEN 18     // MAC address string length (xx:xx:xx:xx:xx:xx = 17 chars + null terminator)
 
 static bool is_monitor_done = false;
 static bool g_btm_pending_valid = false;
@@ -162,7 +164,7 @@ static int em_get_vap_index_from_bssid(mac_addr_t bssid)
         }
     }
 
-    wifi_util_error_print(WIFI_EM, "%s:%d VAP Index not found for BSSID %s\n", __func__, __LINE__, bss_str);
+    wifi_util_error_print(WIFI_EM, "%s:%d VAP Index not found for BSSID %s\n", __func__, __LINE__, search_str);
 
     return RETURN_ERR;
 }
@@ -2973,30 +2975,143 @@ static int del_acl_cb(void *arg)
     return (int)rc;
 }
 
-static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t *p_data, void *userData)
+
+static bus_error_t parse_client_assoc_ctrl_json(const char *json_str, bssid_t *bssid, unsigned char *assoc_control,
+    unsigned short *validity_period, char sta_mac_list[][MAC_ADDR_STR_LEN], unsigned int *sta_count)
+{
+    cJSON *root = NULL, *req_obj = NULL, *sta_array = NULL, *mac_item = NULL;
+    cJSON *bssid_obj = NULL, *assoc_obj = NULL, *validity_obj = NULL;
+    unsigned int count = 0;
+
+    if (!json_str || !bssid || !assoc_control || !validity_period || !sta_mac_list || !sta_count) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid parameters\n", __func__, __LINE__);
+        return bus_error_invalid_input;
+    }
+
+    *sta_count = 0;
+
+    root = cJSON_Parse(json_str);
+    if (!root) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to parse JSON\n", __func__, __LINE__);
+        return bus_error_invalid_input;
+    }
+
+    req_obj = cJSON_GetObjectItem(root, "ClientAssocCtrlRequest");
+    if (!req_obj || !cJSON_IsObject(req_obj)) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d ClientAssocCtrlRequest object not found\n", __func__, __LINE__);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+
+    bssid_obj = cJSON_GetObjectItem(req_obj, "Bssid");
+    if (!bssid_obj || !cJSON_IsString(bssid_obj) || !bssid_obj->valuestring) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Bssid field not found or invalid\n", __func__, __LINE__);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+    if (ether_aton_r(bssid_obj->valuestring, (struct ether_addr *)bssid) == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to parse BSSID: %s\n", __func__, __LINE__, bssid_obj->valuestring);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+
+    assoc_obj = cJSON_GetObjectItem(req_obj, "AssocControl");
+    if (!assoc_obj || !cJSON_IsNumber(assoc_obj)) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d AssocControl field not found or invalid\n", __func__, __LINE__);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+    if (assoc_obj->valueint < 0 || assoc_obj->valueint > UINT8_MAX) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d AssocControl out of range: %d\n", __func__, __LINE__, assoc_obj->valueint);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+    *assoc_control = (unsigned char)assoc_obj->valueint;
+
+    validity_obj = cJSON_GetObjectItem(req_obj, "ValidityPeriod");
+    if (!validity_obj || !cJSON_IsNumber(validity_obj)) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d ValidityPeriod field not found or invalid\n", __func__, __LINE__);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+    if (validity_obj->valueint < 0 || validity_obj->valueint > UINT16_MAX) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d ValidityPeriod out of range: %d\n", __func__, __LINE__, validity_obj->valueint);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+    *validity_period = (unsigned short)validity_obj->valueint;
+
+    sta_array = cJSON_GetObjectItem(req_obj, "StaMacList");
+    if (!sta_array || !cJSON_IsArray(sta_array)) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d StaMacList array not found or invalid\n", __func__, __LINE__);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+
+    cJSON_ArrayForEach(mac_item, sta_array) {
+        if (count >= MAX_STA_COUNT_JSON) {
+            wifi_util_dbg_print(WIFI_CTRL, "%s:%d Maximum STA count reached (%d), ignoring additional STAs\n",
+                __func__, __LINE__, MAX_STA_COUNT_JSON);
+            break;
+        }
+
+        if (!cJSON_IsString(mac_item) || !mac_item->valuestring) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid STA MAC entry in array\n", __func__, __LINE__);
+            continue;
+        }
+
+        if (strlen(mac_item->valuestring) >= MAC_ADDR_STR_LEN) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d STA MAC string too long: %s\n", __func__, __LINE__, mac_item->valuestring);
+            continue;
+        }
+
+        snprintf(sta_mac_list[count], MAC_ADDR_STR_LEN, "%s", mac_item->valuestring);
+        sta_mac_list[count][MAC_ADDR_STR_LEN - 1] = '\0';
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d Parsed STA MAC[%d]: %s\n", __func__, __LINE__, count, sta_mac_list[count]);
+        count++;
+    }
+
+    if (count == 0) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d No valid STA MAC addresses found in StaMacList\n", __func__, __LINE__);
+        cJSON_Delete(root);
+        return bus_error_invalid_input;
+    }
+
+    *sta_count = count;
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Successfully parsed %d STA MAC addresses\n", __func__, __LINE__, count);
+
+    cJSON_Delete(root);
+    return bus_error_success;
+}
+
+static bus_error_t cacr_set_client_acl_rules(char *event_name, raw_data_t *p_data, void *userData)
 {
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d Received Client Assoc Ctrl Event from Agent\n", __func__, __LINE__);
 
     (void)userData;
-    client_assoc_ctrl_req_t *assoc_ctrl_req;
     int vap_index=-1;
     bool success = false;
     kick_details_t *kick_details = NULL;
     wifi_mgr_t *p_wifi_mgr = get_wifimgr_obj();
-    mac_addr_str_t sta_mac_str;
     mac_addr_str_t bssid_mac_str;
     wifi_ctrl_t *ctrl;
     ctrl = &p_wifi_mgr->ctrl;
     bus_error_t ret = bus_error_success;
     int rc = RETURN_OK;
+    bssid_t bssid;
+    unsigned char assoc_control = 0;
+    unsigned short validity_period = 0;
+    char sta_mac_list[MAX_STA_COUNT_JSON][MAC_ADDR_STR_LEN];
+    unsigned int sta_count = 0;
+    unsigned int i = 0;
 
     if (strcmp(event_name, WIFI_EM_CLIENT_ASSOC_CTRL_REQ) != 0) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Not EasyMesh client assoc ctrl event, %s\n", __func__, __LINE__, event_name);
         return bus_error_invalid_namespace;
     }
 
-    if (p_data->data_type != bus_data_type_bytes) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x\n",
+    if (p_data->data_type != bus_data_type_string) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x (expected string)\n",
                 __func__, __LINE__, event_name, p_data->data_type);
         return bus_error_invalid_input;
     }
@@ -3007,35 +3122,42 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
         return bus_error_invalid_input;
     }
 
-    if (p_data->raw_data_len < sizeof(client_assoc_ctrl_req_t)) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s raw_data_len:%zu too small (expected >= %zu)\n",
-           __func__, __LINE__, event_name, p_data->raw_data_len, sizeof(client_assoc_ctrl_req_t));
-        return bus_error_invalid_input;
+    // Parse JSON subdoc
+    memset(sta_mac_list, 0, sizeof(sta_mac_list));
+    ret = parse_client_assoc_ctrl_json((const char *)p_data->raw_data.bytes, &bssid, &assoc_control, &validity_period,
+        sta_mac_list, &sta_count);
+    if (ret != bus_error_success) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to parse client assoc ctrl JSON\n", __func__, __LINE__);
+        return ret;
     }
 
-    assoc_ctrl_req = (client_assoc_ctrl_req_t *)p_data->raw_data.bytes;
-
-    vap_index = em_get_vap_index_from_bssid(assoc_ctrl_req->bssid);
+    vap_index = em_get_vap_index_from_bssid(bssid);
     if (vap_index == RETURN_ERR) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid BSSID %s, unable to resolve vap index\n",
-           __func__, __LINE__, to_mac_str(assoc_ctrl_req->bssid, bssid_mac_str));
+           __func__, __LINE__, to_mac_str(bssid, bssid_mac_str));
         return bus_error_invalid_input;
     }
 
-    /* perform the actual block/disassociation as specified */
-    if (assoc_ctrl_req->assoc_control == 0x00) { /* block */
+    // Process each STA in the list
+    for (i = 0; i < sta_count; i++) {
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d Processing STA[%u]: %s, assoc_control: %u, validity_period: %u\n",
+                __func__, __LINE__, i, sta_mac_list[i], assoc_control, validity_period);
+
+        /* perform the actual block/disassociation as specified */
+        if (assoc_control == 0x00) { /* block */
 
         kick_details = (kick_details_t *)malloc(sizeof(kick_details_t));
         if (!kick_details) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to allocate memory for kick_details\n", __func__, __LINE__);
             ret = bus_error_out_of_resources;
+            //continue;
             goto cleanup;
         }
         memset(kick_details, 0, sizeof(kick_details_t));
         kick_details->timer_id = -1;  // Initialize to invalid ID
 
-        wifi_util_dbg_print(WIFI_CTRL, "%s:%d Blocking STAs %s on BSSID %s for %d seconds\n", __func__, __LINE__,
-           to_mac_str(assoc_ctrl_req->sta_mac, sta_mac_str), to_mac_str(assoc_ctrl_req->bssid, bssid_mac_str), 
-	   assoc_ctrl_req->validity_period);
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d Blocking STA %s on BSSID %s for %u seconds\n", __func__, __LINE__,
+           sta_mac_list[i], to_mac_str(bssid, bssid_mac_str), validity_period);
 
         // Read current filter mode to preserve it
         wifi_vap_info_t *vap_info = getVapInfo(vap_index);
@@ -3064,11 +3186,10 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
         }
 
         // Here passing 2 as argument for Mac Filter black list mode
-        to_mac_str(assoc_ctrl_req->sta_mac, sta_mac_str);
         #ifdef NL80211_ACL
-	    success = (wifi_hal_addApAclDevice(vap_index, sta_mac_str) == RETURN_OK);
+        success = (wifi_hal_addApAclDevice(vap_index, sta_mac_list[i]) == RETURN_OK);
         #else
-	    success = (wifi_addApAclDevice(vap_index, sta_mac_str) == RETURN_OK);
+        success = (wifi_addApAclDevice(vap_index, sta_mac_list[i]) == RETURN_OK);
         #endif
         if (!success) {
             wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to add ACL device on vap %d\n",
@@ -3082,16 +3203,16 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
         }
 
         kick_details->vap_index = vap_index;
-        kick_details->kick_list = strdup(sta_mac_str);
+        kick_details->kick_list = strdup(sta_mac_list[i]);
         if (!kick_details->kick_list) {
             // Roll back ACL add due to strdup failure
             #ifdef NL80211_ACL
-            if (wifi_hal_delApAclDevice(vap_index, sta_mac_str) != RETURN_OK) {
+            if (wifi_hal_delApAclDevice(vap_index, sta_mac_list[i]) != RETURN_OK) {
                 wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to roll back ACL device on vap %d\n",
                     __func__, __LINE__, vap_index);
             }
             #else
-            if (wifi_delApAclDevice(vap_index, sta_mac_str) != RETURN_OK) {
+            if (wifi_delApAclDevice(vap_index, sta_mac_list[i]) != RETURN_OK) {
                 wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to roll back ACL device on vap %d\n",
                     __func__, __LINE__, vap_index);
             }
@@ -3105,18 +3226,17 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
         }
 
         rc = scheduler_add_timer_task(ctrl->sched, TRUE, &kick_details->timer_id, del_acl_cb, kick_details,
-                assoc_ctrl_req->validity_period * 1000, 1, FALSE);
+                validity_period * 1000, 1, FALSE);
         if (rc != RETURN_OK) {
 	    wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to schedule timer task for vap %d\n", __func__,
 	       __LINE__, vap_index);
 	    #ifdef NL80211_ACL
-            if (wifi_hal_delApAclDevice(vap_index, sta_mac_str) != RETURN_OK) {
-
+            if (wifi_hal_delApAclDevice(vap_index, sta_mac_list[i]) != RETURN_OK) {
                 wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to roll back ACL device on vap %d\n",
 				                    __func__, __LINE__, vap_index);
 	    }
 	    #else
-            if (wifi_delApAclDevice(vap_index, sta_mac_str) != RETURN_OK) {
+            if (wifi_delApAclDevice(vap_index, sta_mac_list[i]) != RETURN_OK) {
                 wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to roll back ACL device on vap %d\n",
                     __func__, __LINE__, vap_index);
             }
@@ -3135,28 +3255,22 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
         add_pending_block(kick_details);
     } else {
         /* un-block; cancel any pending timer for this STA */
-        /* Convert STA MAC from bytes to string before deleting from ACL */
-        to_mac_str(assoc_ctrl_req->sta_mac, sta_mac_str);
-
         /* Look for and cancel any pending block timer for this STA */
-        kick_details_t *pending = find_and_remove_pending_block(vap_index, sta_mac_str);
+        kick_details_t *pending = find_and_remove_pending_block(vap_index, sta_mac_list[i]);
         if (pending) {
             wifi_util_dbg_print(WIFI_CTRL, "%s:%d Cancelling pending block timer for STA %s on vap %d\n",
-                __func__, __LINE__, sta_mac_str, vap_index);
+                __func__, __LINE__, sta_mac_list[i], vap_index);
             if (scheduler_cancel_timer_task(ctrl->sched, pending->timer_id) != 0) {
                 wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to cancel timer %d for STA %s on vap %d\n",
-                    __func__, __LINE__, pending->timer_id, sta_mac_str, vap_index);
-            } else {
-                free(pending->kick_list);
-                free(pending);
+                    __func__, __LINE__, pending->timer_id, sta_mac_list[i], vap_index);
             }
         }
 
         #ifdef NL80211_ACL
             //if sta already block then removed it from acl list
-            success = (wifi_hal_delApAclDevice(vap_index, sta_mac_str) == RETURN_OK);
+            success = (wifi_hal_delApAclDevice(vap_index, sta_mac_list[i]) == RETURN_OK);
         #else
-            success = (wifi_delApAclDevice(vap_index, sta_mac_str) == RETURN_OK);
+            success = (wifi_delApAclDevice(vap_index, sta_mac_list[i]) == RETURN_OK);
         #endif
         if (!success) {
             wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to delete ACL device on vap %d\n",
@@ -3165,7 +3279,7 @@ static bus_error_t controller_set_client_acl_rules(char *event_name, raw_data_t 
             goto cleanup;
         }
     }
-
+    }
     return bus_error_success;
 
 cleanup:
@@ -3244,17 +3358,14 @@ int em_init(wifi_app_t *app, unsigned int create_flag)
             { NULL, NULL, NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
             { bus_data_type_string, false, 0, 0, 0, NULL } },
         { WIFI_EM_CLIENT_ASSOC_CTRL_REQ, bus_element_type_method,
-            { NULL, controller_set_client_acl_rules, NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
-            { bus_data_type_bytes, true, 0, 0, 0, NULL } }
+            { NULL, cacr_set_client_acl_rules, NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
+            { bus_data_type_string, true, 0, 0, 0, NULL } }
 
     };
 
     policy_config->btm_steering_dslw_policy.sta_count = 0;
     policy_config->local_steering_dslw_policy.sta_count = 0;
     policy_config->radio_metrics_policies.radio_count = 0;
-
-    // Initialize pending blocks list mutex
-    pthread_mutex_init(&pending_blocks_lock, NULL);
 
     if (app_init(app, create_flag) != 0) {
         return RETURN_ERR;
@@ -3333,9 +3444,6 @@ int em_deinit(wifi_app_t *app)
             t_sta_data);
     }
     hash_map_destroy(client_type_info.sta_client_type.client_type_map);
-
-    // Destroy pending blocks list mutex
-    pthread_mutex_destroy(&pending_blocks_lock);
 
     return RETURN_OK;
 }

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -175,6 +175,7 @@ typedef struct kick_details {
     int vap_index;
     int original_filter_mode;
     bool filter_mode_changed;
+    int timer_id;
 }kick_details_t;
 
 typedef struct {


### PR DESCRIPTION
- Refactored implementation to support multiple STA entries per message (spec compliant)
- Changed the struct to json format to carry cacr information from UWM to OneWifi.

Signed-off-by: Sundram Patel <sundram.p@tataelxsi.co.in>