### PR TITLE
LTE-2853 NOP_STARTED status doesn't change in 30min after radar detection

### DIFF
--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3427,7 +3427,10 @@ int update_db_radar_detected(int radio_index, char *radar_detected_ch_time)
     g_wifidb = get_wifimgr_obj();
 
     radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(radio_index);
-
+    if (radio_params == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s: invalid radio_index %d\n", __FUNCTION__, radio_index);
+        return RETURN_ERR;
+    }
     char *pos_ch_radar_time = strstr(radio_params->radarDetected, radar_detected_ch_time);
     size_t len_ch_radar_time = strlen(radar_detected_ch_time);
     if( strlen(radio_params->radarDetected) == len_ch_radar_time ){
@@ -3455,25 +3458,17 @@ int dfs_nop_start_timer(void *args)
     wifi_channel_change_event_t radio_channel_param;
     wifi_radio_operationParam_t *radio_params = NULL;
 
-    /* Find the 5G radio that has pending radarDetected entries */
+    /* Process all 5G radios that have pending radarDetected entries */
     unsigned int n = getNumberRadios();
-    unsigned int dfs_radio_index;
-    for (dfs_radio_index = 0; dfs_radio_index < n; dfs_radio_index++) {
+    for (unsigned int dfs_radio_index = 0; dfs_radio_index < n; dfs_radio_index++) {
         wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
         if (c == NULL) continue;
         if (c->band != WIFI_FREQUENCY_5_BAND &&
             c->band != WIFI_FREQUENCY_5L_BAND &&
             c->band != WIFI_FREQUENCY_5H_BAND) continue;
-        if (strcmp(c->radarDetected, " ") != 0 && strlen(c->radarDetected) > 0) {
-            break;
-         }
-     }
-    if (dfs_radio_index >= n) {
-        wifi_util_error_print(WIFI_CTRL, "%s: No 5G radio with radarDetected found\n", __FUNCTION__);
-        return RETURN_ERR;
-    }
+        if (strcmp(c->radarDetected, " ") == 0 || strlen(c->radarDetected) == 0) continue;
 
-    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
+    radio_params = c;
     memset(&radio_channel_param, 0, sizeof(radio_channel_param));
 
     char *str_r, *radar_detected_ch_time;
@@ -3543,10 +3538,10 @@ int dfs_nop_start_timer(void *args)
         radar_detected_ch_time = strtok_r(NULL, ";", &str_r);
     }
 
-    if(strlen(radio_params->radarDetected) == 0) {
+    if(radio_params != NULL && strlen(radio_params->radarDetected) == 0) {
         strncpy(radio_params->radarDetected, " ", sizeof(radio_params->radarDetected));
     }
-
+    } /* end for each 5G radio */
     return TIMER_TASK_COMPLETE;
 }
 
@@ -3555,7 +3550,7 @@ int dfs_nop_finish_timer(void *args)
     wifi_channel_change_event_t radio_channel_param;
     wifi_radio_operationParam_t *radio_params = NULL;
     char *str_re, *radar_detected_ch_time;
-    char radarDetected_temp[128];
+    char radarDetected_temp[256];
     unsigned int ch_temp;
 
     if (args == NULL) {
@@ -3574,7 +3569,7 @@ int dfs_nop_finish_timer(void *args)
         if (c->band != WIFI_FREQUENCY_5_BAND &&
             c->band != WIFI_FREQUENCY_5L_BAND &&
             c->band != WIFI_FREQUENCY_5H_BAND) continue;
-        char scan_tmp[128];
+        char scan_tmp[256];
         char *scan_tok, *scan_saveptr;
         strncpy(scan_tmp, c->radarDetected, sizeof(scan_tmp));
         scan_tmp[sizeof(scan_tmp) - 1] = '\0';
@@ -3582,13 +3577,13 @@ int dfs_nop_finish_timer(void *args)
         while (scan_tok != NULL) {
             if ((unsigned int)atoi(scan_tok) == nop_fin_dfs_ch) break;
             scan_tok = strtok_r(NULL, ";", &scan_saveptr);
-         }
+        }
         if (scan_tok != NULL) break;
     }
     if (dfs_radio_index >= n) {
         wifi_util_error_print(WIFI_CTRL, "%s: ch=%d not found in any 5G radio radarDetected\n", __FUNCTION__, nop_fin_dfs_ch);
         return TIMER_TASK_COMPLETE;
-     }
+}
 
     radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
     memset(&radio_channel_param, 0, sizeof(radio_channel_param));

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3421,13 +3421,13 @@ static int reset_radio_operating_parameters(void *args)
     return RETURN_OK;
 }
 
