### PR TITLE
RDKB-63482: MLO reconfiguration improvements and DML updates (#1104)

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -1913,6 +1913,12 @@ INSTMSMT_PH2 -->
                             <writable>true</writable>
                         </parameter>
                         <parameter>
+                            <name>X_RDK_MLDLinkID</name>
+                            <type>unsignedInt[0:255]</type>
+                            <syntax>uint32</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
                             <name>Enable</name>
                             <type>boolean</type>
                             <syntax>bool</syntax>
@@ -2209,31 +2215,25 @@ INSTMSMT_PH2 -->
                             <name>MLD_Enable</name>
                             <type>boolean</type>
                             <syntax>bool</syntax>
-                            <writable>true</writable>
+                            <writable>false</writable>
                         </parameter>
                         <parameter>
                             <name>MLD_ID</name>
                             <type>unsignedInt[0:255]</type>
                             <syntax>uint32</syntax>
-                            <writable>true</writable>
+                            <writable>false</writable>
                         </parameter>
                         <parameter>
                             <name>MLD_Link_ID</name>
                             <type>unsignedInt[0:255]</type>
                             <syntax>uint32</syntax>
-                            <writable>true</writable>
+                            <writable>false</writable>
                         </parameter>
                         <parameter>
                             <name>MLD_Addr</name>
                             <type>string(32)</type>
                             <syntax>string</syntax>
                             <writable>false</writable>
-                        </parameter>
-                        <parameter>
-                            <name>MLD_Apply</name>
-                            <type>boolean</type>
-                            <syntax>bool</syntax>
-                            <writable>true</writable>
                         </parameter>
                         <parameter>
                             <name>RetryLimit</name>

--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -1210,24 +1210,6 @@
             "min": 0,
             "max": 1
           }
-        },
-        "mld_addr": {
-          "type": {
-            "key": {
-              "type": "string"
-            },
-            "min": 0,
-            "max": 1
-          }
-        },
-        "mld_apply": {
-          "type": {
-            "key": {
-              "type": "boolean"
-            },
-            "min": 0,
-            "max": 1
-          }
         }
       },
     "isRoot": true

--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -99,6 +99,7 @@ extern "C" {
 
 #define UNDEFINED_MLD_ID 255
 #define MLD_UNIT_COUNT 8
+#define MIN_MLO_GROUP_SIZE 2
 
 #define PLAN_ID_LENGTH     38
 #define MAX_STEP_COUNT  32 /*Active Measurement Step Count */

--- a/lib/inc/schema_gen.h
+++ b/lib/inc/schema_gen.h
@@ -153,8 +153,6 @@
         PJS_OVS_BOOL(mld_enable) \
         PJS_OVS_INT(mld_id) \
         PJS_OVS_INT(mld_link_id) \
-        PJS_OVS_STRING(mld_addr, 32 + 1) \
-        PJS_OVS_BOOL(mld_apply) \
     )
 
 #define PJS_SCHEMA_Wifi_Interworking_Config \
@@ -2111,9 +2109,7 @@
     COLUMN(repurposed_bridge_name)\
     COLUMN(mld_enable)\
     COLUMN(mld_id)\
-    COLUMN(mld_link_id)\
-    COLUMN(mld_addr)\
-    COLUMN(mld_apply)
+    COLUMN(mld_link_id)
 
 #define SCHEMA__Wifi_Interworking_Config "Wifi_Interworking_Config"
 #define SCHEMA_COLUMN__Wifi_Interworking_Config(COLUMN) \
@@ -3492,8 +3488,6 @@
 #define SCHEMA__Wifi_VAP_Config__mld_enable "mld_enable"
 #define SCHEMA__Wifi_VAP_Config__mld_id "mld_id"
 #define SCHEMA__Wifi_VAP_Config__mld_link_id "mld_link_id"
-#define SCHEMA__Wifi_VAP_Config__mld_addr "mld_addr"
-#define SCHEMA__Wifi_VAP_Config__mld_apply "mld_apply"
 
 #define SCHEMA__Wifi_Interworking_Config__enable "enable"
 #define SCHEMA__Wifi_Interworking_Config__vap_name "vap_name"

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1771,7 +1771,6 @@ int init_wireless_interface_mac()
                 memcpy(wifi_vap_info->u.bss_info.mld_info.common_info.mld_addr, hal_vap_info_map->vap_array[j].u.bss_info.mld_info.common_info.mld_addr, sizeof(wifi_vap_info->u.bss_info.mld_info.common_info.mld_addr));
                 wifi_vap_info->u.bss_info.mld_info.common_info.mld_link_id = hal_vap_info_map->vap_array[j].u.bss_info.mld_info.common_info.mld_link_id;
                 wifi_vap_info->u.bss_info.mld_info.common_info.mld_id = hal_vap_info_map->vap_array[j].u.bss_info.mld_info.common_info.mld_id;
-                wifi_vap_info->u.bss_info.mld_info.common_info.mld_apply = hal_vap_info_map->vap_array[j].u.bss_info.mld_info.common_info.mld_apply;
 #endif
             }
         }
@@ -1780,6 +1779,36 @@ int init_wireless_interface_mac()
     hal_vap_info_map = NULL;
     return RETURN_OK;
 }
+
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+/**
+ * Called after init_wireless_interface_mac() so mgr cache BSSIDs are populated.
+ * Updates mld_enable/mld_addr in the mgr cache and writes changed radios to DB.
+ */
+void init_wifi_mld_groups(void)
+{
+    unsigned int r_idx;
+    unsigned int radio_bitmap = 0;
+    wifi_vap_info_map_t *mgr_vap_info_map;
+
+    radio_bitmap = update_mld_groups(NULL, NULL, 0, WIFI_CTRL);
+
+    for (r_idx = 0; r_idx < getNumberRadios(); r_idx++) {
+        if (!(radio_bitmap & (1u << r_idx))) {
+            continue;
+        }
+        mgr_vap_info_map = get_wifidb_vap_map(r_idx);
+        if (mgr_vap_info_map != NULL) {
+            rdk_wifi_vap_info_t *rdk_vaps = get_wifidb_rdk_vaps(r_idx);
+            if (rdk_vaps != NULL) {
+                wifidb_update_wifi_vap_config(r_idx, mgr_vap_info_map, rdk_vaps);
+                wifi_util_dbg_print(WIFI_CTRL, "%s:%d: Updated MLD group info for radio index %d\n", __func__, __LINE__, r_idx);
+            }
+        }
+    }
+}
+#endif /* CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO */
+
 int validate_and_sync_private_vap_credentials()
 {
     uint8_t num_of_radios = getNumberRadios();
@@ -1864,10 +1893,13 @@ int start_wifi_ctrl(wifi_ctrl_t *ctrl)
 
     monitor_ret = init_wifi_monitor();
 
-    start_wifi_services();
-
     init_wireless_interface_mac();
 
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    init_wifi_mld_groups();
+#endif
+
+    start_wifi_services();
 
     ctrl->webconfig_state = ctrl_webconfig_state_vap_all_cfg_rsp_pending;
     telemetry_bootup_time_wifibroadcast(); //Telemetry Marker for btime_wifibcast_split
@@ -3239,6 +3271,243 @@ BOOL isRadioBeEnabled(UINT radio_index)
 #endif /* CONFIG_IEEE80211BE */
     return FALSE;
 }
