### PR TITLE
RDKB-65513: Send MLO LmLite notifications from the associ link in backward compatibility mode (#1183)

### DIFF
--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -2448,6 +2448,20 @@ static void assoc_dev_event(assoc_dev_data_t *assoc_data)
     }
 }
 
+static void assoc_dev_update_mlo_link(assoc_dev_data_t *assoc_data, int link_idx)
+{
+    if (assoc_data == NULL || link_idx < 0 || link_idx >= MAX_NUM_RADIOS) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid input parameters assoc_data: %p, link_idx: %d\n",
+            __func__, __LINE__, assoc_data, link_idx);
+        return;
+    }
+    assoc_data->ap_index = assoc_data->mld_info.cli_LinkInfo[link_idx].cli_VapIndex;
+    assoc_data->dev_stats.cli_RSSI = assoc_data->mld_info.cli_LinkInfo[link_idx].cli_RSSI;
+    assoc_data->association_link = assoc_data->mld_info.cli_LinkInfo[link_idx].cli_IsAssocLink;
+    memcpy(assoc_data->link_address, assoc_data->mld_info.cli_LinkInfo[link_idx].cli_LinkAddress,
+        sizeof(assoc_data->link_address));
+}
+
 void process_assoc_device_event(void *data)
 {
     if (data == NULL) {
@@ -2460,16 +2474,22 @@ void process_assoc_device_event(void *data)
     check_and_remove_mac_on_other_vaps(assoc_data);
 
     if (assoc_data->mld_info.cli_MLDSta == true) {
+        int assoc_link_idx = -1;
         for (int link_idx = 0; link_idx < MAX_NUM_RADIOS; link_idx++) {
             if (assoc_data->mld_info.cli_LinkInfo[link_idx].cli_Valid) {
-                UINT link_vap_index = assoc_data->mld_info.cli_LinkInfo[link_idx].cli_VapIndex;
-                assoc_data->ap_index = link_vap_index;
-                assoc_data->dev_stats.cli_RSSI = assoc_data->mld_info.cli_LinkInfo[link_idx].cli_RSSI;
-                assoc_data->association_link = assoc_data->mld_info.cli_LinkInfo[link_idx].cli_IsAssocLink;
-                memcpy(assoc_data->link_address, assoc_data->mld_info.cli_LinkInfo[link_idx].cli_LinkAddress,
-                    sizeof(assoc_data->link_address));
+                if (assoc_data->mld_info.cli_LinkInfo[link_idx].cli_IsAssocLink) {
+                    assoc_link_idx = link_idx;
+                }
+                assoc_dev_update_mlo_link(assoc_data, link_idx);
                 assoc_dev_event(assoc_data);
             }
+        }
+        /* In case of MLO client upcoming LM_lite notification needs to be from assoc link */
+        if (assoc_link_idx != -1) {
+            assoc_dev_update_mlo_link(assoc_data, assoc_link_idx);
+        } else {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d No valid associated link found for MLD STA " MAC_FMT "\n",
+                __func__, __LINE__, MAC_ARG(assoc_data->dev_stats.cli_MACAddress));
         }
     } else {
         assoc_dev_event(assoc_data);

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -474,7 +474,7 @@ static int notify_LM_Lite_host(wifi_ctrl_t *ctrl, LM_wifi_host_t *host, bool syn
         ('\0' != host->ssid[0]) ? (char *)host->ssid : "NULL",
         (char *)host->RSSI, (host->Status == TRUE) ? 1 : 0, host->mld_sta);
 #endif /*CONFIG_MLO_ENABLED_NOTIFY_LM_LITE*/
-
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d: msg: %s\n", __func__, __LINE__, str);
     rc = get_bus_descriptor()->bus_set_string_fn(&ctrl->handle, WIFI_LMLITE_NOTIFY, str);
     if (rc != bus_error_success) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: bus: Write Failed %d\n", __func__, __LINE__,


### PR DESCRIPTION
RDKB-65513: Send MLO LmLite notifications from the associ link in backward compatibility mode (#1183)

Reason for change: The MLO client notification to LmLite must be issued from the associated link
	when operating in backward compatibility (when CONFIG_MLO_ENABLED_NOTIFY_LM_LITE  config is not enabled)

Test Procedure: On the OneWifi build in backward compatibility mode when CONFIG_MLO_ENABLED_NOTIFY_LM_LITE is disabled,
	verify if the connection/disconnection LmLite notification are sent from same VAP and it is assoc link VAP

Risks:Low
Priority:P1