### PR TITLE
RDKBACCL-1885 : observing BPI build issue in tip code of onewifi

### DIFF
--- a/source/webconfig/Makefile.am
+++ b/source/webconfig/Makefile.am
@@ -72,7 +72,7 @@ libwifi_webconfig_la_CPPFLAGS += -I$(top_srcdir)/source/dml/wifi_ssp -I$(top_src
 
 libwifi_webconfig_la_CFLAGS =  $(SYSTEMD_CFLAGS)
 
-libwifi_webconfig_la_SOURCES = wifi_webconfig.c wifi_encoder.c wifi_decoder.c wifi_ovsdb_translator.c  wifi_webconfig_home.c wifi_webconfig_mesh.c wifi_webconfig_private.c wifi_webconfig_radio.c  wifi_webconfig_xfinity.c wifi_webconfig_associated_client.c wifi_webconfig_wifiapi_radio.c wifi_webconfig_wifiapi_vap.c wifi_webconfig_macfilter.c wifi_webconfig_blaster.c wifi_webconfig_harvester.c wifi_webconfig_wifi_config.c wifi_webconfig_csi.c wifi_webconfig_mesh_sta.c wifi_webconfig_mesh_backhaul.c wifi_webconfig_null.c wifi_webconfig_stats_config.c wifi_webconfig_steering_config.c wifi_webconfig_steering_clients.c wifi_webconfig_lnf.c wifi_webconfig_vif_neighbors.c wifi_webconfig_mesh_backhaul_sta.c wifi_webconfig_dml.c wifi_webconfig_levl.c wifi_webconfig_cac.c wifi_webconfig_radio_stats.c wifi_webconfig_neighbor_stats.c wifi_webconfig_assocdevice_stats.c wifi_webconfig_radiodiag_stats.c wifi_webconfig_radio_temperature.c wifi_webconfig_multivap.c wifi_webconfig_easymesh_config.c wifi_webconfig_beacon_report.c wifi_webconfig_memwraptool.c wifi_webconfig_link_report.c wifi_webconfig_ignite.c
+libwifi_webconfig_la_SOURCES = wifi_webconfig.c wifi_encoder.c wifi_decoder.c wifi_webconfig_home.c wifi_webconfig_mesh.c wifi_webconfig_private.c wifi_webconfig_radio.c  wifi_webconfig_xfinity.c wifi_webconfig_associated_client.c wifi_webconfig_wifiapi_radio.c wifi_webconfig_wifiapi_vap.c wifi_webconfig_macfilter.c wifi_webconfig_blaster.c wifi_webconfig_harvester.c wifi_webconfig_wifi_config.c wifi_webconfig_csi.c wifi_webconfig_mesh_sta.c wifi_webconfig_mesh_backhaul.c wifi_webconfig_null.c wifi_webconfig_stats_config.c wifi_webconfig_steering_config.c wifi_webconfig_steering_clients.c wifi_webconfig_lnf.c wifi_webconfig_vif_neighbors.c wifi_webconfig_mesh_backhaul_sta.c wifi_webconfig_dml.c wifi_webconfig_levl.c wifi_webconfig_cac.c wifi_webconfig_radio_stats.c wifi_webconfig_neighbor_stats.c wifi_webconfig_assocdevice_stats.c wifi_webconfig_radiodiag_stats.c wifi_webconfig_radio_temperature.c wifi_webconfig_multivap.c wifi_webconfig_easymesh_config.c wifi_webconfig_beacon_report.c wifi_webconfig_memwraptool.c wifi_webconfig_link_report.c wifi_webconfig_ignite.c
 if EM_APP_SUPPORT
 libwifi_webconfig_la_SOURCES += wifi_webconfig_em_channel_stats.c wifi_webconfig_em_sta_link_metrics.c wifi_webconfig_em_ap_metrics_report.c
 libwifi_webconfig_la_CFLAGS += $(EM_APP_FLAG)
@@ -80,6 +80,8 @@ endif
 
 if WITH_EASYMESH
 libwifi_webconfig_la_SOURCES += wifi_easymesh_translator.c
+else
+libwifi_webconfig_la_SOURCES += wifi_ovsdb_translator.c
 endif
 
 libwifi_webconfig_la_SOURCES +=  $(top_srcdir)/lib/common/util.c $(top_srcdir)/source/utils/wifi_util.c $(top_srcdir)/source/utils/collection.c


### PR DESCRIPTION
Reason for change: Observing below errors,
../../../git/source/webconfig/wifi_ovsdb_translator.c:3075:98: error: 'struct schema_Wifi_VIF_State' has no member named 'mld_if_name'; did you mean 'if_name'?       |  3075 |         if (get_mlo_vap_name_from_per_radio(vap->vap_name, vap_row->mld_if_name, sizeof(vap_row->mld_if_name))) {
which is caused by https://github.com/rdkcentral/OneWifi/pull/1158
Test Procedure: BPI build successful
Risks: None