+
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+static bool is_mlo_wpa3_personal(wifi_security_modes_t mode)
+{
+    return (mode == wifi_security_mode_wpa3_personal ||
+            mode == wifi_security_mode_wpa3_transition ||
+            mode == wifi_security_mode_wpa3_compatibility);
+}
+
+static bool is_mlo_security_mode_compatible(wifi_security_modes_t mode_a,
+    wifi_security_modes_t mode_b)
+{
+    if (mode_a == mode_b) {
+        return true;
+    }
+
+    if (is_mlo_wpa3_personal(mode_a) && is_mlo_wpa3_personal(mode_b)) {
+        return true;
+    }
+
+    return false;
+}
+
+/* Check if VAP's SSID, password, and security mode match the main link. */
+bool is_mlo_config_matching(wifi_vap_info_t *main_vap, wifi_vap_info_t *vap)
+{
+    /* Compare SSID */
+    if (strncmp(main_vap->u.bss_info.ssid, vap->u.bss_info.ssid, sizeof(ssid_t)) != 0) {
+        return false;
+    }
+
+    /* Compare Password/Key */
+    if (strncmp(main_vap->u.bss_info.security.u.key.key,
+                vap->u.bss_info.security.u.key.key,
+                sizeof(main_vap->u.bss_info.security.u.key.key)) != 0) {
+        return false;
+    }
+
+    /* Compare Security Mode — WPA3 variants are MLO-compatible across bands */
+    if (!is_mlo_security_mode_compatible(main_vap->u.bss_info.security.mode,
+            vap->u.bss_info.security.mode)) {
+        return false;
+    }
+
+    return true;
+}
+
+static wifi_vap_info_t *webconfig_find_vap_by_name(webconfig_subdoc_decoded_data_t *data, char *vap_name)
+{
+    unsigned int j, k;
+
+    for (j = 0; j < getNumberRadios(); j++) {
+        for (k = 0; k < getNumberVAPsPerRadio(j); k++) {
+            if (strcmp(data->radios[j].vaps.vap_map.vap_array[k].vap_name, vap_name) == 0) {
+                return &data->radios[j].vaps.vap_map.vap_array[k];
+            }
+        }
+    }
+    return NULL;
+}
+
+typedef struct {
+    wifi_mld_common_info_t *mld_conf;
+    wifi_vap_info_t        *vap_info;
+    bool                    is_compatible;
+} mld_group_entry_t;
+
+/**
+ * update_mld_groups - Common MLO group validation and propagation.
+ *
+ * Iterates all MLD units (0..MLD_UNIT_COUNT-1). For each unit, walks all
+ * radios/VAPs in the mgr cache:
+ *   - If data != NULL (webconfig path): only processes VAPs in vap_names[],
+ *     modifies the vap_info from webconfig decoded data.
+ *   - If data == NULL (DB/init path): processes all VAPs, modifies mgr cache directly.
+ *   - Seeds mld_addr from mgr cache BSSID (first pass only)
+ *   - Disables MLD, validates bounds, collects candidates
+ *   - Tags compatible entries via is_mlo_config_matching()
+ *   - Validates group (>= MIN_MLO_GROUP_SIZE, main link, non-zero MAC)
+ *   - Propagates shared MLD address to compatible entries
+ *
+ * @param data           Webconfig decoded data (NULL for DB/init path)
+ * @param vap_names      Array of VAP names to filter (ignored if data == NULL)
+ * @param vap_names_size Number of entries in vap_names (ignored if data == NULL)
+ * @param log_type       Log module (WIFI_MGR, WIFI_DB, etc.)
+ * @return Bitmask of radio indices where mld_enable was changed
+ */
+unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
+    char **vap_names, unsigned int vap_names_size, wifi_dbg_type_t log_type)
+{
+    const mac_address_t zero_mac = { 0 };
+    mac_address_t mlo_mac = { 0 };
+    mac_addr_str_t mac_str = { 0 };
+    unsigned int radio_bitmap = 0;
+    unsigned int i;
+
+    for (i = 0; i < MLD_UNIT_COUNT; i++) {
+        unsigned int total_candidates = 0;
+        unsigned int compatible_count = 0;
+        unsigned int r_idx, k;
+        wifi_vap_info_t *main_link_vap = NULL;
+        mld_group_entry_t entries[MAX_NUM_RADIOS];
+
+        memset(entries, 0, sizeof(entries));
+        memset(mlo_mac, 0, sizeof(mac_address_t));
+
+        /* --- STEP 1: Seed MLD Address and Collect Candidates for this unit --- */
+        for (r_idx = 0; r_idx < getNumberRadios(); r_idx++) {
+            wifi_vap_info_map_t *mgr_vap_map = get_wifidb_vap_map(r_idx);
+            if (mgr_vap_map == NULL) {
+                continue;
+            }
+
+            for (k = 0; k < mgr_vap_map->num_vaps; k++) {
+                wifi_vap_info_t *mgr_vap = &mgr_vap_map->vap_array[k];
+                wifi_vap_info_t *target_vap = NULL;
+                wifi_mld_common_info_t *mld_conf = NULL;
+
+                if (isVapSTAMesh(mgr_vap->vap_index)) {
+                    continue;
+                }
+
+                /* Determine target vap_info to modify */
+                if (data != NULL) {
+                    /* Webconfig path: only process VAPs in vap_names list */
+                    unsigned int n;
+                    for (n = 0; n < vap_names_size; n++) {
+                        if (strcmp(vap_names[n], mgr_vap->vap_name) == 0) {
+                            target_vap = webconfig_find_vap_by_name(data, mgr_vap->vap_name);
+                            break;
+                        }
+                    }
+                } else {
+                    /* DB/init path: modify mgr cache directly */
+                    target_vap = mgr_vap;
+                }
+
+                if (target_vap == NULL) {
+                    continue;
+                }
+
+                mld_conf = &target_vap->u.bss_info.mld_info.common_info;
+
+                /* Seed mld_addr and disable MLD on first pass only.
+                 * Subsequent group iterations must not overwrite values
+                 * already propagated by an earlier group. */
+                if (i == 0) {
+                    memcpy(mld_conf->mld_addr, mgr_vap->u.bss_info.bssid, sizeof(mac_address_t));
+                    if (mld_conf->mld_enable) {
+                        radio_bitmap |= (1u << mgr_vap->radio_index);
+                    }
+                    mld_conf->mld_enable = false;
+                }
+
+                /* Validate MLD configuration bounds */
+                if (mld_conf->mld_id >= MLD_UNIT_COUNT || mld_conf->mld_link_id >= MAX_NUM_MLD_LINKS) {
+                    continue;
+                }
+
+                /* Only collect VAPs belonging to the current MLD unit */
+                if (mld_conf->mld_id != i) {
+                    continue;
+                }
+
+                /* Main link (link_id == 0) provides the shared MLD MAC address */
+                if (mld_conf->mld_link_id == 0 && target_vap->u.bss_info.enabled == true) {
+                    main_link_vap = target_vap;
+                    memcpy(mlo_mac, mgr_vap->u.bss_info.bssid, sizeof(mac_address_t));
+                }
+
+                /* Store candidate */
+                if (total_candidates < MAX_NUM_RADIOS) {
+                    entries[total_candidates].mld_conf = mld_conf;
+                    entries[total_candidates].vap_info = target_vap;
+                    entries[total_candidates].is_compatible = false;
+                    total_candidates++;
+                }
+            }
+        }
+
+        /* --- STEP 2: Tag Entries as Compatible with the Main Link --- */
+        if (main_link_vap != NULL) {
+            unsigned int j;
+            for (j = 0; j < total_candidates; j++) {
+                mld_group_entry_t *entry = &entries[j];
+
+                if (entry->vap_info == main_link_vap ||
+                        is_mlo_config_matching(main_link_vap, entry->vap_info)) {
+                    entry->is_compatible = true;
+                    compatible_count++;
+                } else {
+                    wifi_util_info_print(log_type,
+                        "%s:%d: vap_index=%d excluded from MLO group %d "
+                        "(SSID/security mismatch with main link)\n",
+                        __func__, __LINE__, entry->vap_info->vap_index, i);
+                }
+            }
+        }
+
+        /* --- STEP 3: Validate Group and Propagate Shared MLD Address --- */
+        if (compatible_count < MIN_MLO_GROUP_SIZE || main_link_vap == NULL ||
+                memcmp(mlo_mac, zero_mac, sizeof(mac_address_t)) == 0) {
+            if (total_candidates > 0) {
+                wifi_util_info_print(log_type,
+                    "%s:%d: MLO group %d disabled (compatible_count=%u, main_link=%s)\n",
+                    __func__, __LINE__, i, compatible_count,
+                    main_link_vap ? "Found" : "Missing");
+            }
+            continue;
+        }
+
+        to_mac_str(mlo_mac, mac_str);
+        {
+            unsigned int j;
+            for (j = 0; j < total_candidates; j++) {
+                mld_group_entry_t *entry = &entries[j];
+
+                if (!entry->is_compatible) {
+                    continue;
+                }
+
+                entry->mld_conf->mld_enable = true;
+                memcpy(entry->mld_conf->mld_addr, mlo_mac, sizeof(mac_address_t));
+                radio_bitmap |= (1u << entry->vap_info->radio_index);
+
+                wifi_util_info_print(log_type,
+                    "%s:%d: MLO Enabled! mld_addr=%s for vap_index=%d (link_id=%d, mld_id=%d)\n",
+                    __func__, __LINE__, mac_str, entry->vap_info->vap_index,
+                    entry->mld_conf->mld_link_id, entry->mld_conf->mld_id);
+            }
+        }
+    }
+
+    return radio_bitmap;
+}
+
+#endif /* CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO */
 
 void get_subdoc_name_from_vap_index(uint8_t vap_index, int* subdoc)
 {

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -429,6 +429,11 @@ int get_mld_mac_from_link_mac(mac_address_t in_addr, mac_address_t mld_addr);
 void hotspot_timing_start(void);
 void hotspot_timing_stop(void);
 
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
+    char **vap_names, unsigned int vap_names_size, wifi_dbg_type_t log_type);
+#endif /* CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO */
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -851,165 +851,6 @@ bool is_force_apply_true(rdk_wifi_vap_info_t *rdk_vap_info) {
     return false;
 }
 
