### PR TITLE
RDKCOM-5579: RDKBDEV-3429 RDKBACCL-1615 : [TDK][AUTO][BPI][DML]Data t…

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -3033,7 +3033,7 @@ INSTMSMT_PH2 -->
                                         </parameter>
                                         <parameter>
                                             <name>CuThresholdSupported</name>
-                                            <type>string(32)</type>
+                                            <type>string(64)</type>
                                             <syntax>string</syntax>
                                             <writable>false</writable>
                                         </parameter>


### PR DESCRIPTION
…ype compliance fails for Device.WiFi.AccessPoint.<i>.ConnectionControl.PreAssocDeny.CuThresholdSupported (#1063)

* RDKBACCL-1615 : [TDK][AUTO][BPI][DML]Data type compliance fails for Device.WiFi.AccessPoint.<i>.ConnectionControl.PreAssocDeny.CuThresholdSupported

Reason for change: To satisfy the defined value for CuThresholdSupported, increased the length
Test Procedure: dmcli eRT getv Device.WiFi.AccessPoint.1.ConnectionControl.PreAssocDeny.CuThresholdSupported
Signed-off-by: SsandhyaR <Sandhyarani_Sirasanagandla@comcast.com>
Risks: None



* Increase CuThresholdSupported type length to 64

---------