-int update_db_radar_detected(char *radar_detected_ch_time)
+int update_db_radar_detected(int radio_index, char *radar_detected_ch_time)
 {
     wifi_radio_operationParam_t *radio_params = NULL;
     wifi_mgr_t *g_wifidb;
     g_wifidb = get_wifimgr_obj();
 
-    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(RADIO_INDEX_DFS);
+    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(radio_index);
 
     char *pos_ch_radar_time = strstr(radio_params->radarDetected, radar_detected_ch_time);
     size_t len_ch_radar_time = strlen(radar_detected_ch_time);
@@ -3456,7 +3456,24 @@ int dfs_nop_start_timer(void *args)
     wifi_channel_change_event_t radio_channel_param;
     wifi_radio_operationParam_t *radio_params = NULL;
 
-    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(RADIO_INDEX_DFS);
+    /* Find the 5G radio that has pending radarDetected entries */
+    int dfs_radio_index = RADIO_INDEX_DFS;
+    {
+        unsigned int n = getNumberRadios();
+        for (unsigned int i = 0; i < n; i++) {
+            wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(i);
+            if (c == NULL) continue;
+            if (c->band != WIFI_FREQUENCY_5_BAND &&
+                c->band != WIFI_FREQUENCY_5L_BAND &&
+                c->band != WIFI_FREQUENCY_5H_BAND) continue;
+            if (strcmp(c->radarDetected, " ") != 0 && strlen(c->radarDetected) > 0) {
+                dfs_radio_index = (int)i;
+                break;
+            }
+        }
+    }
+
+    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
     memset(&radio_channel_param, 0, sizeof(radio_channel_param));
 
     char *str_r, *radar_detected_ch_time;
@@ -3477,9 +3494,9 @@ int dfs_nop_start_timer(void *args)
         unsigned int dfs_radar_channel, dfs_timer_secs = 0;
         wifi_channelBandwidth_t dfs_radar_ch_bw = 0;
         time_t time_now = time(NULL);
-        wifi_radio_feature_param_t *radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(RADIO_INDEX_DFS);
+        wifi_radio_feature_param_t *radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(dfs_radio_index);
         if (radio_feat == NULL) {
-            wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, RADIO_INDEX_DFS);
+            wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, dfs_radio_index);
             return RETURN_ERR;
         }
 