-
-#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
-wifi_vap_info_t *get_vap_info_from_webconfig(webconfig_subdoc_decoded_data_t *data, char *vap_name)
-{
-    unsigned int j, k;
-
-    for (j = 0; j < getNumberRadios(); j++) {
-        for (k = 0; k < getNumberVAPsPerRadio(j); k++) {
-            if (strcmp(data->radios[j].vaps.vap_map.vap_array[k].vap_name, vap_name) == 0) {
-                return &data->radios[j].vaps.vap_map.vap_array[k];
-            }
-        }
-    }
-    return NULL;
-}
-
-wifi_vap_info_t *get_vap_info_from_radio(char *vap_name)
-{
-    unsigned int j;
-    int tgt_radio_idx, tgt_vap_index;
-    rdk_wifi_radio_t *radio;
-    wifi_vap_info_t *mgr_vap_info = NULL;
-    wifi_vap_info_map_t *mgr_vap_map = NULL;
-    wifi_mgr_t *mgr = get_wifimgr_obj();
-
-    if ((tgt_radio_idx = convert_vap_name_to_radio_array_index(&mgr->hal_cap.wifi_prop, vap_name)) == -1) {
-        wifi_util_error_print(WIFI_MGR, "%s:%d: Could not find radio index for vap name:%s\n",
-                    __func__, __LINE__, vap_name);
-        return NULL;
-    }
-
-    tgt_vap_index = convert_vap_name_to_index(&mgr->hal_cap.wifi_prop, vap_name);
-    if (tgt_vap_index == -1) {
-        wifi_util_error_print(WIFI_MGR, "%s:%d: Could not find vap index for vap name:%s\n",
-                    __func__, __LINE__, vap_name);
-        return NULL;
-    }
-
-    for (j = 0; j < getNumberRadios(); j++) {
-        radio = &mgr->radio_config[j];
-        if (radio->vaps.radio_index == (unsigned int)tgt_radio_idx) {
-            mgr_vap_map = &radio->vaps.vap_map;
-            break;
-        }
-    }
-
-    if (mgr_vap_map == NULL) {
-        wifi_util_error_print(WIFI_MGR,
-            "%s:%d: Could not find tgt_radio_idx:%d for vap name:%s\n", __func__, __LINE__,
-            tgt_radio_idx, vap_name);
-        return NULL;
-    }
-
-    for (j = 0; j < mgr_vap_map->num_vaps; j++) {
-        if (mgr_vap_map->vap_array[j].vap_index == (unsigned int)tgt_vap_index) {
-            mgr_vap_info = &mgr_vap_map->vap_array[j];
-            break;
-        }
-    }
-
-    return mgr_vap_info;
-}
-
-static void update_mld_group(webconfig_subdoc_decoded_data_t *data, char **vap_names, unsigned int size)
-{
-    unsigned int i;
-    wifi_vap_info_t *mgr_vap_info, *vap_info;
-    wifi_mld_common_info_t *mld_conf;
-    mac_address_t zero_mac = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    mac_address_t mlo_mac = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    mac_addr_str_t mac_str = { 0 };
-    unsigned char *mld_addr_map[MAX_NUM_RADIOS] = { 0 };
-    unsigned char mld_id = UNDEFINED_MLD_ID;
-    wifi_mld_common_info_t *mld_map[MAX_NUM_RADIOS] = { 0 };
-    unsigned int mld_vap_count = 0;
-    bool disable_mld = false;
-
-    if (size > MAX_NUM_RADIOS) {
-        wifi_util_error_print(WIFI_MGR, "%s:%d: size %d exceeds MAX_NUM_RADIOS %d\n",
-            __func__, __LINE__, size, MAX_NUM_RADIOS);
-        return;
-    }
-    for (i = 0; i < size; i++) {
-
-        vap_info = get_vap_info_from_webconfig(data, vap_names[i]);
-        if (vap_info == NULL) {
-            wifi_util_error_print(WIFI_MGR, "%s:%d: Could not find vap_info vap name:%s\n",
-                __func__, __LINE__, vap_names[i]);
-            return;
-        }
-
-        if (isVapSTAMesh(vap_info->vap_index))
-            continue;
-
-        mgr_vap_info = get_vap_info_from_radio(vap_names[i]);
-        if (mgr_vap_info == NULL) {
-            wifi_util_error_print(WIFI_MGR, "%s:%d: Could not find mgr_vap_info vap name:%s\n",
-                __func__, __LINE__, vap_names[i]);
-            return;
-        }
-
-        mld_conf = &vap_info->u.bss_info.mld_info.common_info;
-
-        /* Initialize mld_mac with VAP's BSSID */
-        memcpy(mld_conf->mld_addr, mgr_vap_info->u.bss_info.bssid, sizeof(mac_address_t));
-
-        if (mld_conf->mld_id < MLD_UNIT_COUNT && mld_conf->mld_link_id < MAX_NUM_MLD_LINKS) {
-            if (mld_id == UNDEFINED_MLD_ID)
-                mld_id = mld_conf->mld_id;
-            if (mld_id != mld_conf->mld_id) {
-                wifi_util_error_print(WIFI_MGR, "%s:%d: vap name:%s is not part of mld unit %d. VAP's mld_id %d\n",
-                    __func__, __LINE__, vap_names[i], mld_id, mld_conf->mld_id);
-                continue;
-            }
-            if (mld_conf->mld_enable) {
-                mld_vap_count++;
-                mld_addr_map[i] = mld_conf->mld_addr;
-                mld_map[i] = mld_conf;
-                if (mld_conf->mld_link_id == 0) {
-                    memcpy(mlo_mac, mgr_vap_info->u.bss_info.bssid, sizeof(mac_address_t));
-                }
-            } else {
-                if (mld_conf->mld_link_id == 0) {
-                    wifi_util_info_print(WIFI_MGR, "%s:%d: Main link is disabled -> Disable whole MLO group\n",__func__, __LINE__);
-                    disable_mld = true;
-                }
-            }
-        }
-    }
-    if (mld_vap_count > 0) {
-        if (disable_mld || mld_vap_count < 2) {
-            /* Disable MLD when main link is disabled or less than 2 VAPs are mld enabled */
-            for (i = 0; i < size; i++) {
-                if (mld_map[i] != NULL) {
-                    mld_map[i]->mld_enable = false;
-                    wifi_util_info_print(WIFI_MGR,
-                        "%s:%d: Disabling mld for vap name:%s - disable_mld %d mld_vap_count %d\n",
-                        __func__, __LINE__, vap_names[i], disable_mld, mld_vap_count);
-                }
-            }
-            return;
-        }
-    }
-
-    if (memcmp(mlo_mac, zero_mac, sizeof(mac_address_t)) == 0) {
-        return; /* VAPs group does not contain MLO enabled VAPs */
-    }
-
-    to_mac_str(mlo_mac, mac_str);
-    for (i = 0; i < size; i++) {
-        if (mld_addr_map[i] != NULL) {
-            memcpy(mld_addr_map[i], mlo_mac, sizeof(mac_address_t));
-            wifi_util_info_print(WIFI_MGR, "%s:%d: Updating mld_addr %s for vap name:%s\n",
-                __func__, __LINE__, mac_str, vap_names[i]);
-        }
-    }
-}
-#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
-
 int webconfig_hal_vap_apply_by_name(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data, char **vap_names, unsigned int size)
 {
     unsigned int i, j, k;
@@ -1026,9 +867,6 @@ int webconfig_hal_vap_apply_by_name(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_
     rdk_wifi_vap_info_t tgt_rdk_vap_info;
     int ret = 0;
 
-#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
-    update_mld_group(data, vap_names, size);
-#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
     for (i = 0; i < size; i++) {
 
         if ((svc = get_svc_by_name(ctrl, vap_names[i])) == NULL) {
@@ -1800,6 +1638,9 @@ int webconfig_hal_private_vap_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_
             num_vaps++;
         }
     }
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    update_mld_groups(data, vap_names, num_vaps, WIFI_MGR);
+#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
     return webconfig_hal_vap_apply_by_name(ctrl, data, vap_names, num_vaps);
 }
 
@@ -1819,6 +1660,9 @@ int webconfig_hal_home_vap_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_dat
             num_vaps++;
         }
     }
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    update_mld_groups(data, vap_names, num_vaps, WIFI_MGR);
+#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
     return webconfig_hal_vap_apply_by_name(ctrl, data, vap_names, num_vaps);
 }
 
