### PR TITLE
RDKBWIFI-469: Fix Onewifi github workflow

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Clone unified-wifi-mesh repository
       run: |
         mkdir -p easymesh_project
-        git clone https://github.com/rdkcentral/unified-wifi-mesh.git easymesh_project/unified-wifi-mesh
+        git clone -b main --single-branch https://github.com/rdkcentral/unified-wifi-mesh.git easymesh_project/unified-wifi-mesh
         mv OneWifi easymesh_project/OneWifi
 
     - name: Cache dependencies


### PR DESCRIPTION
Current workflow clone UWM from default branch which is develop. Changing this to UWM's main when workflow is triggered from OneWifi's main branch