### PR TITLE
[RDKB-64929] Ignite telemetry markers (#1132)

### DIFF
--- a/source/apps/linkquality/wifi_linkquality.c
+++ b/source/apps/linkquality/wifi_linkquality.c
@@ -32,10 +32,11 @@
 #include "wifi_monitor.h"
 #include "scheduler.h"
 
-#define MAX_STR_LEN 128
 #define MAX_BUFF_LEN 1048
 #define IGNITE_SCORE_LOG_INTERVAL_MS 900000 // 15 mins
 #define IGNITE_INITIAL_PUBLISH_ITERATIONS 5
+#define MAX_STR_LEN 128
+#define IGNITE_SCORE_THRESHOLD_BUFF 64
 
 static char *wifi_health_log = "/rdklogs/logs/wifihealth.txt";
 
@@ -103,12 +104,12 @@ static int ignite_score_log_timer(void *args)
     }
     ignite_lq_state_t *ignite = &wifi_app->data.u.linkquality.ignite;
 
-    char tmp[128] = { 0 };
+    char tmp[MAX_STR_LEN] = { 0 };
     char buff[MAX_BUFF_LEN] = { 0 };
 
     get_formatted_time(tmp);
-    snprintf(buff, sizeof(buff), "%s WIFI_IGNITE_LINKQUALITY:%f %f\n", tmp, ignite->last_score,
-        ignite->last_threshold);
+    snprintf(buff, sizeof(buff), "%s WIFI_IGNITE_LINKQUALITY:%f %f %s\n", tmp, ignite->last_score,
+        ignite->last_threshold, ignite->ignite_service_status);
     wifi_util_info_print(WIFI_APPS, "%s:%d: %s\n", __func__, __LINE__, buff);
     write_to_file(wifi_health_log, buff);
     return RETURN_OK;
@@ -116,10 +117,13 @@ static int ignite_score_log_timer(void *args)
 
 void publish_station_score(const char *input_str, double score, double threshold)
 {
-    char str[MAX_STR_LEN] = { '\0' };
     int current_state = -1;
     bus_error_t status;
     raw_data_t rdata;
+    char str[MAX_STR_LEN] = { '\0' };
+    char tmp[MAX_STR_LEN] = { 0 };
+    char buff[MAX_BUFF_LEN] = { 0 };
+    char telemetry_val[IGNITE_SCORE_THRESHOLD_BUFF] = {0};
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
 
     wifi_app_t *wifi_app = get_app_by_inst(&ctrl->apps_mgr, wifi_app_inst_link_quality);
@@ -156,9 +160,11 @@ void publish_station_score(const char *input_str, double score, double threshold
     if (score < threshold) {
         current_state = 0;
         snprintf(str, MAX_STR_LEN, "Non-Serviceable");
+        snprintf(ignite->ignite_service_status, MAX_IGNITE_STR_LEN, "Manageable");
     } else if (score >= threshold) {
         current_state = 1;
         snprintf(str, MAX_STR_LEN, "Serviceable");
+        snprintf(ignite->ignite_service_status, MAX_IGNITE_STR_LEN, "Serviceable");
     }
 
     if (current_state != -1 && current_state != ignite->last_service_state) {
@@ -175,15 +181,28 @@ void publish_station_score(const char *input_str, double score, double threshold
             wifi_util_error_print(WIFI_CTRL, "%s:%d: bus: bus_event_publish_fn Event failed %d\n",
                 __func__, __LINE__, status);
         }
+        get_formatted_time(tmp);
         if (ignite->last_service_state == -1) {
-            char tmp[128] = { 0 };
-            char buff[MAX_BUFF_LEN] = { 0 };
-            get_formatted_time(tmp);
-            snprintf(buff, sizeof(buff), "%s WIFI_IGNITE_LINKQUALITY:%f %f\n", tmp,
-                ignite->last_score, ignite->last_threshold);
-            wifi_util_info_print(WIFI_APPS, "%s:%d: Score at first RBUS publish after connection: %s\n", __func__,
-                __LINE__, buff);
+            snprintf(buff, sizeof(buff), "%s WIFI_IGNITE_LINKQUALITY_FIRST_PUBLISH:%f %f %s\n", tmp,
+                ignite->last_score, ignite->last_threshold, ignite->ignite_service_status);
+            wifi_util_info_print(WIFI_APPS,
+                "%s:%d: Score at first RBUS publish after connection: %s\n", __func__, __LINE__,
+                buff);
             write_to_file(wifi_health_log, buff);
+            snprintf(telemetry_val, IGNITE_SCORE_THRESHOLD_BUFF, "%f %f %s", ignite->last_score,
+                ignite->last_threshold, ignite->ignite_service_status);
+            get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_LINKQUALITY_FIRST_PUBLISH",
+                telemetry_val);
+        } else {
+            snprintf(buff, sizeof(buff), "%s WIFI_IGNITE_LINKQUALITY_STATE_CHANGE:%f %f %s\n", tmp,
+                ignite->last_score, ignite->last_threshold, ignite->ignite_service_status);
+            wifi_util_info_print(WIFI_APPS, "%s:%d: State change score: %s\n", __func__, __LINE__,
+                buff);
+            write_to_file(wifi_health_log, buff);
+            snprintf(telemetry_val, IGNITE_SCORE_THRESHOLD_BUFF, "%f %f %s", ignite->last_score,
+                ignite->last_threshold, ignite->ignite_service_status);
+            get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_LINKQUALITY_STATE_CHANGE",
+                telemetry_val);
         }
         ignite->last_service_state = current_state;
     }

