### PR TITLE
RDKB-65195: Optimization of bus node data allocation (#1150)

### DIFF
--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2421,8 +2421,8 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
     if(!ctrl->hotspot_client_dhcp_failure_subscribed) {
         if (bus_desc->bus_event_subs_fn(&ctrl->handle, HOTSPOT_CLIENT_DHCP_FAILURE_DISCONNECTED, hotspot_client_dhcp_failure_disconnect, NULL, 
             0) != bus_error_success) {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe fail\n",
-                    __FUNCTION__, __LINE__, HOTSPOT_CLIENT_DHCP_FAILURE_DISCONNECTED);
+            // wifi_util_dbg_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe fail\n",
+            //         __FUNCTION__, __LINE__, HOTSPOT_CLIENT_DHCP_FAILURE_DISCONNECTED);
         } else {
             ctrl->hotspot_client_dhcp_failure_subscribed = true;
             wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe success\n",

--- a/source/platform/common/bus_common.c
+++ b/source/platform/common/bus_common.c
@@ -242,7 +242,7 @@ elem_node_map_t* bus_insert_elem_node(elem_node_map_t* root, bus_mux_data_elem_t
     next_node = current_node->child;
     create_child = 1;
 
-    wifi_util_info_print(WIFI_BUS,"Request to insert element [%s]!!\r\n", elem->full_name);
+    wifi_util_dbg_print(WIFI_BUS,"Request to insert element [%s]!!\r\n", elem->full_name);
 
     strncpy(name, elem->full_name, strlen(elem->full_name) + 1);
 
@@ -346,12 +346,18 @@ elem_node_map_t* bus_insert_elem_node(elem_node_map_t* root, bus_mux_data_elem_t
 
     current_node->type           = elem->type;
     current_node->node_data_type = elem->node_data_type;
-    if (current_node->node_elem_data != NULL) {
-        free(current_node->node_elem_data);
-        current_node->node_elem_data = NULL;
-        current_node->node_elem_data_len = 0;
+
+    if (current_node->node_elem_data_len != elem->cfg_data_len) {
+        if (current_node->node_elem_data != NULL) {
+            wifi_util_info_print(WIFI_BUS, "%s:%d Updated node [%s] data len from %d to %d\n",
+                __func__, __LINE__, current_node->full_name, current_node->node_elem_data_len,
+                elem->cfg_data_len);
+            free(current_node->node_elem_data);
+            current_node->node_elem_data = NULL;
+            current_node->node_elem_data_len = 0;
+        }
+        current_node->node_elem_data = malloc(elem->cfg_data_len);
     }
-    current_node->node_elem_data = malloc(elem->cfg_data_len);
     if(current_node->node_elem_data == NULL)
     {
         wifi_util_error_print(WIFI_BUS, "Failed to create node [%s]\n", elem->full_name);
@@ -368,9 +374,6 @@ elem_node_map_t* bus_insert_elem_node(elem_node_map_t* root, bus_mux_data_elem_t
         {
             wifi_util_error_print(WIFI_BUS, "Failed to create node [%s]\n",
                  elem->full_name);
-            free(current_node->node_elem_data);
-            current_node->node_elem_data = NULL;
-            current_node->node_elem_data_len = 0;
             BUS_MUX_UNLOCK(get_bus_mux_mutex());
             return NULL;
         }

--- a/source/platform/rdkb/bus.c
+++ b/source/platform/rdkb/bus.c
@@ -999,7 +999,7 @@ static void bus_sub_cb_registration(char *event_name, rbus_sub_callback_table_t 
         user_cb_set = true;
     }
 
-    wifi_util_info_print(WIFI_BUS,"%s:%d sub_user_cb_set:%d event_name:%s\n", __func__, __LINE__, user_cb_set, event_name);
+    wifi_util_dbg_print(WIFI_BUS,"%s:%d sub_user_cb_set:%d event_name:%s\n", __func__, __LINE__, user_cb_set, event_name);
 
     if (user_cb_set == true) {
         elem_node_map_t          *sub_cb_mux_map = get_bus_mux_sub_cb_map();


### PR DESCRIPTION
Reason for change: Avoid unnecessary free and malloc when the data length is same.
Test Procedure: Debug
Risks: Low
Priority: P1



(cherry picked from commit efb9d4991c7f85896f1f67c9802e18b467357785)