@@ -3487,8 +3504,8 @@ int dfs_nop_start_timer(void *args)
         while(radar_detected_ch_time[i] != ',') {
             if(radar_detected_ch_time[i] == '\0') {
                 wifi_util_error_print(WIFI_CTRL,"%s:%d Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, __LINE__, radio_params->radarDetected);
-                update_db_radar_detected(radar_detected_ch_time);
-                update_wifi_radio_config(RADIO_INDEX_DFS, radio_params, radio_feat);
+                update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+                update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
                 return RETURN_ERR;
             }
             i++;
@@ -3497,15 +3514,15 @@ int dfs_nop_start_timer(void *args)
         while(radar_detected_ch_time[i] != ',') {
             if(radar_detected_ch_time[i] == '\0') {
                 wifi_util_error_print(WIFI_CTRL,"%s: Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, radio_params->radarDetected);
-                update_db_radar_detected(radar_detected_ch_time);
-                update_wifi_radio_config(RADIO_INDEX_DFS, radio_params, radio_feat);
+                update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+                update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
                 return RETURN_ERR;
             }
             i++;
         }
         radar_detected_time = atol(&radar_detected_ch_time[++i]);
 
-        radio_channel_param.radioIndex = RADIO_INDEX_DFS;
+        radio_channel_param.radioIndex = dfs_radio_index;
         radio_channel_param.event = WIFI_EVENT_DFS_RADAR_DETECTED;
         radio_channel_param.sub_event = WIFI_EVENT_RADAR_DETECTED;
         radio_channel_param.channel = dfs_radar_channel;
@@ -3514,8 +3531,8 @@ int dfs_nop_start_timer(void *args)
 
         dfs_timer_secs = ((time_now - radar_detected_time) < ((long long)radio_params->DFSTimer * 60) && (time_now > radar_detected_time)) ? (((long long)radio_params->DFSTimer * 60) - (time_now - radar_detected_time)) : 0;
         if(dfs_timer_secs == 0) {
-            update_db_radar_detected(radar_detected_ch_time);
-            update_wifi_radio_config(RADIO_INDEX_DFS, radio_params, radio_feat);
+            update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+            update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
             wifi_util_dbg_print(WIFI_CTRL, "%s Radar event time-out for dfs_radar_channel:%d \n", __FUNCTION__, dfs_radar_channel);
         } else {
             bool is_nop_start_reboot = 1;
@@ -3547,7 +3564,34 @@ int dfs_nop_finish_timer(void *args)
     }
 
     unsigned int nop_fin_dfs_ch = *(unsigned int *) args;
-    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(RADIO_INDEX_DFS);
+
+    /* Find which 5G radio has this channel in its radarDetected */
+    int dfs_radio_index = RADIO_INDEX_DFS;
+    {
+        unsigned int n = getNumberRadios();
+        for (unsigned int i = 0; i < n; i++) {
+            wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(i);
+            if (c == NULL) continue;
+            if (c->band != WIFI_FREQUENCY_5_BAND &&
+                c->band != WIFI_FREQUENCY_5L_BAND &&
+                c->band != WIFI_FREQUENCY_5H_BAND) continue;
+            char scan_tmp[128];
+            char *scan_tok, *scan_saveptr;
+            strncpy(scan_tmp, c->radarDetected, sizeof(scan_tmp));
+            scan_tmp[sizeof(scan_tmp) - 1] = '\0';
+            scan_tok = strtok_r(scan_tmp, ";", &scan_saveptr);
+            while (scan_tok != NULL) {
+                if ((unsigned int)atoi(scan_tok) == nop_fin_dfs_ch) {
+                    dfs_radio_index = (int)i;
+                    break;
+                }
+                scan_tok = strtok_r(NULL, ";", &scan_saveptr);
+            }
+            if (dfs_radio_index != RADIO_INDEX_DFS) break;
+        }
+    }
+
+    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
     memset(&radio_channel_param, 0, sizeof(radio_channel_param));
     strncpy(radarDetected_temp, radio_params->radarDetected, sizeof(radarDetected_temp));
 
@@ -3564,7 +3608,7 @@ int dfs_nop_finish_timer(void *args)
             while(radar_detected_ch_time[i] != ',' && radar_detected_ch_time[i] != '\0') i++;
             dfs_radar_ch_bw = (radar_detected_ch_time[i] != '\0') ? (wifi_channelBandwidth_t) atoi(&radar_detected_ch_time[++i]) : radio_params->channelWidth;
 
-            radio_channel_param.radioIndex = RADIO_INDEX_DFS;
+            radio_channel_param.radioIndex = dfs_radio_index;
             radio_channel_param.event = WIFI_EVENT_DFS_RADAR_DETECTED;
             radio_channel_param.sub_event = WIFI_EVENT_RADAR_NOP_FINISHED;
             radio_channel_param.channel = nop_fin_dfs_ch;
@@ -3772,7 +3816,7 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
                     while(radar_detected_ch_time != NULL) {
                         ch_temp = atoi(radar_detected_ch_time);
                         if(ch_temp == ch_chg->channel) {
-                            if(update_db_radar_detected(radar_detected_ch_time) != RETURN_OK) {
+                            if(update_db_radar_detected(ch_chg->radioIndex, radar_detected_ch_time) != RETURN_OK) {
                                 wifi_util_error_print(WIFI_CTRL, "%s update_db_radar_detected returned error for channel:%d \n", __FUNCTION__, ch_chg->channel);
                             }
                             break;

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -51,7 +51,6 @@
 
 static unsigned msg_id = 1000;
 
-#define RADIO_INDEX_DFS 1
 unsigned int temp_ch_list_5g[] = {36,40,44,48,52,56,60,64,100,104,108,112,116,120,124,128,132,136,140,144,149,153,157,161,165};
 
 typedef enum {
@@ -3457,20 +3456,21 @@ int dfs_nop_start_timer(void *args)
     wifi_radio_operationParam_t *radio_params = NULL;
 
     /* Find the 5G radio that has pending radarDetected entries */
-    int dfs_radio_index = RADIO_INDEX_DFS;
-    {
-        unsigned int n = getNumberRadios();
-        for (unsigned int i = 0; i < n; i++) {
-            wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(i);
-            if (c == NULL) continue;
-            if (c->band != WIFI_FREQUENCY_5_BAND &&
-                c->band != WIFI_FREQUENCY_5L_BAND &&
-                c->band != WIFI_FREQUENCY_5H_BAND) continue;
-            if (strcmp(c->radarDetected, " ") != 0 && strlen(c->radarDetected) > 0) {
-                dfs_radio_index = (int)i;
-                break;
-            }
-        }
+    unsigned int n = getNumberRadios();
+    unsigned int dfs_radio_index;
+    for (dfs_radio_index = 0; dfs_radio_index < n; dfs_radio_index++) {
+        wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
+        if (c == NULL) continue;
+        if (c->band != WIFI_FREQUENCY_5_BAND &&
+            c->band != WIFI_FREQUENCY_5L_BAND &&
+            c->band != WIFI_FREQUENCY_5H_BAND) continue;
+        if (strcmp(c->radarDetected, " ") != 0 && strlen(c->radarDetected) > 0) {
+            break;
+         }
+     }
+    if (dfs_radio_index >= n) {
+        wifi_util_error_print(WIFI_CTRL, "%s: No 5G radio with radarDetected found\n", __FUNCTION__);
+        return RETURN_ERR;
     }
 
     radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
@@ -3566,30 +3566,29 @@ int dfs_nop_finish_timer(void *args)
     unsigned int nop_fin_dfs_ch = *(unsigned int *) args;
 
     /* Find which 5G radio has this channel in its radarDetected */
-    int dfs_radio_index = RADIO_INDEX_DFS;
-    {
-        unsigned int n = getNumberRadios();
-        for (unsigned int i = 0; i < n; i++) {
-            wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(i);
-            if (c == NULL) continue;
-            if (c->band != WIFI_FREQUENCY_5_BAND &&
-                c->band != WIFI_FREQUENCY_5L_BAND &&
-                c->band != WIFI_FREQUENCY_5H_BAND) continue;
-            char scan_tmp[128];
-            char *scan_tok, *scan_saveptr;
-            strncpy(scan_tmp, c->radarDetected, sizeof(scan_tmp));
-            scan_tmp[sizeof(scan_tmp) - 1] = '\0';
-            scan_tok = strtok_r(scan_tmp, ";", &scan_saveptr);
-            while (scan_tok != NULL) {
-                if ((unsigned int)atoi(scan_tok) == nop_fin_dfs_ch) {
-                    dfs_radio_index = (int)i;
-                    break;
-                }
-                scan_tok = strtok_r(NULL, ";", &scan_saveptr);
-            }
-            if (dfs_radio_index != RADIO_INDEX_DFS) break;
-        }
+    unsigned int n = getNumberRadios();
+    unsigned int dfs_radio_index;
+    for (dfs_radio_index = 0; dfs_radio_index < n; dfs_radio_index++) {
+        wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
+        if (c == NULL) continue;
+        if (c->band != WIFI_FREQUENCY_5_BAND &&
+            c->band != WIFI_FREQUENCY_5L_BAND &&
+            c->band != WIFI_FREQUENCY_5H_BAND) continue;
+        char scan_tmp[128];
+        char *scan_tok, *scan_saveptr;
+        strncpy(scan_tmp, c->radarDetected, sizeof(scan_tmp));
+        scan_tmp[sizeof(scan_tmp) - 1] = '\0';
+        scan_tok = strtok_r(scan_tmp, ";", &scan_saveptr);
+        while (scan_tok != NULL) {
+            if ((unsigned int)atoi(scan_tok) == nop_fin_dfs_ch) break;
+            scan_tok = strtok_r(NULL, ";", &scan_saveptr);
+         }
+        if (scan_tok != NULL) break;
     }
+    if (dfs_radio_index >= n) {
+        wifi_util_error_print(WIFI_CTRL, "%s: ch=%d not found in any 5G radio radarDetected\n", __FUNCTION__, nop_fin_dfs_ch);
+        return TIMER_TASK_COMPLETE;
+     }
 
     radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
     memset(&radio_channel_param, 0, sizeof(radio_channel_param));


### PR DESCRIPTION
Reason for change: 
 dfs_nop_finish_timer/dfs_nop_start_timer hardcode radio_index=1 for radarDetected, causing NOP_FINISHED to never be written on XLE (wl2, radio_index=2); fix scans all 5G radios to find the correct index dynamically.
Test Procedure: 
trigger radar detection on XLE 5GH, verify NOP_FINISHED state written after 30-min NOP timer expires.
Risks: low
Priority: P2
Signed-off-by: poornakumar_mezhiselvam@comcast.com