--- a/source/apps/linkquality/wifi_linkquality.h
+++ b/source/apps/linkquality/wifi_linkquality.h
@@ -20,6 +20,8 @@
 #ifndef WIFI_LINKQUALITY_H
 #define WIFI_LINKQUALITY_H
 
+#define MAX_IGNITE_STR_LEN 32
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,6 +35,7 @@ typedef struct {
     int score_log_timer_id;
     int last_service_state;
     int iteration_count;
+    char ignite_service_status[MAX_IGNITE_STR_LEN];
 } ignite_lq_state_t;
 
 typedef struct {

--- a/source/core/services/vap_svc_mesh_ext.c
+++ b/source/core/services/vap_svc_mesh_ext.c
@@ -44,6 +44,28 @@
 #define EXT_DISCONNECTION_DISCONNECT 1
 #define EXT_DISCONNECTION_DISCONNECT_AND_IGNORE_RADIO 2
 
+#define MAX_STATUS_LEN 5
+#define MAX_STR_LEN    128
+#define MAC_ADDR_STR_LEN 18
+#define MAX_IFACE_LEN   32
+#define MAX_BUFF_LEN    256
+#define MAX_TELEMETRY_BUFF_LEN 1024
+
+//safe_strcat defined locally to accomodate the contents in the existing destination and 
+//incoming source buffer to avoid overflow
+#define safe_strcat(dst, max, src)  \
+    do { \
+        if ((src) == NULL) { \
+            wifi_util_error_print(WIFI_CTRL, "%s:%d NULL src\n", __func__, __LINE__); \
+        } else if ((strlen(dst) + strlen(src) + 1) > (max)) { \
+            wifi_util_error_print(WIFI_CTRL, "%s:%d overflow prevented dst_len=%zu src_len=%zu max=%zu\n", \
+                __func__, __LINE__, strlen(dst), strlen(src), (size_t)(max)); \
+        } else { \
+            strcat(dst, src); \
+        } \
+    } while(0)
+
+static const char *wifi_health_log = "/rdklogs/logs/wifihealth.txt";
 /**
  * @brief Temporary structure for sorting with computed scores
  */
@@ -711,15 +733,23 @@ int process_udhcp_ip_check(vap_svc_t *svc)
     } else {
         if ((ip_check_count < EXT_UDHCP_IP_CHECK_NUM) &&
             (ext->conn_state == connection_state_connected)) {
-            char iface[32] = "brww0";
+            char iface[MAX_IFACE_LEN] = "brww0";
+            char tmp[MAX_STR_LEN] = { 0 };
+            get_formatted_time(tmp);
             if (has_valid_ip(iface)) {
-                wifi_util_info_print(WIFI_CTRL, "IGNITE_RF_DOWN: Received Valid IP address on brww0 interface\n");
+                write_to_file(wifi_health_log, "%s WIFI_IGNITE_VALID_IP_BRWW0:True\n", tmp);
+                get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_VALID_IP_BRWW0", "True");
+                wifi_util_info_print(WIFI_CTRL,
+                    "IGNITE_RF_DOWN: Received Valid IP address on brww0 interface\n");
                 scheduler_cancel_timer_task(ctrl->sched, ext->ext_udhcp_ip_check_id);
                 ext->ext_udhcp_ip_check_id = 0;
                 ip_check_count = 0;
                 return 0;
             } else {
-                wifi_util_error_print(WIFI_CTRL, "IGNITE_RF_DOWN: Invalid IP address detected on brww0 interface\n");
+                write_to_file(wifi_health_log, "\n%s WIFI_IGNITE_VALID_IP_BRWW0:False\n", tmp);
+                get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_VALID_IP_BRWW0", "False");
+                wifi_util_error_print(WIFI_CTRL,
+                    "IGNITE_RF_DOWN: Invalid IP address detected on brww0 interface\n");
             }
         }
     }
