### PR TITLE
RDKB-64918: [MLO] WiFI Blaster enhancements to support throughput calculations of MLO clients (#1168) (#1188)

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -247,6 +247,8 @@ typedef struct {
     unsigned char DestMac[MAC_ADDRESS_LENGTH];
     unsigned int StepId;
     int ApIndex;
+    bool isMLO;
+    int mldApIndex[MAX_NUM_RADIOS - 1];
 } active_msmt_step_t;
 
 typedef enum {

--- a/source/apps/blaster/wifi_blaster.c
+++ b/source/apps/blaster/wifi_blaster.c
@@ -86,7 +86,7 @@
     arg[4], \
     arg[5]
 
-void calculate_throughput();
+void calculate_throughput(int mld_num);
 
 #define WIFI_BLASTER_POST_STEP_TIMEOUT 100  // ms
 #define WIFI_BLASTER_CPU_THRESHOLD     90   // percentage
@@ -149,7 +149,7 @@ static inline char *to_sta_key    (mac_addr_t mac, sta_key_t key)
     return (char *)key;
 }
 
-bool is_blaster_device_associated(int ap_index, mac_address_t sta_mac)
+bool is_blaster_device_associated(int ap_index, mac_address_t sta_mac, bool *is_mlo)
 {
     rdk_wifi_vap_info_t *rdk_vap_info = NULL;
     assoc_dev_data_t *sta = NULL;
@@ -178,6 +178,8 @@ bool is_blaster_device_associated(int ap_index, mac_address_t sta_mac)
         return false;
     }
     else {
+        if (is_mlo && !(*is_mlo))
+            *is_mlo = sta->dev_stats.cli_MLDEnable;
         return true;
     }
 
@@ -734,7 +736,8 @@ void SetActiveMsmtStepDstMac(char *DstMac, ULONG StepIns)
 {
     wifi_actvie_msmt_t  *g_active_msmt = get_wifi_blaster();
     mac_address_t bmac;
-    int i;
+    int i, j = 0;
+    bool client_found = false;
     wifi_mgr_t *mgr = get_wifimgr_obj();
     active_msmt_t *cfg = &g_active_msmt->active_msmt;
     wifi_ctrl_t *ctrl = &mgr->ctrl;
@@ -754,16 +757,36 @@ void SetActiveMsmtStepDstMac(char *DstMac, ULONG StepIns)
     memcpy(cfg->Step[StepIns].DestMac, bmac, sizeof(mac_address_t));
 
     active_msmt_set_step_status(__func__, StepIns, ACTIVE_MSMT_STEP_PENDING);
+    for (i = 0; i < MAX_NUM_RADIOS - 1; i++) {
+        cfg->Step[StepIns].mldApIndex[i] = -1;
+    }
+    cfg->Step[StepIns].isMLO = false;
 
     for (i = 0; i < (int)getTotalNumberVAPs(); i++) {
         UINT vap_index = VAP_INDEX(mgr->hal_cap, i);
-
-        if (is_blaster_device_associated(vap_index, bmac)  == true) {
+        if (is_blaster_device_associated(vap_index, bmac, &cfg->Step[StepIns].isMLO) == true) {
             wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: found client %s on ap %d\n", __func__, __LINE__, DstMac,vap_index);
-            cfg->Step[StepIns].ApIndex = vap_index;
-            return;
+            if (!client_found) {
+                cfg->Step[StepIns].ApIndex = vap_index;
+                client_found = true;
+            }
+            else if (cfg->Step[StepIns].isMLO && (j < MAX_NUM_RADIOS - 1)){
+                wifi_vap_info_t *vap = NULL;
+                vap = getVapInfo(vap_index);
+// BCM specific, set MAP vap index as blast vap index
+                if (vap && vap->u.bss_info.mld_info.common_info.mld_link_id == 0) {
+                    wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: found MAP\n", __func__, __LINE__);
+                    cfg->Step[StepIns].mldApIndex[j] = cfg->Step[StepIns].ApIndex;
+                    cfg->Step[StepIns].ApIndex = vap_index;
+                } else
+                    cfg->Step[StepIns].mldApIndex[j] = vap_index;
+//
+                j++;
+            }
         }
     }
+    if (client_found)
+        return;
 
     wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: client %s not found \n", __func__, __LINE__, DstMac);
 
@@ -1393,6 +1416,9 @@ void WiFiBlastClient(void)
 
             /*TODO RDKB-34680 CID: 154402,154401  Data race condition*/
             g_active_msmt->curStepData.ApIndex = apIndex;
+            g_active_msmt->curStepData.isMLO = cfg->Step[StepCount].isMLO;
+            memcpy(g_active_msmt->curStepData.mldApIndex, cfg->Step[StepCount].mldApIndex,
+                sizeof(g_active_msmt->curStepData.mldApIndex));
             wifi_util_error_print(WIFI_BLASTER, "Value of apindex is %d \n", apIndex);
             g_active_msmt->curStepData.StepId = cfg->Step[StepCount].StepId;
 
@@ -1416,7 +1442,7 @@ void WiFiBlastClient(void)
             /* WiFiBlastClient is derefered task, so client could disconnect
              * before it starts
              */
-            if (is_blaster_device_associated(apIndex, bmac) == false) {
+            if (is_blaster_device_associated(apIndex, bmac, NULL) == false) {
 
                 if (g_wifi_ctrl->network_mode == rdk_dev_mode_type_ext) {
 
@@ -1712,7 +1738,11 @@ static int push_blaster_config_event_to_monitor_queue(wifi_mon_stats_request_sta
     data->u.mon_stats_config.args.vap_index = g_active_msmt->curStepData.ApIndex;
     wifi_util_error_print(WIFI_BLASTER,"%s:%d Blaster config values vap_index = %d\n", __func__, __LINE__, g_active_msmt->curStepData.ApIndex);
     config_sample_blaster(data);
-
+    for (int i = 0; (i < MAX_NUM_RADIOS - 1) && (g_active_msmt->curStepData.mldApIndex[i] >= 0); i++) {
+        data->u.mon_stats_config.args.vap_index = g_active_msmt->curStepData.mldApIndex[i];
+        wifi_util_error_print(WIFI_BLASTER,"%s:%d Blaster config values MLD vap_index = %d\n", __func__, __LINE__, g_active_msmt->curStepData.mldApIndex[i]);
+        config_sample_blaster(data);
+    }
     if (NULL != data) {
         free(data);
         data = NULL;
@@ -1850,6 +1880,7 @@ static void sample_blaster(wifi_provider_response_t *provider_response)
     wifi_actvie_msmt_t  *g_active_msmt = get_wifi_blaster();
     active_msmt_step_t *step = &g_active_msmt->curStepData;
     unsigned int *SampleCount = get_sample_count();
+    unsigned int count = 0;
     wifi_apps_mgr_t *apps_mgr;
     wifi_app_t *wifi_app =  NULL;
 
@@ -1868,6 +1899,19 @@ static void sample_blaster(wifi_provider_response_t *provider_response)
     }
 
     int index = g_active_msmt->curStepData.ApIndex;
+    int mld_num = -1;
+    int mld_idx = 0;
+    while((mld_num < MAX_NUM_RADIOS - 2) && (g_active_msmt->curStepData.mldApIndex[mld_num+1] >= 0))
+    {
+        if (provider_response->args.vap_index == (unsigned int)g_active_msmt->curStepData.mldApIndex[mld_num+1]) {
+            index = provider_response->args.vap_index;
+            mld_idx = mld_num+2;
+        }
+        mld_num++;
+    }
+    if (g_active_msmt->curStepData.isMLO)
+        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d Received MLO link stats response from AP %d\n", __func__, __LINE__, index);
+
     int radio_index = get_radio_index_for_vap_index(&(get_wifimgr_obj())->hal_cap.wifi_prop, index);
 #if defined (_PP203X_PRODUCT_REQ_) || defined (_GREXT02ACTS_PRODUCT_REQ_)
     wifi_radio_operationParam_t* radioOperation = NULL;
@@ -1890,7 +1934,7 @@ if ( *SampleCount <= (GetActiveMsmtNumberOfSamples())) {
     if (radio_index != RETURN_ERR) {
         wifi_util_error_print(WIFI_BLASTER, "%s: bmac is %02x:%02x:%02x:%02x:%02x:%02x\n", __func__, bmac[0], bmac[1], bmac[2], bmac[3], bmac[4], bmac[5]);
         wifi_util_error_print(WIFI_BLASTER, "%s: provider_response->stat_array_size %u\n", __func__, provider_response->stat_array_size);
-        for (unsigned int count = 0; count < provider_response->stat_array_size; count++) {
+        for (count = 0; count < provider_response->stat_array_size; count++) {
             wifi_util_error_print(WIFI_BLASTER, "%s: provider mac is %02x:%02x:%02x:%02x:%02x:%02x \n", __func__, assoc_stats[count].sta_mac[0], assoc_stats[count].sta_mac[1],
                 assoc_stats[count].sta_mac[2], assoc_stats[count].sta_mac[3], assoc_stats[count].sta_mac[4], assoc_stats[count].sta_mac[5]);
             if (!memcmp(bmac, assoc_stats[count].sta_mac, sizeof(mac_address_t))) {
@@ -1911,30 +1955,31 @@ if ( *SampleCount <= (GetActiveMsmtNumberOfSamples())) {
 
             (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].WaitAndLatencyInMs = ((getCurrentTimeInMicroSeconds () - wifi_app->data.u.blaster.blaster_start) / 1000);
             active_msmt_log_message(BLASTER_DEBUG_LOG, "PKTGEN_WAIT_IN_MS duration : %lu and value of getcurrent time is %lu and value of blaster_start is %lu \n", ((getCurrentTimeInMicroSeconds () - wifi_app->data.u.blaster.blaster_start)/1000), getCurrentTimeInMicroSeconds (), wifi_app->data.u.blaster.blaster_start);
-
-            g_active_msmt->active_msmt_data[*SampleCount].rssi = dev_conn->cli_RSSI;
-            g_active_msmt->active_msmt_data[*SampleCount].TxPhyRate = dev_conn->cli_LastDataDownlinkRate;
-            g_active_msmt->active_msmt_data[*SampleCount].RxPhyRate = dev_conn->cli_LastDataUplinkRate;
-            g_active_msmt->active_msmt_data[*SampleCount].SNR = dev_conn->cli_SNR;
-            g_active_msmt->active_msmt_data[*SampleCount].ReTransmission = dev_conn->cli_Retransmissions;
-            g_active_msmt->active_msmt_data[*SampleCount].MaxTxRate = dev_conn->cli_MaxDownlinkRate;
-            g_active_msmt->active_msmt_data[*SampleCount].MaxRxRate = dev_conn->cli_MaxUplinkRate;
+            if (!g_active_msmt->curStepData.isMLO || (g_active_msmt->curStepData.isMLO && assoc_stats[count].assoc_link)) {
+                g_active_msmt->active_msmt_data[*SampleCount].rssi = dev_conn->cli_RSSI;
+                g_active_msmt->active_msmt_data[*SampleCount].TxPhyRate = dev_conn->cli_LastDataDownlinkRate;
+                g_active_msmt->active_msmt_data[*SampleCount].RxPhyRate = dev_conn->cli_LastDataUplinkRate;
+                g_active_msmt->active_msmt_data[*SampleCount].SNR = dev_conn->cli_SNR;
+                g_active_msmt->active_msmt_data[*SampleCount].ReTransmission = dev_conn->cli_Retransmissions;
+                g_active_msmt->active_msmt_data[*SampleCount].MaxTxRate = dev_conn->cli_MaxDownlinkRate;
+                g_active_msmt->active_msmt_data[*SampleCount].MaxRxRate = dev_conn->cli_MaxUplinkRate;
 #if defined (_PP203X_PRODUCT_REQ_) || defined (_GREXT02ACTS_PRODUCT_REQ_)
-            if (radioOperation != NULL) {
-                convert_channel_width_to_str(radioOperation->channelWidth, g_active_msmt->active_msmt_data[*SampleCount].Operating_channelwidth, OPER_BUFFER_LEN);
-                convert_variant_to_str(radioOperation->variant, g_active_msmt->active_msmt_data[*SampleCount].Operating_standard, OPER_BUFFER_LEN);
-            }
+                if (radioOperation != NULL) {
+                    convert_channel_width_to_str(radioOperation->channelWidth, g_active_msmt->active_msmt_data[*SampleCount].Operating_channelwidth, OPER_BUFFER_LEN);
+                    convert_variant_to_str(radioOperation->variant, g_active_msmt->active_msmt_data[*SampleCount].Operating_standard, OPER_BUFFER_LEN);
+                }
 #else
-            if (strstr(dev_conn->cli_OperatingStandard, "802.11") != NULL) {
-                sscanf(dev_conn->cli_OperatingStandard, "802.11%2s", g_active_msmt->active_msmt_data[*SampleCount].Operating_standard);
-            } else {
-                snprintf(g_active_msmt->active_msmt_data[*SampleCount].Operating_standard, OPER_BUFFER_LEN, dev_conn->cli_OperatingStandard);
-            }
-            snprintf(g_active_msmt->active_msmt_data[*SampleCount].Operating_channelwidth, OPER_BUFFER_LEN, dev_conn->cli_OperatingChannelBandwidth);
+                if (strstr(dev_conn->cli_OperatingStandard, "802.11") != NULL) {
+                    sscanf(dev_conn->cli_OperatingStandard, "802.11%2s", g_active_msmt->active_msmt_data[*SampleCount].Operating_standard);
+                } else {
+                    snprintf(g_active_msmt->active_msmt_data[*SampleCount].Operating_standard, OPER_BUFFER_LEN, dev_conn->cli_OperatingStandard);
+                }
+                snprintf(g_active_msmt->active_msmt_data[*SampleCount].Operating_channelwidth, OPER_BUFFER_LEN, dev_conn->cli_OperatingChannelBandwidth);
 #endif //_PP203X_PRODUCT_REQ_ , _GREXT02ACTS_PRODUCT_REQ_
+            }
 
-            (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentAck = dev_conn->cli_DataFramesSentAck;
-            (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentTotal = dev_conn->cli_PacketsSent + dev_conn->cli_DataFramesSentNoAck;
+            (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentAck[mld_idx] = dev_conn->cli_DataFramesSentAck;
+            (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentTotal[mld_idx] = dev_conn->cli_PacketsSent + dev_conn->cli_DataFramesSentNoAck;
 
             wifi_util_dbg_print(WIFI_BLASTER,"samplecount[%d] : PacketsSentAck[%lu] PacketsSentTotal[%lu]"
                     " WaitAndLatencyInMs[%d ms] RSSI[%d] TxRate[%lu Mbps] RxRate[%lu Mbps] SNR[%d]"
@@ -1946,7 +1991,7 @@ if ( *SampleCount <= (GetActiveMsmtNumberOfSamples())) {
                 if (ctrl->network_mode == rdk_dev_mode_type_ext) {
                     active_msmt_status_t status;
 
-                    if (is_blaster_device_associated(index, bmac) == false) {
+                    if (is_blaster_device_associated(index, bmac, NULL) == false) {
                         snprintf(msg, sizeof(msg), "The MAC is disconnected");
                         status = ACTIVE_MSMT_STATUS_NO_CLIENT;
                     }
@@ -1960,24 +2005,32 @@ if ( *SampleCount <= (GetActiveMsmtNumberOfSamples())) {
                 }
 
                 active_msmt_log_message(BLASTER_DEBUG_LOG, "%s : %d Unable to get provider response for : %s\n",__func__,__LINE__,g_active_msmt->curStepData.DestMac);
-                (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentTotal = 0;
-                (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentAck = 0;
+                (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentTotal[mld_idx] = 0;
+                (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentAck[mld_idx] = 0;
                 (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].WaitAndLatencyInMs = 0;
                 sample_done_notify();
                 return;
             }
         } else {
             active_msmt_log_message(BLASTER_DEBUG_LOG, "%s:%d radio_index is invalid. So, client is treated as offline\n",__func__, __LINE__);
-            (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentTotal = 0;
-            (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentAck = 0;
+            (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentTotal[mld_idx] = 0;
+            (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].PacketsSentAck[mld_idx] = 0;
             (wifi_app->data.u.blaster.frameCountSample)[*SampleCount].WaitAndLatencyInMs = 0;
             strncpy(g_active_msmt->active_msmt_data[*SampleCount].Operating_standard, "NULL",OPER_BUFFER_LEN);
             strncpy(g_active_msmt->active_msmt_data[*SampleCount].Operating_channelwidth, "NULL",OPER_BUFFER_LEN);
             sample_done_notify();
             return;
         }
-        wifi_app->data.u.blaster.blaster_start = getCurrentTimeInMicroSeconds ();
-        *SampleCount += 1;
+        if (!g_active_msmt->curStepData.isMLO)
+        {
+            wifi_app->data.u.blaster.blaster_start = getCurrentTimeInMicroSeconds ();
+            *SampleCount += 1;
+        }
+        else if (mld_num < 0 || index == g_active_msmt->curStepData.mldApIndex[mld_num])
+        {
+            wifi_app->data.u.blaster.blaster_start = getCurrentTimeInMicroSeconds ();
+            *SampleCount += 1;
+        }
 }
     if (dev_conn != NULL){
         //free(dev_conn);
@@ -1986,13 +2039,12 @@ if ( *SampleCount <= (GetActiveMsmtNumberOfSamples())) {
     wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Sample count value = %d\n", __func__, __LINE__, *SampleCount);
     if (*SampleCount == g_active_msmt->active_msmt.ActiveMsmtNumberOfSamples + 1){
         *SampleCount = 0;
-        wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: calling calculate_throughput\n", __func__, __LINE__);
-        calculate_throughput();
+        calculate_throughput(mld_num+1);
         sample_done_notify();
     }
 }
 
-void calculate_throughput()
+void calculate_throughput(int mld_num)
 {
     wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: Entered in \n", __func__, __LINE__);
     unsigned long totalduration = 0;
@@ -2015,37 +2067,45 @@ void calculate_throughput()
         return;
     }
 
-    unsigned long DiffsamplesAck = 0, Diffsamples = 0, TotalAckSamples = 0, TotalSamples = 0;
-    double  tp = 0, AckRate = 0, AckSum = 0, Rate = 0, AvgAckThroughput = 0;
+    unsigned long DiffsamplesAck = 0, Diffsamples = 0, DiffsamplesAckLink = 0, DiffsamplesLink = 0, TotalAckSamples = 0, TotalSamples = 0;
+    double  tp = 0, AckRate = 0, AckSum = 0, Rate = 0, AckRateLink = 0, RateLink = 0, AvgAckThroughput = 0;
 
     int index = g_active_msmt->curStepData.ApIndex;
 
     wifi_util_dbg_print(WIFI_BLASTER, "%s:%d: calculating the throughput\n", __func__, __LINE__);
     // Analyze samples and get Throughput
     for (SampleCount = 0; SampleCount < GetActiveMsmtNumberOfSamples() ; SampleCount++) {
-        DiffsamplesAck = (wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].PacketsSentAck - (wifi_app->data.u.blaster.frameCountSample)[SampleCount].PacketsSentAck;
-        Diffsamples = (wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].PacketsSentTotal - (wifi_app->data.u.blaster.frameCountSample)[SampleCount].PacketsSentTotal;
+        DiffsamplesAck = 0;
+        Diffsamples = 0;
+        AckRate = 0;
+        Rate = 0;
+        for (int i = 0; i <= mld_num; i++) {
+            DiffsamplesAckLink = (wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].PacketsSentAck[i] - (wifi_app->data.u.blaster.frameCountSample)[SampleCount].PacketsSentAck[i];
+            DiffsamplesLink = (wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].PacketsSentTotal[i] - (wifi_app->data.u.blaster.frameCountSample)[SampleCount].PacketsSentTotal[i];
+            DiffsamplesAck += DiffsamplesAckLink;
+            Diffsamples += DiffsamplesLink;
 
-        if ((wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].WaitAndLatencyInMs != 0) {
-            tp = (double)(DiffsamplesAck*8*GetActiveMsmtPktSize());              //number of bits
-            wifi_util_dbg_print(WIFI_BLASTER,"tp = [%f bits]\n", tp );
-            tp = tp/1000000;                //convert to Mbits
-            wifi_util_dbg_print(WIFI_BLASTER,"tp = [%f Mb]\n", tp );
-            AckRate = (tp/(wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].WaitAndLatencyInMs) * 1000;                        //calculate bitrate in the unit of Mbpms
-            tp = (double)(Diffsamples*8*GetActiveMsmtPktSize());         //number of bits
-            wifi_util_dbg_print(WIFI_BLASTER,"tp = [%f bits]\n", tp );
-            tp = tp/1000000;                //convert to Mbits
-            wifi_util_dbg_print(WIFI_BLASTER,"tp = [%f Mb]\n", tp );
-            Rate = (tp/(wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].WaitAndLatencyInMs) * 1000;                   //calculate bitrate in the unit of Mbpms
-        } else {
-            AckRate = 0;
-            Rate = 0;
+            if ((wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].WaitAndLatencyInMs != 0) {
+                tp = (double)(DiffsamplesAckLink*8*GetActiveMsmtPktSize());              //number of bits
+                wifi_util_dbg_print(WIFI_BLASTER,"tp = [%f bits]\n", tp );
+                tp = tp/1000000;                //convert to Mbits
+                wifi_util_dbg_print(WIFI_BLASTER,"tp = [%f Mb]\n", tp );
+                AckRateLink = (tp/(wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].WaitAndLatencyInMs) * 1000;
+                AckRate += (tp/(wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].WaitAndLatencyInMs) * 1000;                        //calculate bitrate in the unit of Mbpms
+                tp = (double)(DiffsamplesLink*8*GetActiveMsmtPktSize());         //number of bits
+                wifi_util_dbg_print(WIFI_BLASTER,"tp = [%f bits]\n", tp );
+                tp = tp/1000000;                //convert to Mbits
+                wifi_util_dbg_print(WIFI_BLASTER,"tp = [%f Mb]\n", tp );
+                RateLink = (tp/(wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].WaitAndLatencyInMs) * 1000;
+                Rate += (tp/(wifi_app->data.u.blaster.frameCountSample)[SampleCount+1].WaitAndLatencyInMs) * 1000;                   //calculate bitrate in the unit of Mbpms
+                if (mld_num > 0)
+                    wifi_util_dbg_print(WIFI_BLASTER,"Sample[%d] Link[%d] DiffsamplesAck[%lu]   Diffsamples[%lu]   BitrateAckPackets[%.5f Mbps]   BitrateTotalPackets[%.5f Mbps]\n", SampleCount, i, DiffsamplesAckLink, DiffsamplesLink, AckRateLink, RateLink);
+            }
         }
-
         /* updating the throughput in the global variable */
         g_active_msmt->active_msmt_data[SampleCount].throughput = AckRate;
 
-        wifi_util_dbg_print(WIFI_BLASTER,"Sample[%d]   DiffsamplesAck[%lu]   Diffsamples[%lu]   BitrateAckPackets[%.5f Mbps]   BitrateTotalPackets[%.5f Mbps]\n", SampleCount, DiffsamplesAck, Diffsamples, AckRate, Rate );
+        wifi_util_dbg_print(WIFI_BLASTER,"Sample[%d] Total DiffsamplesAck[%lu]   Diffsamples[%lu]   BitrateAckPackets[%.5f Mbps]   BitrateTotalPackets[%.5f Mbps]\n", SampleCount, DiffsamplesAck, Diffsamples, AckRate, Rate);
         AckSum += AckRate;
         Sum += Rate;
         TotalAckSamples += DiffsamplesAck;

--- a/source/apps/blaster/wifi_blaster.h
+++ b/source/apps/blaster/wifi_blaster.h
@@ -50,8 +50,8 @@ extern "C" {
 
 typedef struct wifi_app wifi_app_t;
 typedef struct _pktGenFrameCountSamples {
-        ULONG   PacketsSentAck;
-        ULONG   PacketsSentTotal;
+        ULONG   PacketsSentAck[MAX_NUM_RADIOS];
+        ULONG   PacketsSentTotal[MAX_NUM_RADIOS];
         int             WaitAndLatencyInMs;             //Wait duration + API Latency in millsecs
 } pktGenFrameCountSamples;
 


### PR DESCRIPTION
Reason for change:
Implement blaster trhoughput calculation for multilink clients
 - Added detection of MLO client for blaster targets
 - Added logic to start blast on MAP (BCM specific), no traffic is generated otherwise for mlo clients
 - Added stats monitoring of all valid links in case of MultiLink
 - Reworked sampling logic to store stats per link per sample
 - Improved throughput calculation logic to calculate per link througput, the sum of all links tput is the result tput for MLO client

Test Procedure:
1) Configure MLO (currently 210 config)
2) Connect MLO client
3) Start blasting via webapp or manually with following commands dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.WifiClient.ActiveMeasurements.Enable bool true dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_Report.WifiClient.ActiveMeasurements.Plan.PlanID string a82d191b187241028acb747fe4a029001 dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_Report.WifiClient.ActiveMeasurements.Plan.Step.1.StepID uint 0 dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_Report.WifiClient.ActiveMeasurements.Plan.Step.1.DestMac string 8876B9F27B8D dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_Report.WifiClient.ActiveMeasurements.Enable bool true 4) Check overall calculated tput in webapp or manually via /tmp/wifiBlaster logs

Risks: Medium
Priority: P1