@@ -1838,6 +1682,9 @@ int webconfig_hal_xfinity_vap_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_
             num_vaps++;
         }
     }
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    update_mld_groups(data, vap_names, num_vaps, WIFI_MGR);
+#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
     return webconfig_hal_vap_apply_by_name(ctrl, data, vap_names, num_vaps);
 }
 
@@ -1857,6 +1704,9 @@ int webconfig_hal_lnf_vap_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data
             num_vaps++;
         }
     }
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    update_mld_groups(data, vap_names, num_vaps, WIFI_MGR);
+#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
     return webconfig_hal_vap_apply_by_name(ctrl, data, vap_names, num_vaps);
 }
 
@@ -1876,6 +1726,9 @@ int webconfig_hal_mesh_vap_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_dat
             num_vaps++;
         }
     }
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    update_mld_groups(data, vap_names, num_vaps, WIFI_MGR);
+#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
     return webconfig_hal_vap_apply_by_name(ctrl, data, vap_names, num_vaps);
 }
 
@@ -1895,6 +1748,9 @@ int webconfig_hal_mesh_sta_vap_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded
             num_vaps++;
         }
     }
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    update_mld_groups(data, vap_names, num_vaps, WIFI_MGR);
+#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
     return webconfig_hal_vap_apply_by_name(ctrl, data, vap_names, num_vaps);
 }
 