@@ -1130,7 +1160,9 @@ void ext_try_connecting(vap_svc_t *svc)
             return;
         }
         vap_index = get_sta_vap_index_for_radio(svc->prop, radio_index);
-
+        if (ctrl->rf_status_down == true) {
+            hotspot_timing_target_detected();
+        }
         wifi_util_info_print(WIFI_CTRL,"%s:%d connecting to ssid:%s bssid:%s rssi:%d frequency:%d on vap:%d radio:%d\n",
                     __func__, __LINE__, candidate->external_ap.ssid,
                     to_mac_str(candidate->external_ap.bssid, bssid_str), candidate->external_ap.rssi,
@@ -1726,6 +1758,10 @@ int process_ext_scan_results(vap_svc_t *svc, void *arg)
     vap_svc_ext_t *ext;
     wifi_ctrl_t *ctrl;
     ssid_t sta_ssid;
+    char tmp[MAX_STR_LEN] = { 0 };
+    char buff[MAX_BUFF_LEN] = { 0 };
+    char target_metrics_buf[MAX_TELEMETRY_BUFF_LEN] = {0};
+    char telemetry_buf[MAX_TELEMETRY_BUFF_LEN] = {0};
 
     ctrl = svc->ctrl;
     ext = &svc->u.ext;
@@ -1773,6 +1809,28 @@ int process_ext_scan_results(vap_svc_t *svc, void *arg)
         " connection state:%s\n", __FUNCTION__,__LINE__, results->radio_index, num,
         ext_conn_state_to_str(ext->conn_state));
 
+    if (ctrl->rf_status_down == true) {
+	    static char *event_names[] = {
+		    "WIFI_IGNITE_ELIGIBLE_TARGET_2G",
+		    "WIFI_IGNITE_ELIGIBLE_TARGET_5G",
+		    "WIFI_IGNITE_ELIGIBLE_TARGET_6G"
+	    };
+        get_formatted_time(tmp);
+	    if (results->radio_index < MAX_NUM_RADIOS) {
+		    snprintf(buff, MAX_BUFF_LEN, "%s %s:%u\n", tmp, event_names[results->radio_index], num);
+		    write_to_file(wifi_health_log,buff);
+            wifi_util_info_print(WIFI_CTRL, "%s:%d telemetry val : %s\n", __func__, __LINE__, buff);
+		    get_stubs_descriptor()->t2_event_d_fn(event_names[results->radio_index], num);
+	    } else {
+		    wifi_util_error_print(WIFI_CTRL, "%s %d Unsupported Radio index %u\n", __func__, __LINE__, results->radio_index);
+	    }
+	    if (num != 0 ) {
+	        memset(tmp, '\0', sizeof(tmp));
+	        get_formatted_time(tmp);
+	        snprintf(target_metrics_buf, MAX_TELEMETRY_BUFF_LEN, "%s WIFI_IGNITE_ELIGIBLE_TARGET_METRICS:", tmp);
+	    }
+    }
+
     if ((ext->candidates_list.scan_list == NULL) && num) {
         ext->candidates_list.scan_list = (bss_candidate_t *) malloc(num * sizeof(bss_candidate_t));
         scan_list = ext->candidates_list.scan_list;
@@ -1789,23 +1847,45 @@ int process_ext_scan_results(vap_svc_t *svc, void *arg)
         scan_list->conn_attempt = connection_attempt_wait;
         scan_list->conn_retry_attempt = 0;
         scan_list->radio_freq_band = band;
-        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: AP with ssid:%s, bssid:%s, rssi:%d, freq:%d\n",
-            __func__, __LINE__, tmp_bss->ssid, to_mac_str(tmp_bss->bssid, bssid_str), tmp_bss->rssi, tmp_bss->freq);
+        if (ctrl->rf_status_down == true) {
+            char delimiter = (i + 1) < num ? ';' : ' ';
+            
+            snprintf(buff, MAX_BUFF_LEN, "%s,%d,%d,%d,%d%c",
+                to_mac_str(tmp_bss->bssid, bssid_str),
+                tmp_bss->freq,
+                tmp_bss->rssi,
+                tmp_bss->snr,
+                tmp_bss->chan_utilization,
+                delimiter);
+
+            safe_strcat(telemetry_buf, MAX_TELEMETRY_BUFF_LEN, buff);
+        }
+
         wifi_util_info_print(WIFI_CTRL, "%s:%d: AP with ssid:%s, bssid:%s, rssi:%d, freq:%d\n",
-            __func__, __LINE__, scan_list->external_ap.ssid, to_mac_str(scan_list->external_ap.bssid, bssid_str), scan_list->external_ap.rssi, scan_list->external_ap.freq);
+            __func__, __LINE__, scan_list->external_ap.ssid,
+            to_mac_str(scan_list->external_ap.bssid, bssid_str), scan_list->external_ap.rssi,
+            scan_list->external_ap.freq);
         tmp_bss++;
         scan_list++;
     }
 
