### PR TITLE
RDKB-65545: [Coverity change] [VXB10] [8.3p5s1] WIFI_WARN_RadioOutrange is observed post OneWifi Crash | Increase in Load Avg | Log upload is frequent | No Client connectivity 

### DIFF
--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -617,7 +617,13 @@ bus_error_t webconfig_init_data_get_subdoc(char *event_name, raw_data_t *p_data,
             sizeof(wifi_hal_capability_t));
         data->u.decoded.num_radios = num_of_radios;
         // tell webconfig to encode
-	    webconfig_encode(&ctrl->webconfig, data, webconfig_subdoc_type_dml);
+	     if (webconfig_encode(&ctrl->webconfig, data, webconfig_subdoc_type_dml) != webconfig_error_none) {
+	        wifi_util_error_print(WIFI_CTRL, "%s:%d webconfig encode failed\n", __func__, __LINE__);
+	        webconfig_data_free(data);
+            free(data);
+	        data = NULL;
+	        return bus_error_general;
+	    }
 
         uint32_t str_size = (strlen(data->u.encoded.raw) + 1);
         p_data->data_type = bus_data_type_string;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2142,8 +2142,7 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
 
     if ((cfg->hw_mode != 0) && (validate_wifi_hw_variant(cfg->freq_band, cfg->hw_mode) == RETURN_OK)) {
         config->variant = cfg->hw_mode;
-    }
-    	
+    }	
     config->csa_beacon_count = cfg->csa_beacon_count;
     if (cfg->country != 0) {
         config->countryCode = cfg->country;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2143,31 +2143,7 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
     if ((cfg->hw_mode != 0) && (validate_wifi_hw_variant(cfg->freq_band, cfg->hw_mode) == RETURN_OK)) {
         config->variant = cfg->hw_mode;
     }
-    if (config->band == WIFI_FREQUENCY_6_BAND) {
-        if (is_bandwidth_and_hw_variant_compatible(config->variant, config->channelWidth) != true) {
-            wifi_util_info_print(WIFI_DB,
-                "%s:%d 6G hw_mode/channel_width mismatch (variant=%d bw=%d), normalizing\n",
-                __func__, __LINE__, config->variant, config->channelWidth);
-
-#ifdef CONFIG_IEEE80211BE 
-            if (config->variant & WIFI_80211_VARIANT_BE) {
-                config->channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
-            } else
-#endif /* CONFIG_IEEE80211BE */
-                if (config->variant & WIFI_80211_VARIANT_AX) {
-                    config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
-                } else { 
-#ifdef CONFIG_IEEE80211BE
-                    config->variant = WIFI_80211_VARIANT_BE;
-                    config->channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
-#else
-                    config->variant = WIFI_80211_VARIANT_AX; 
-                    config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
-#endif /* CONFIG_IEEE80211BE */
-                }
-        }
-    }
-	
+    	
     config->csa_beacon_count = cfg->csa_beacon_count;
     if (cfg->country != 0) {
         config->countryCode = cfg->country;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2142,7 +2142,7 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
 
     if ((cfg->hw_mode != 0) && (validate_wifi_hw_variant(cfg->freq_band, cfg->hw_mode) == RETURN_OK)) {
         config->variant = cfg->hw_mode;
-    }	
+    }
     config->csa_beacon_count = cfg->csa_beacon_count;
     if (cfg->country != 0) {
         config->countryCode = cfg->country;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -2143,6 +2143,31 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
     if ((cfg->hw_mode != 0) && (validate_wifi_hw_variant(cfg->freq_band, cfg->hw_mode) == RETURN_OK)) {
         config->variant = cfg->hw_mode;
     }
+    if (config->band == WIFI_FREQUENCY_6_BAND) {
+        if (is_bandwidth_and_hw_variant_compatible(config->variant, config->channelWidth) != true) {
+            wifi_util_info_print(WIFI_DB,
+                "%s:%d 6G hw_mode/channel_width mismatch (variant=%d bw=%d), normalizing\n",
+                __func__, __LINE__, config->variant, config->channelWidth);
+
+#ifdef CONFIG_IEEE80211BE 
+            if (config->variant & WIFI_80211_VARIANT_BE) {
+                config->channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
+            } else
+#endif /* CONFIG_IEEE80211BE */
+                if (config->variant & WIFI_80211_VARIANT_AX) {
+                    config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
+                } else { 
+#ifdef CONFIG_IEEE80211BE
+                    config->variant = WIFI_80211_VARIANT_BE;
+                    config->channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
+#else
+                    config->variant = WIFI_80211_VARIANT_AX; 
+                    config->channelWidth = WIFI_CHANNELBANDWIDTH_160MHZ;
+#endif /* CONFIG_IEEE80211BE */
+                }
+        }
+    }
+	
     config->csa_beacon_count = cfg->csa_beacon_count;
     if (cfg->country != 0) {
         config->countryCode = cfg->country;


### PR DESCRIPTION
Reason for Change: Hardware variant and bandwidth mismatch observed.
Test Procedure: Verify callback_Wifi_Radio_Config when a mismatch is detected.
Ensure that the hardware variant is updated according to the detected bandwidth mismatch.
Priority: P0
Risks: High
Signed-off-by: [mothishree_mallaiyanjothimani@comcast.com]