@@ -1914,6 +1770,9 @@ int webconfig_hal_mesh_backhaul_vap_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_de
             num_vaps++;
         }
     }
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    update_mld_groups(data, vap_names, num_vaps, WIFI_MGR);
+#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
     return webconfig_hal_vap_apply_by_name(ctrl, data, vap_names, num_vaps);
 }
 

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -546,8 +546,6 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg.u.bss_info.mld_info.common_info.mld_id = 255;
 #endif
         cfg.u.bss_info.mld_info.common_info.mld_link_id = 255;
-        cfg.u.bss_info.mld_info.common_info.mld_apply = 1;
-//        strcpy(cfg.u.bss_info.mld_info.common_info.mld_addr, "11:11:11:11:11:11");
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.showSsid = true;
             cfg.u.bss_info.wps.methods = WIFI_ONBOARDINGMETHODS_PUSHBUTTON;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -1097,7 +1097,6 @@ void callback_Wifi_VAP_Config(ovsdb_update_monitor_t *mon,
             l_bss_param_cfg->mld_info.common_info.mld_enable = new_rec->mld_enable;
             l_bss_param_cfg->mld_info.common_info.mld_id = new_rec->mld_id;
             l_bss_param_cfg->mld_info.common_info.mld_link_id = new_rec->mld_link_id;
-            l_bss_param_cfg->mld_info.common_info.mld_apply = new_rec->mld_apply;
             if (strlen(new_rec->anqp_parameters) != 0) {
                 strncpy((char *)l_bss_param_cfg->interworking.anqp.anqpParameters,new_rec->anqp_parameters,(sizeof(l_bss_param_cfg->interworking.anqp.anqpParameters)-1));
             }
@@ -2876,7 +2875,6 @@ int wifidb_update_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
         cfg.mld_enable = config->u.bss_info.mld_info.common_info.mld_enable;
         cfg.mld_id = config->u.bss_info.mld_info.common_info.mld_id;
         cfg.mld_link_id = config->u.bss_info.mld_info.common_info.mld_link_id;
-        cfg.mld_apply = config->u.bss_info.mld_info.common_info.mld_apply;
 
         wifi_util_dbg_print(WIFI_DB,
             "%s:%d: VAP Config update data cfg.radio_name=%s cfg.vap_name=%s cfg.ssid=%s "
@@ -2890,7 +2888,7 @@ int wifidb_update_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
             "cfg.wps_enabled=%d cfg.beacon_rate_ctl=%s cfg.mfp_config=%s "
             "network_initiated_greylist=%d exists=%d hostap_mgt_frame_ctrl=%d mbo_enabled=%d "
             "interop_ctrl:%d inum_sta:%d "
-            "mld_enable=%d mld_id=%d mld_link_id=%d mld_apply=%d\n",
+            "mld_enable=%d mld_id=%d mld_link_id=%d\n",
             __func__, __LINE__, cfg.radio_name, cfg.vap_name, cfg.ssid, cfg.enabled,
             cfg.ssid_advertisement_enabled, cfg.isolation_enabled, cfg.mgmt_power_control,
             cfg.bss_max_sta, cfg.bss_transition_activated, cfg.nbr_report_activated,
@@ -2901,7 +2899,7 @@ int wifidb_update_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
             cfg.wps_enabled, cfg.beacon_rate_ctl, cfg.mfp_config, cfg.network_initiated_greylist,
             cfg.exists, cfg.hostap_mgt_frame_ctrl, cfg.mbo_enabled,
             cfg.interop_ctrl, cfg.inum_sta,
-            cfg.mld_enable, cfg.mld_id, cfg.mld_link_id, cfg.mld_apply);
+            cfg.mld_enable, cfg.mld_id, cfg.mld_link_id);
     }
     if(onewifi_ovsdb_table_upsert_with_parent(g_wifidb->wifidb_sock_path,&table_Wifi_VAP_Config,&cfg,false,filter_vap,SCHEMA_TABLE(Wifi_Radio_Config),(onewifi_ovsdb_where_simple(SCHEMA_COLUMN(Wifi_Radio_Config,radio_name),radio_name)),SCHEMA_COLUMN(Wifi_Radio_Config,vap_configs)) == false)
     {
@@ -5160,7 +5158,6 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
 
 #endif
                 config->vap_array[i].u.bss_info.mld_info.common_info.mld_link_id = 255;
-                config->vap_array[i].u.bss_info.mld_info.common_info.mld_apply = 1;
                 is_vap_info_upgrade_needed = true;
             }
         }