+    if ((ctrl->rf_status_down == true) && (num != 0)) {
+        safe_strcat(telemetry_buf, MAX_TELEMETRY_BUFF_LEN, "\n");
+        safe_strcat(target_metrics_buf, MAX_TELEMETRY_BUFF_LEN, telemetry_buf);
+        write_to_file(wifi_health_log, target_metrics_buf);
+        get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_ELIGIBLE_TARGET_METRICS", telemetry_buf);
+    }
+
     if (ext->candidates_list.scan_list && (ext->candidates_list.scan_count > 0)) {
         if (ctrl->rf_status_down == false) {
-            sort_bss_results_by_rssi(ext->candidates_list.scan_list, 0, ext->candidates_list.scan_count - 1);
+            sort_bss_results_by_rssi(ext->candidates_list.scan_list, 0,
+                ext->candidates_list.scan_count - 1);
         } else {
-            ext->ranked_count = sort_bss_results_by_ranking(
-                    ext->candidates_list.scan_list,
-                    ext->candidates_list.scan_count);
+            ext->ranked_count = sort_bss_results_by_ranking(ext->candidates_list.scan_list,
+                ext->candidates_list.scan_count);
             ext->candidates_list.scan_count = ext->ranked_count;
-            wifi_util_dbg_print(WIFI_CTRL, "%s:%d: rank-count : %d scan-count : %d\n", __func__, __LINE__, ext->ranked_count, ext->candidates_list.scan_count);
+            wifi_util_dbg_print(WIFI_CTRL, "%s:%d: rank-count : %d scan-count : %d\n", __func__,
+                __LINE__, ext->ranked_count, ext->candidates_list.scan_count);
         }
     }
 
@@ -1916,9 +1996,6 @@ static int apply_pending_channel_change(vap_svc_t *svc, int vap_index)
     return RETURN_OK;
 }
 
