### PR TITLE
XB10-2622: [VXB10] [8.3p5s1] WIFI_WARN_RadioOutrange is observed post OneWifi Crash | Increase in Load Avg | Log upload is frequent | No Client connectivity

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2101,7 +2101,11 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
         wifi_util_info_print(WIFI_DB,"%s:%d Validation of channel/channel_width of existing DB failed, setting default values chan=%d chanwidth=%d \n", __func__, __LINE__, config->channel, config->channelWidth);
     }
 
-    if (config->band == WIFI_FREQUENCY_6_BAND) {
+    if ((cfg->hw_mode != 0) && (validate_wifi_hw_variant(cfg->freq_band, cfg->hw_mode) == RETURN_OK)) {
+        config->variant = cfg->hw_mode;
+    }
+
+ if (config->band == WIFI_FREQUENCY_6_BAND) {
         if (is_bandwidth_and_hw_variant_compatible(config->variant, config->channelWidth) != true) {
             wifi_util_info_print(WIFI_DB,
                 "%s:%d 6G hw_mode/channel_width mismatch (variant=%d bw=%d), normalizing\n",
@@ -2119,10 +2123,6 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
                     config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
                 }
         }
-    }
-
-    if ((cfg->hw_mode != 0) && (validate_wifi_hw_variant(cfg->freq_band, cfg->hw_mode) == RETURN_OK)) {
-        config->variant = cfg->hw_mode;
     }
 
     config->csa_beacon_count = cfg->csa_beacon_count;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2107,20 +2107,24 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
                 "%s:%d 6G hw_mode/channel_width mismatch (variant=%d bw=%d), normalizing\n",
                 __func__, __LINE__, config->variant, config->channelWidth);
 
+#ifdef CONFIG_IEEE80211BE
             if (config->variant & WIFI_80211_VARIANT_BE) {
                 config->channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
-            } else if (config->variant & WIFI_80211_VARIANT_AX) {
-                config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
-            } else {
-                config->variant = WIFI_80211_VARIANT_AX;
-                config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
-            }
+            } else
+#endif /* CONFIG_IEEE80211BE */
+                if (config->variant & WIFI_80211_VARIANT_AX) {
+                    config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
+                } else {
+                    config->variant = WIFI_80211_VARIANT_AX;
+                    config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
+                }
         }
     }
-    
+
     if ((cfg->hw_mode != 0) && (validate_wifi_hw_variant(cfg->freq_band, cfg->hw_mode) == RETURN_OK)) {
         config->variant = cfg->hw_mode;
     }
+
     config->csa_beacon_count = cfg->csa_beacon_count;
     if (cfg->country != 0) {
         config->countryCode = cfg->country;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2101,6 +2101,23 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
         wifi_util_info_print(WIFI_DB,"%s:%d Validation of channel/channel_width of existing DB failed, setting default values chan=%d chanwidth=%d \n", __func__, __LINE__, config->channel, config->channelWidth);
     }
 
+    if (config->band == WIFI_FREQUENCY_6_BAND) {
+        if (is_bandwidth_and_hw_variant_compatible(config->variant, config->channelWidth) != true) {
+            wifi_util_info_print(WIFI_DB,
+                "%s:%d 6G hw_mode/channel_width mismatch (variant=%d bw=%d), normalizing\n",
+                __func__, __LINE__, config->variant, config->channelWidth);
+
+            if (config->variant & WIFI_80211_VARIANT_BE) {
+                config->channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
+            } else if (config->variant & WIFI_80211_VARIANT_AX) {
+                config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
+            } else {
+                config->variant = WIFI_80211_VARIANT_AX;
+                config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
+            }
+        }
+    }
+    
     if ((cfg->hw_mode != 0) && (validate_wifi_hw_variant(cfg->freq_band, cfg->hw_mode) == RETURN_OK)) {
         config->variant = cfg->hw_mode;
     }

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2119,8 +2119,13 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
                 if (config->variant & WIFI_80211_VARIANT_AX) {
                     config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
                 } else {
+#ifdef CONFIG_IEEE80211BE
+                    config->variant = WIFI_80211_VARIANT_BE;
+                    config->channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
+#else
                     config->variant = WIFI_80211_VARIANT_AX;
                     config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
+#endif /* CONFIG_IEEE80211BE */
                 }
         }
     }


### PR DESCRIPTION
Reason for Change: Hardware variant and bandwidth mismatch observed.
Test Procedure: Verify callback_Wifi_Radio_Config when a mismatch is detected. 
Ensure that the hardware variant is updated according to the detected bandwidth mismatch.
Priority: P0
Risks: High
Signed-off-by: mothishree_mallaiyanjothimani@comcast.com