@@ -6567,7 +6564,6 @@ int wifidb_get_wifi_vap_info(char *vap_name, wifi_vap_info_t *config,
             config->u.bss_info.mld_info.common_info.mld_enable = pcfg->mld_enable;
             config->u.bss_info.mld_info.common_info.mld_id = pcfg->mld_id;
             config->u.bss_info.mld_info.common_info.mld_link_id = pcfg->mld_link_id;
-            config->u.bss_info.mld_info.common_info.mld_apply = pcfg->mld_apply;
         }
     }
     free(pcfg);
@@ -7720,7 +7716,6 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
         cfg->u.bss_info.mld_info.common_info.mld_id = 255;
 #endif
         cfg->u.bss_info.mld_info.common_info.mld_link_id = 255;
-        cfg->u.bss_info.mld_info.common_info.mld_apply = 1;
 
         memset(&cfg->u.bss_info.mld_info.common_info.mld_addr, 0, sizeof(cfg->u.bss_info.mld_info.common_info.mld_addr));
         if (isVapPrivate(vap_index)) {
@@ -8125,101 +8120,6 @@ void wifidb_init_default_value()
     wifi_util_info_print(WIFI_DB,"%s:%d Wifi db update completed\n",__func__, __LINE__);
 
 }
-#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
-static int get_ap_mac_by_vap_index(wifi_vap_info_map_t *hal_vap_info_map, int vap_index,  mac_address_t mac)
-{
-    unsigned int j = 0;
-
-    for (j = 0; j < hal_vap_info_map->num_vaps; j++) {
-        if ((int)hal_vap_info_map->vap_array[j].vap_index == vap_index) {
-            memcpy(mac, hal_vap_info_map->vap_array[j].u.bss_info.bssid, sizeof(mac_address_t));
-            return RETURN_OK;
-        }
-    }
-    wifi_util_error_print(WIFI_DB, "%s:%d vap_info not found for vap_index value: %d\n"
-        ,__FUNCTION__, __LINE__, vap_index);
-    return RETURN_ERR;
-}
-
-static int wifidb_vap_config_update_mld_mac()
-{
-    wifi_vap_info_map_t  *hal_vap_info_map = NULL;
-    wifi_vap_info_map_t *mgr_vap_info_map = NULL;
-    mac_address_t mlo_mac = {0};
-    mac_address_t zero_mac = {0};
-    unsigned char *mld_addr_map[MAX_NUM_RADIOS] = {0};
-    unsigned int r_idx=0;
-    unsigned int i = 0;
-    unsigned int k = 0;
-    int ret = RETURN_OK;
-
-    hal_vap_info_map = (wifi_vap_info_map_t *)malloc(sizeof(wifi_vap_info_map_t));
-    if (hal_vap_info_map == NULL) {
-        wifi_util_error_print(WIFI_DB, "%s:%d Failed to allocate memory for hal_vap_info_map\n",__FUNCTION__, __LINE__);
-        return RETURN_ERR;
-    }
-
-    for (i = 0; i < MLD_UNIT_COUNT; i++) {
-        memset(mld_addr_map, 0, sizeof(mld_addr_map));
-        memset(mlo_mac, 0, sizeof(mac_address_t));
-
-        wifi_util_info_print(WIFI_DB, "%s:%d: Updating MLO MAC for mld_unit %d\r\n", __func__, __LINE__, i);
-
-        for (r_idx=0; r_idx < getNumberRadios(); r_idx++) {
-            memset(hal_vap_info_map, 0, sizeof(wifi_vap_info_map_t));
-            /* wifi_hal_getRadioVapInfoMap is used  to get the macaddress of wireless interfaces */
-            ret = wifi_hal_getRadioVapInfoMap(r_idx, hal_vap_info_map);
-            if (ret != RETURN_OK) {
-                wifi_util_error_print(WIFI_DB, "%s:%d wifi_hal_getRadioVapInfoMap failed for radio: %d\n",__FUNCTION__, __LINE__, r_idx);
-                free(hal_vap_info_map);
-                hal_vap_info_map = NULL;
-                return ret;
-            }
-            /* vap map with loaded DB - find the main mlo vap */
-            mgr_vap_info_map = get_wifidb_vap_map(r_idx);
-            if (mgr_vap_info_map == NULL) {
-                wifi_util_error_print(WIFI_DB, "%s:%d get_wifidb_vap_map failed for radio: %d\n",__FUNCTION__, __LINE__, r_idx);
-                free(hal_vap_info_map);
-                hal_vap_info_map = NULL;
-                return RETURN_ERR;
-            }
-            for (k = 0; k < mgr_vap_info_map->num_vaps; k++) {
-                wifi_vap_info_t *vap_config = &mgr_vap_info_map->vap_array[k];
-                wifi_mld_common_info_t *mld_info = NULL;
-
-                if (isVapSTAMesh(vap_config->vap_index)) {
-                    continue;
-                }
-
-                mld_info = &vap_config->u.bss_info.mld_info.common_info;
-                if (i == 0) { /* Initialise all vap's mld_mac with interface mac */
-                    get_ap_mac_by_vap_index(hal_vap_info_map, vap_config->vap_index, mld_info->mld_addr);
-                }
-
-                if (mld_info->mld_enable && mld_info->mld_id == i) {
-                    mld_addr_map[r_idx] = mld_info->mld_addr; /* store mld_addr ptr to be updated later */
-                    if(mld_info->mld_link_id == 0) { /* check if the link is main MLO link */
-                        get_ap_mac_by_vap_index(hal_vap_info_map, vap_config->vap_index, mlo_mac);
-                    }
-                }
-            }
-        }
-
-        if (memcmp(mlo_mac, zero_mac, sizeof(mac_address_t)) == 0) {
-            continue;
-        }
-
-        for (r_idx = 0; r_idx < getNumberRadios(); r_idx++) {
-            if (mld_addr_map[r_idx] != NULL) {
-                memcpy(mld_addr_map[r_idx], mlo_mac, sizeof(mac_address_t));
-            }
-        }
-    }
-    free(hal_vap_info_map);
-    hal_vap_info_map = NULL;
-    return RETURN_OK;
-}
-#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
 
 /************************************************************************************
  ************************************************************************************
@@ -8450,9 +8350,6 @@ void init_wifidb_data()
             pthread_mutex_unlock(&g_wifidb->data_cache_lock);
             return;
         }
-#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
-        wifidb_vap_config_update_mld_mac();
-#endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
         pthread_mutex_unlock(&g_wifidb->data_cache_lock);
     }
 

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -5512,6 +5512,18 @@ SSID_GetParamUlongValue
         return TRUE;
     }
 
+    if( AnscEqualString(ParamName, "X_RDK_MLDLinkID", TRUE))
+    {
+        wifi_mld_common_info_t *mld_common_info = NULL;
+
+        if (isVapSTAMesh(pcfg->vap_index)) {
+            mld_common_info = &pcfg->u.sta_info.mld_info.common_info;
+        } else {
+            mld_common_info = &pcfg->u.bss_info.mld_info.common_info;
+        }
+        *puLong = (uint32_t)mld_common_info->mld_link_id;
+        return TRUE;
+    }
 
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
     return FALSE;
@@ -6010,6 +6022,60 @@ SSID_SetParamUlongValue
         ULONG                       uValue
     )
 {
+    wifi_vap_info_t *pcfg = (wifi_vap_info_t *)hInsContext;
+
+    if (pcfg == NULL)
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Null pointer get fail\n", __FUNCTION__,__LINE__);
+        return FALSE;
+    }
+
+    uint8_t instance_number = (uint8_t)convert_vap_name_to_index(&((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop, pcfg->vap_name) +1;
+    wifi_vap_info_t *vapInfo = (wifi_vap_info_t *) get_dml_cache_vap_info(instance_number-1);
+
+    if (vapInfo == NULL)
+    {
+        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Unable to get VAP info for instance_number:%d\n", __FUNCTION__,__LINE__,instance_number);
+        return FALSE;
+    }
+
+    if( AnscEqualString(ParamName, "X_RDK_MLDLinkID", TRUE))
+    {
+        if (isVapSTAMesh(pcfg->vap_index)) {
+            wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
+            return TRUE;
+        }
+
+        /* MLD_Link_ID is per radio configuration. In current design, we store it in each VAP structure.
+         * So when MLD_Link_ID is updated for one VAP, we need to update it for all VAPs of the same radio.
+         */
+        unsigned int total_vaps = getTotalNumberVAPs();
+
+        for (unsigned int vap_idx = 0; vap_idx < total_vaps; vap_idx++) {
+            wifi_vap_info_t *temp_vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(vap_idx);
+            if (temp_vapInfo == NULL) {
+                wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Unable to get VAP info for vap index:%d\n",
+                    __FUNCTION__, __LINE__, vap_idx);
+                continue;
+            }
+            if (temp_vapInfo->radio_index != pcfg->radio_index) {
+                continue;
+            }
+            if (isVapSTAMesh(vap_idx)) {
+                continue;
+            }
+            wifi_util_dbg_print(WIFI_DMCLI,
+                "%s:%d Updating mld_link_id radio_index %d vap index:%d old val %u new val %u\n",
+                __FUNCTION__, __LINE__, temp_vapInfo->radio_index, vap_idx,
+                temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id, uValue);
+            if (temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id == (unsigned int)uValue) {
+                continue;
+            }
+            temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id = uValue;
+            set_dml_cache_vap_config_changed(vap_idx);
+        }
+        return TRUE;
+    }
 
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
     return FALSE;