-#define MAX_STR_LEN    128
-#define MAC_ADDR_STR_LEN 18
-
 int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
 {
     wifi_mgr_t *mgr = (wifi_mgr_t *)get_wifimgr_obj();
@@ -1941,7 +2018,7 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
     char *bridge_name = "brww0";
     char *bssid_mac_str = NULL;
     int ret = 0;
-
+    char tmp[MAX_STR_LEN] = {0};
     ctrl = svc->ctrl;
     ext = &svc->u.ext;
 
@@ -2014,9 +2091,11 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
 
             // change the state
             ext_set_conn_state(ext, connection_state_connected, __func__, __LINE__);
-            if (ctrl->rf_status_down == true) { 
-                char mac_str[32] = {'\0'};
+            if (ctrl->rf_status_down == true) {
+                char mac_str[32] = { '\0' };
+                char bssid_str[MAC_ADDR_STR_LEN] = {'\0'};
                 uint8_mac_to_string_mac(temp_vap_info->u.sta_info.mac, mac_str);
+                uint8_mac_to_string_mac(temp_vap_info->u.sta_info.bssid, bssid_str);
                 wifi_util_dbg_print(WIFI_CTRL,
                     "%s:%d Bridge:%s  Using MAC-Str:%s MAC : %02x:%02x:%02x:%02x:%02x:%02x\n",
                     __func__, __LINE__, bridge_name, mac_str, temp_vap_info->u.sta_info.mac[0],
@@ -2037,12 +2116,20 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
                 snprintf(cmd, sizeof(cmd), "ip link set dev %s up", bridge_name);
                 wifi_util_dbg_print(WIFI_CTRL,"%s:%d cmd : %s\n",__func__,__LINE__, cmd);
                 get_stubs_descriptor()->v_secure_system_fn(cmd);
-
+                hotspot_timing_connected(ext->connected_vap_index, bssid_str);
                 rc = publish_endpoint_status(ctrl, sta_data->stats.connect_status);
+                memset(tmp, 0, sizeof(tmp));
+                get_formatted_time(tmp);
                 if (rc != bus_error_success) {
-                    wifi_util_error_print(WIFI_CTRL,"IGNITE_RF_DOWN: Failed to publish connect status to WM\n");
+                    write_to_file(wifi_health_log, "\n%s WIFI_IGNITE_CONN_PUBLISH:False\n", tmp);
+                    get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_CONN_PUBLISH", "False");
+                    wifi_util_error_print(WIFI_CTRL,
+                        "IGNITE_RF_DOWN: Failed to publish connect status to WM\n");
                 } else {
-                    wifi_util_info_print(WIFI_CTRL,"IGNITE_RF_DOWN: Connect status sent successfully to the WM\n");
+                    write_to_file(wifi_health_log, "\n%s WIFI_IGNITE_CONN_PUBLISH:True\n", tmp);
+                    get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_CONN_PUBLISH", "True");
+                    wifi_util_info_print(WIFI_CTRL,
+                        "IGNITE_RF_DOWN: Connect status sent successfully to the WM\n");
                 }
                 bssid_mac_str = (char *)malloc(MAC_ADDR_STR_LEN);
                 if (bssid_mac_str != NULL) {
@@ -2169,12 +2256,20 @@ int process_ext_sta_conn_status(vap_svc_t *svc, void *arg)
 
         if (ctrl->rf_status_down == true) {
             rc = 0;
-	    rc = publish_endpoint_status(ctrl, sta_data->stats.connect_status);
-
+            hotspot_timing_disconnected();
+            rc = publish_endpoint_status(ctrl, sta_data->stats.connect_status);
+            memset(tmp, 0, sizeof(tmp));
+            get_formatted_time(tmp);
             if (rc != bus_error_success) {
-                wifi_util_error_print(WIFI_CTRL, "IGNITE_RF_DOWN: Failed to publish disconnect status to WM\n");
+                write_to_file(wifi_health_log, "\n%s WIFI_IGNITE_DISCONN_PUBLISH:False\n", tmp);
+                get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_DISCONN_PUBLISH", "False");
+                wifi_util_error_print(WIFI_CTRL,
+                    "IGNITE_RF_DOWN: Failed to publish disconnect status to WM\n");
             } else {
-                wifi_util_info_print(WIFI_CTRL, "IGNITE_RF_DOWN: Disconnect status sent successfully to the WM\n");
+                write_to_file(wifi_health_log, "\n%s WIFI_IGNITE_DISCONN_PUBLISH:True\n", tmp);
+                get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_DISCONN_PUBLISH", "True");
+                wifi_util_info_print(WIFI_CTRL,
+                    "IGNITE_RF_DOWN: Disconnect status sent successfully to the WM\n");
             }
         }
         if (ext->conn_state == connection_state_connection_to_nb_in_progress) {

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -426,6 +426,8 @@ void hotspot_cfg_sem_signal(bool status);
 bus_error_t publish_endpoint_status(wifi_ctrl_t *ctrl, int connection_status);
 int publish_endpoint_enable(void);
 int get_mld_mac_from_link_mac(mac_address_t in_addr, mac_address_t mld_addr);
+void hotspot_timing_start(void);
+void hotspot_timing_stop(void);
 
 #ifdef __cplusplus
 }

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -176,6 +176,15 @@ typedef struct kick_details {
 }kick_details_t;
 
 typedef struct {
+    struct timespec start_time;
+    struct timespec target_detection_time;
+    struct timespec end_time;
+    struct timespec disconnection_time;
+} hotspot_timing_t;
+
+extern hotspot_timing_t g_hotspot_timing;
+
+typedef struct {
     wifi_connection_status_t    connect_status;
     bssid_t                     bssid;
 }__attribute__((packed)) wifi_sta_conn_info_t;

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -27,17 +27,24 @@
 #include "wifi_monitor.h"
 #include "wifi_webconfig.h"
 #include "run_qmgr.h"
+#include "wifi_stubs.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include <limits.h>
+
 #define MAX_EVENT_NAME_SIZE 200
 #define MAX_STR_LEN 128
+#define MAX_BUFF_LEN 256
+#define MAX_TELEMETRY_BUFF_LEN 64
 #define MAX_STATUS_LEN 5
 #define STA_STATUS_DISCONNECTED 1
 
+hotspot_timing_t g_hotspot_timing;
 apply_ignite_config_t g_apply_ignite_config;
+
+static const char *wifi_health_log = "/rdklogs/logs/wifihealth.txt";
 
 static int get_subdoc_type(wifi_provider_response_t *response, webconfig_subdoc_type_t *subdoc,
     char *eventName)
@@ -144,6 +151,209 @@ static void mask_to_quality_flags(uint32_t mask, quality_flags_t* f)
     f->int_reconn   = mask & LINKQ_INT_RECONN;
 }
 
+static inline double hotspot_timing_elapsed_sec(const struct timespec *start,
+                                                const struct timespec *end)
+{
+    if (start->tv_sec == 0 || end->tv_sec == 0) {
+        wifi_util_error_print(WIFI_CTRL,
+            "HOTSPOT_TIMING: [elapsed_sec] invalid timestamp "
+            "Time_1=%ld Time_2=%ld\n",
+            (long)start->tv_sec, (long)end->tv_sec);
+        return 0.0;
+    }
+
+    long sec  = (long)(end->tv_sec  - start->tv_sec);
+    long nsec = (long)(end->tv_nsec - start->tv_nsec);
+
+    if (nsec < 0) {
+        sec  -= 1;
+        nsec += 1000000000L;
+    }
+
+    double elapsed = (double)sec + (double)nsec / 1000000000.0;
+
+    wifi_util_dbg_print(WIFI_CTRL,
+        "HOTSPOT_TIMING: [elapsed_sec] "
+        "start=%ld.%09ld end=%ld.%09ld elapsed=%.3f sec\n",
+        (long)start->tv_sec, (long)start->tv_nsec,
+        (long)end->tv_sec,   (long)end->tv_nsec,
+        elapsed);
+
+    return elapsed;
+}
+
+/* ------------------------------------------------------------------ */
+/* hotspot_timing_start()                                               */
+/* Called : start_station_vaps() when rf_status == true                */
+/* ------------------------------------------------------------------ */
+void hotspot_timing_start(void)
+{
+    clock_gettime(CLOCK_MONOTONIC, &g_hotspot_timing.start_time);
+
+    memset(&g_hotspot_timing.target_detection_time, 0, sizeof(struct timespec));
+    memset(&g_hotspot_timing.end_time,              0, sizeof(struct timespec));
+    memset(&g_hotspot_timing.disconnection_time,    0, sizeof(struct timespec));
+
+    wifi_util_dbg_print(WIFI_CTRL,
+        "HOTSPOT_TIMING: [start] start_time = %ld sec %ld nsec\n",
+        (long)g_hotspot_timing.start_time.tv_sec,
+        (long)g_hotspot_timing.start_time.tv_nsec);
+}
+
+/* ------------------------------------------------------------------ */
+/* hotspot_timing_stop()                                                */
+/* Called : start_station_vaps() when rf_status == false               */
+/* ------------------------------------------------------------------ */
+void hotspot_timing_stop(void)
+{
+    wifi_util_info_print(WIFI_CTRL,
+        "HOTSPOT_TIMING: [stop] RF restored – clearing all timestamps\n");
+
+    memset(&g_hotspot_timing, 0, sizeof(hotspot_timing_t));
+}
+
+/* ------------------------------------------------------------------ */
+/* hotspot_timing_target_detected()                                     */
+/* Called : ext_try_connecting() when target candidate is found         */
+/* ------------------------------------------------------------------ */
+void hotspot_timing_target_detected(void)
+{
+    char tmp[MAX_STR_LEN] = {0};
+    double target_detection_duration = 0.00;
+    char buff[MAX_BUFF_LEN] = {0};
+    char telemetry_buf[MAX_TELEMETRY_BUFF_LEN] = {0};
+
+    /* Already recorded for this attempt — skip */
+    if (g_hotspot_timing.target_detection_time.tv_sec != 0) {
+        wifi_util_info_print(WIFI_CTRL,
+            "HOTSPOT_TIMING: [target_detected] already recorded "
+            "(%ld sec) – skip\n",
+            (long)g_hotspot_timing.target_detection_time.tv_sec);
+        return;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &g_hotspot_timing.target_detection_time);
+    get_formatted_time(tmp);
+    target_detection_duration = hotspot_timing_elapsed_sec(&g_hotspot_timing.start_time,
+		    &g_hotspot_timing.target_detection_time);
+
+    snprintf(buff, MAX_BUFF_LEN, "%s WIFI_IGNITE_HOTSPOT_TARGET_DETECTION_TIME:%.3f\n", tmp, target_detection_duration);
+    write_to_file(wifi_health_log, buff);
+    snprintf(telemetry_buf, MAX_TELEMETRY_BUFF_LEN, "%.3f", target_detection_duration);
+    get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_HOTSPOT_TARGET_DETECTION_TIME", telemetry_buf);
+    wifi_util_dbg_print(WIFI_CTRL,
+		    "HOTSPOT_TIMING: [target_detected] target_detection_time = "
+		    "%ld sec %ld nsec\n",
+        (long)g_hotspot_timing.target_detection_time.tv_sec,
+        (long)g_hotspot_timing.target_detection_time.tv_nsec);
+}
+
+/* ------------------------------------------------------------------ */
+/* hotspot_timing_connected()                                           */
+/* Called : process_ext_sta_conn_status() on connected event           */
+/* Note   : end_time preserved for disconnected() check                */
+/*          Only target_detection_time is reset here                   */
+/* ------------------------------------------------------------------ */
+void hotspot_timing_connected(unsigned int vap_index, char *bssid_str)
+{
+    char tmp[MAX_STR_LEN] = {0};
+    double connection_duration = 0.00;
+    char buff[MAX_BUFF_LEN] = {0};
+    char telemetry_buf[MAX_TELEMETRY_BUFF_LEN] = {0};
+    clock_gettime(CLOCK_MONOTONIC, &g_hotspot_timing.end_time);
+
+    wifi_util_dbg_print(WIFI_CTRL,
+        "HOTSPOT_TIMING: [connected] end_time = %ld sec %ld nsec\n",
+        (long)g_hotspot_timing.end_time.tv_sec,
+        (long)g_hotspot_timing.end_time.tv_nsec);
+
+    connection_duration = hotspot_timing_elapsed_sec(&g_hotspot_timing.start_time,
+                                   &g_hotspot_timing.end_time);
+
+    wifi_util_info_print(WIFI_CTRL,
+        "HOTSPOT_TIMING: [connected] Duration of RF failure = %.3f sec\n", connection_duration);
+
+    get_formatted_time(tmp);
+    snprintf(buff, MAX_BUFF_LEN, "%s WIFI_IGNITE_HOTSPOT_CONN_INFO: %u %s %.3f\n", tmp, vap_index, bssid_str, connection_duration);
+    write_to_file(wifi_health_log, buff);
+    memset(telemetry_buf, 0, MAX_TELEMETRY_BUFF_LEN);
+    snprintf(telemetry_buf, MAX_TELEMETRY_BUFF_LEN, "%u %s %.3f", vap_index, bssid_str, connection_duration);
+    get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_HOTSPOT_CONN_INFO", telemetry_buf);
+
+    //Reset the target detection time once the enrollee connection established to hotspot
+    memset(&g_hotspot_timing.target_detection_time, 0, sizeof(struct timespec));
+}
+
+/* ------------------------------------------------------------------ */
+/* hotspot_timing_disconnected()                                        */
+/* Called : process_ext_sta_conn_status() on disconnected event        */
+/* ------------------------------------------------------------------ */
+void hotspot_timing_disconnected(void)
+{
+    char tmp[MAX_STR_LEN] = { 0 };
+    double session_duration = 0.00;
+    char buff[MAX_BUFF_LEN] = { 0 };
+    char telemetry_buf[MAX_TELEMETRY_BUFF_LEN] = { 0 };
+
+    if (g_hotspot_timing.end_time.tv_sec != 0) {
+        clock_gettime(CLOCK_MONOTONIC, &g_hotspot_timing.disconnection_time);
+
+        wifi_util_dbg_print(WIFI_CTRL,
+            "HOTSPOT_TIMING: [disconnected] disconnection_time = "
+            "%ld sec %ld nsec\n",
+            (long)g_hotspot_timing.disconnection_time.tv_sec,
+            (long)g_hotspot_timing.disconnection_time.tv_nsec);
+
+        get_formatted_time(tmp);
+        session_duration = hotspot_timing_elapsed_sec(&g_hotspot_timing.end_time,
+            &g_hotspot_timing.disconnection_time);
+        wifi_util_info_print(WIFI_CTRL,
+            "HOTSPOT_TIMING: [disconnected] "
+            "Connection held for = %.3f sec\n",
+            session_duration);
+        snprintf(buff, sizeof(buff), "%s WIFI_IGNITE_HOTSPOT_SESSION_DURATION_SEC:%.3f\n", tmp,
+            session_duration);
+        write_to_file(wifi_health_log, buff);
+        memset(telemetry_buf, 0, sizeof(telemetry_buf));
+        snprintf(telemetry_buf, sizeof(telemetry_buf), "%.3f", session_duration);
+        get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_HOTSPOT_SESSION_DURATION_SEC",
+            telemetry_buf);
+        /* Assign before clearing disconnection_time */
+        g_hotspot_timing.start_time = g_hotspot_timing.disconnection_time;
+
+        wifi_util_dbg_print(WIFI_CTRL,
+            "HOTSPOT_TIMING: [disconnected] was connected – "
+            "start_time reset to %ld sec for next attempt\n",
+            (long)g_hotspot_timing.start_time.tv_sec);
+
+        memset(&g_hotspot_timing.target_detection_time, 0, sizeof(struct timespec));
+        memset(&g_hotspot_timing.end_time, 0, sizeof(struct timespec));
+        memset(&g_hotspot_timing.disconnection_time, 0, sizeof(struct timespec));
+
+    } else {
+        /*
+         * end_time == 0 → device never connected this attempt.
+         * Log elapsed from current start_time.
+         * Preserve start_time and target_detection_time for next attempt.
+         */
+        clock_gettime(CLOCK_MONOTONIC, &g_hotspot_timing.disconnection_time);
+
+        wifi_util_info_print(WIFI_CTRL,
+            "HOTSPOT_TIMING: [disconnected] disconnection_time = "
+            "%ld sec %ld nsec\n",
+            (long)g_hotspot_timing.disconnection_time.tv_sec,
+            (long)g_hotspot_timing.disconnection_time.tv_nsec);
+
+        wifi_util_info_print(WIFI_CTRL,
+            "HOTSPOT_TIMING: [disconnected] "
+            "Disconnected before connecting – elapsed = %.3f sec\n",
+            hotspot_timing_elapsed_sec(&g_hotspot_timing.start_time,
+                &g_hotspot_timing.disconnection_time));
+
+        memset(&g_hotspot_timing.disconnection_time, 0, sizeof(struct timespec));
+    }
+}
+
 bus_error_t get_endpoint_enable(char *name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     (void)user_data;
@@ -163,6 +373,7 @@ bus_error_t set_endpoint_enable(char *name, raw_data_t *p_data, bus_user_data_t 
     (void)user_data;
     bus_error_t rc = bus_error_success;
     bool rf_status = false;
+    char tmp[MAX_STR_LEN] = {0};
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     if (ctrl == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d NULL pointers\n", __func__, __LINE__);
@@ -181,9 +392,13 @@ bus_error_t set_endpoint_enable(char *name, raw_data_t *p_data, bus_user_data_t 
     ctrl->rf_status_down = rf_status;
     wifi_util_info_print(WIFI_CTRL, "%s:%d RF-Status : %d\n", __func__, __LINE__, ctrl->rf_status_down);
     start_station_vaps(rf_status);
+    get_formatted_time(tmp);
     if (rf_status) {
-	    wifi_util_info_print(WIFI_CTRL, "IGNITE_RF_DOWN: Docsis disabled. Starting Station Vaps\n");
-        apps_mgr_link_quality_event(&ctrl->apps_mgr, wifi_event_type_exec, wifi_event_exec_start, NULL, 0);
+        write_to_file(wifi_health_log, "\n%s WIFI_IGNITE_ENABLED:True\n", tmp);
+        get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_ENABLED", "True");
+        wifi_util_info_print(WIFI_CTRL, "IGNITE_RF_DOWN: Docsis disabled. Starting Station Vaps\n");
+        apps_mgr_link_quality_event(&ctrl->apps_mgr, wifi_event_type_exec, wifi_event_exec_start,
+            NULL, 0);
 
         wifi_global_config_t *global_cfg = get_wifidb_wifi_global_config();
         if (global_cfg != NULL &&
@@ -206,6 +421,8 @@ bus_error_t set_endpoint_enable(char *name, raw_data_t *p_data, bus_user_data_t 
             }
         }
     } else {
+        write_to_file(wifi_health_log, "\n%s WIFI_IGNITE_ENABLED:False\n", tmp);
+        get_stubs_descriptor()->t2_event_s_fn("WIFI_IGNITE_ENABLED", "False");
        wifi_util_info_print(WIFI_CTRL, "IGNITE_RF_DOWN: Docsis enabled. Stoping Station Vaps\n");
        apps_mgr_link_quality_event(&ctrl->apps_mgr, wifi_event_type_exec, wifi_event_exec_stop, NULL, 0);
        //Stop station vaps

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -3198,10 +3198,12 @@ void start_station_vaps(bool rf_status)
         wifi_util_error_print(WIFI_CTRL, "[%s %d] vap-idx : %d radio-idx : %d vap-array-idx : %d\n", __func__, __LINE__, vap_index,
                 radio_index, vap_array_index);
         if (rf_status == true) {
+	    hotspot_timing_start();
             data->u.decoded.radios[radio_index]
                 .vaps.vap_map.vap_array[vap_array_index]
                 .u.sta_info.ignite_enabled = true;
         } else {
+	    hotspot_timing_stop();
             data->u.decoded.radios[radio_index]
                 .vaps.vap_map.vap_array[vap_array_index]
                 .u.sta_info.ignite_enabled = false;


### PR DESCRIPTION
[RDKB-64929] Ignite telemetry markers

Reason for change: Added t2 events to trace ignite functionality
Test Procedure: Added events were updated in the telemetry logs.
Risks: Low
Signed-off-by: Dharmalakshmi A Dharmalakshmi_Annamalai@comcast.com