@@ -6783,13 +6849,6 @@ AccessPoint_GetParamBoolValue
         return TRUE;
     }
 
-    if( AnscEqualString(ParamName, "MLD_Apply", TRUE))
-    {
-        /* collect value */
-        *pBool = pcfg->u.bss_info.mld_info.common_info.mld_apply;
-        return TRUE;
-    }
-
     if( AnscEqualString(ParamName, "WMMCapability", TRUE))
     {
         /* collect value */
@@ -7157,7 +7216,14 @@ AccessPoint_GetParamUlongValue
 
     if( AnscEqualString(ParamName, "MLD_Link_ID", TRUE))
     {
-        *puLong = pcfg->u.bss_info.mld_info.common_info.mld_link_id;
+        wifi_mld_common_info_t *mld_common_info = NULL;
+
+        if (isVapSTAMesh(pcfg->vap_index)) {
+            mld_common_info = &pcfg->u.sta_info.mld_info.common_info;
+        } else {
+            mld_common_info = &pcfg->u.bss_info.mld_info.common_info;
+        }
+        *puLong = mld_common_info->mld_link_id;
         return TRUE;
     }
 
@@ -7449,40 +7515,6 @@ AccessPoint_SetParamBoolValue
         
         /* save update to backup */
         vapInfo->u.bss_info.showSsid = bValue;
-        set_dml_cache_vap_config_changed(instance_number - 1);
-        return TRUE;
-    }
-
-    if( AnscEqualString(ParamName, "MLD_Enable", TRUE))
-    {
-        if (bValue && !isRadioBeEnabled(pcfg->radio_index))
-        {
-            wifi_util_error_print(WIFI_DMCLI,
-                "%s:%d Cannot enable MLD on VAP %s: radio %d has no BE mode\n", __FUNCTION__,
-                __LINE__, pcfg->vap_name, pcfg->radio_index);
-            return FALSE;
-        }
-
-        if ( vapInfo->u.bss_info.mld_info.common_info.mld_enable == bValue )
-        {
-            return TRUE;
-        }
-
-        /* save update to backup */
-        vapInfo->u.bss_info.mld_info.common_info.mld_enable = bValue;
-        set_dml_cache_vap_config_changed(instance_number - 1);
-        return TRUE;
-    }
-
-    if( AnscEqualString(ParamName, "MLD_Apply", TRUE))
-    {
-        if ( vapInfo->u.bss_info.mld_info.common_info.mld_apply == bValue )
-        {
-            return TRUE;
-        }
-
-        /* save update to backup */
-        vapInfo->u.bss_info.mld_info.common_info.mld_apply = bValue;
         set_dml_cache_vap_config_changed(instance_number - 1);
         return TRUE;
     }
@@ -7901,65 +7933,6 @@ AccessPoint_SetParamUlongValue
     if( AnscEqualString(ParamName, "X_COMCAST-COM_AssociatedDevicesHighWatermarkThreshold", TRUE))
     {
         cfg->associated_devices_highwatermark_threshold = uValue;
-        return TRUE;
-    }
-
-    if( AnscEqualString(ParamName, "MLD_ID", TRUE))
-    {
-        if (isVapSTAMesh(pcfg->vap_index)) {
-            wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
-            return TRUE;
-        }
-        if (!isRadioBeEnabled(pcfg->radio_index)) {
-            wifi_util_error_print(WIFI_DMCLI,"%s:%d Cannot set MLD_ID on VAP %s: radio %d has no BE mode\n",
-                __FUNCTION__, __LINE__, pcfg->vap_name, pcfg->radio_index);
-            return FALSE;
-        }
-        if ( vapInfo->u.bss_info.mld_info.common_info.mld_id == (unsigned int)uValue )
-        {
-            return  TRUE;
-        }
-        /* save update to backup */
-        vapInfo->u.bss_info.mld_info.common_info.mld_id = uValue;
-        set_dml_cache_vap_config_changed(instance_number - 1);
-        return TRUE;
-    }
-
-    if( AnscEqualString(ParamName, "MLD_Link_ID", TRUE))
-    {
-        if (isVapSTAMesh(pcfg->vap_index)) {
-            wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
-            return TRUE;
-        }
-
-        /* MLD_Link_ID is per radio configuration. In current design, we store it in each VAP structure.
-         * So when MLD_Link_ID is updated for one VAP, we need to update it for all VAPs of the same radio.
-         */
-        unsigned int total_vaps = getTotalNumberVAPs();
-
-        for (unsigned int vap_idx = 0; vap_idx < total_vaps; vap_idx++) {
-            wifi_vap_info_t *temp_vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(vap_idx);
-            if (temp_vapInfo == NULL) {
-                wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Unable to get VAP info for vap index:%d\n",
-                    __FUNCTION__, __LINE__, vap_idx);
-                continue;
-            }
-            if (temp_vapInfo->radio_index != pcfg->radio_index) {
-                continue;
-            }
-            if (isVapSTAMesh(vap_idx)) {
-                continue;
-            }
-            wifi_util_dbg_print(WIFI_DMCLI,
-                "%s:%d Updating mld_link_id radio_index %d vap index:%d old val %u new val %u\n",
-                __FUNCTION__, __LINE__, temp_vapInfo->radio_index, vap_idx,
-                uValue, temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id);
-            if (temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id == (unsigned int)uValue) {
-                continue;
-            }
-            temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id = uValue;
-            set_dml_cache_vap_config_changed(vap_idx);
-        }
         return TRUE;
     }
 

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -3970,8 +3970,6 @@ bool is_vap_param_config_changed(wifi_vap_info_t *vap_info_old, wifi_vap_info_t 
             //should not be executed for BPi
             IS_CHANGED(vap_info_old->u.bss_info.mld_info.common_info.mld_link_id,
                 vap_info_new->u.bss_info.mld_info.common_info.mld_link_id) ||
-            IS_CHANGED(vap_info_old->u.bss_info.mld_info.common_info.mld_apply,
-                vap_info_new->u.bss_info.mld_info.common_info.mld_apply) ||
             is_mld_addr_changed(vap_info_old, vap_info_new) ||
 #endif // CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO
             IS_CHANGED(vap_info_old->u.bss_info.hostap_mgt_frame_ctrl,

--- a/source/utils/wifi_validator.c
+++ b/source/utils/wifi_validator.c
@@ -1524,10 +1524,6 @@ int validate_vap(const cJSON *vap, wifi_vap_info_t *vap_info, wifi_platform_prop
     validate_param_bool(vap, "MLD_Enable", param);
 	vap_info->u.bss_info.mld_info.common_info.mld_enable = (param->type & cJSON_True) ? true:false;
 
-    // MLD Apply
-	validate_param_bool(vap, "MLD_Apply", param);
-	vap_info->u.bss_info.mld_info.common_info.mld_apply = (param->type & cJSON_True) ? true:false;
-
     // MLD ID
 	validate_param_integer(vap, "MLD_ID", param);
 	vap_info->u.bss_info.mld_info.common_info.mld_id = param->valuedouble;

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -1763,10 +1763,6 @@ webconfig_error_t decode_vap_common_object(const cJSON *vap, wifi_vap_info_t *va
     decode_param_bool(vap, "MLD_Enable", param);
     vap_info->u.bss_info.mld_info.common_info.mld_enable = (param->type & cJSON_True) ? true:false;
 
-    // MLD Apply
-    decode_param_bool(vap, "MLD_Apply", param);
-    vap_info->u.bss_info.mld_info.common_info.mld_apply = (param->type & cJSON_True) ? true:false;
-
     // MLD_ID
     decode_param_integer(vap, "MLD_ID", param);
     vap_info->u.bss_info.mld_info.common_info.mld_id = param->valuedouble;

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -413,9 +413,6 @@ webconfig_error_t encode_vap_common_object(const wifi_vap_info_t *vap_info,
     // MLD Enable
     cJSON_AddBoolToObject(vap_object, "MLD_Enable", vap_info->u.bss_info.mld_info.common_info.mld_enable);
 
-    // MLD Apply
-    cJSON_AddBoolToObject(vap_object, "MLD_Apply", vap_info->u.bss_info.mld_info.common_info.mld_apply);
-
     // MLD_ID
     cJSON_AddNumberToObject(vap_object, "MLD_ID", vap_info->u.bss_info.mld_info.common_info.mld_id);
 


### PR DESCRIPTION
* RDKB-63482: wifi: MLO reconfiguration improvments and DML updates

Reason for change:
  - Remove mld_apply parameter from codebase (no longer needed)
  - Remove mld_addr from DB schema; compute it at runtime from BSSID
  - Make old MLO DML parameters read-only
  - Add Device.WiFi.SSID.{i}.X_RDK_MLDLinkID DML parameter
  - Unify MLO group validation into shared mlo_update_all_groups() used by both webconfig and DB init paths
  - Add is_mlo_config_matching() to enforce SSID, password and security mode consistency before forming an MLO group; WPA3 variants treated as inter-compatible across bands Test Procedure:
    - Verify MLO groups can be configured via DML: Device.WiFi.SSID.{i}.MLDUnit Device.WiFi.SSID.{i}.X_RDK_MLDLinkID
    - Verify MLO groups are correctly formed on DB init and webconfig
    - Verify MLO groups are correctly updated when changing SSID, password or security mode of an existing MLO group member Risks: Medium
Priority: P1

* Do not call update_mld_groups for multivap subdocs

As multivap subdocs contains information about the only one VAP in the MLD group, calling update_mld_groups for that subdocs will cause the MLD group to be disable on that VAP, which is not the expected behavior.

Before it was filtered by vap_names size less than MAX_NUM_RADIOS. So this behaviour is not changed.

* Swap the arguments so logs correctly reflect old=current and new=uValue



---------




(cherry picked from commit fb95308b98c9acec3c71037ac84942e912bddd49)