### PR TITLE
RDKBWIFI-472:  Add support to control BTM disassociation timer

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -92,6 +92,7 @@ extern "C" {
 #define WIFI_LINK_QUALITY_DATA      "Device.WiFi.LinkQualityData"
 #define WIFI_LINK_QUALITY_FLAGS     "Device.WiFi.LinkQualityFlags"
 #define WIFI_IGNITE_STATUS "Device.WiFi.EndPoint.1.LinkQualityStatus"
+#define WIFI_IGNORE_11V_DISASSOC  "Device.WiFi.AccessPoint.{i}.X_RDKCENTRAL-COM_Ignore11vDisassoc"
 
 #ifndef MAX_NUM_MLD_LINKS
 #define MAX_NUM_MLD_LINKS 15

--- a/include/wifi_events.h
+++ b/include/wifi_events.h
@@ -184,6 +184,7 @@ typedef enum {
     wifi_event_type_sm_app_enable,
     wifi_event_type_link_quality_rfc,
     wifi_event_type_send_btm_req,
+    wifi_event_type_command_set_ignore_disassoc_timer,
     wifi_event_command_max,
 
     wifi_event_monitor_diagnostics = wifi_event_type_base

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -4328,6 +4328,39 @@ void process_rsn_override_rfc(bool type)
     tgt_vap_map = NULL;
 }
 
+void process_set_ignore_disassoc_timer_command(wifi_ctrl_t *ctrl,
+                                               void *data, unsigned int len)
+{
+    ignore_11v_disassoc_cmd_t *cmd = NULL;
+
+    if ((data == NULL) || (ctrl == NULL)) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: NULL input\n", __func__, __LINE__);
+        return;
+    }
+
+    if (len < sizeof(ignore_11v_disassoc_cmd_t)) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: invalid data len %u, expected %zu\n",
+                              __func__, __LINE__, len, sizeof(ignore_11v_disassoc_cmd_t));
+        return;
+    }
+
+    cmd = (ignore_11v_disassoc_cmd_t *)data;
+
+    if ((cmd->ap_idx < 0) || (cmd->ap_idx >= (int)getTotalNumberVAPs())) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: invalid ap_idx %d\n",
+                              __func__, __LINE__, cmd->ap_idx);
+        return;
+    }
+
+    wifi_util_info_print(WIFI_CTRL, "%s:%d: ap_idx=%d ignore_11v_disassoc=%d\n",
+                         __func__, __LINE__, cmd->ap_idx, cmd->ignore);
+
+    if (wifi_setApIgnoreBTMDisassocTimer(cmd->ap_idx, cmd->ignore) != RETURN_OK) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: HAL call failed for ap_idx=%d\n",
+                              __func__, __LINE__, cmd->ap_idx);
+    }
+}
+
 void handle_command_event(wifi_ctrl_t *ctrl, void *data, unsigned int len,
     wifi_event_subtype_t subtype)
 {
@@ -4508,6 +4541,9 @@ void handle_command_event(wifi_ctrl_t *ctrl, void *data, unsigned int len,
     case wifi_event_type_xfinity_rrm:
     case wifi_event_type_sm_app_enable:
         // not handle here
+        break;
+    case wifi_event_type_command_set_ignore_disassoc_timer:
+        process_set_ignore_disassoc_timer_command(ctrl, data, len);
         break;
     default:
         wifi_util_error_print(WIFI_CTRL, "[%s]:WIFI hal handler not supported this event %s\r\n",

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -4321,10 +4321,14 @@ bus_error_t set_ignore_disassoc_timer(char *name, raw_data_t *p_data, bus_user_d
     cmd.ap_idx = ap_idx;
     cmd.ignore  = p_data->raw_data.b;
 
-    push_event_to_ctrl_queue(&cmd, sizeof(cmd),
-                             wifi_event_type_command,
-                             wifi_event_type_command_set_ignore_disassoc_timer,
-                             NULL);
+    if (push_event_to_ctrl_queue(&cmd, sizeof(cmd),
+                                 wifi_event_type_command,
+                                 wifi_event_type_command_set_ignore_disassoc_timer,
+                                 NULL) != RETURN_OK) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: failed to enqueue command for ap_idx=%d\n",
+                              __func__, __LINE__, cmd.ap_idx);
+        return bus_error_out_of_resources;
+    }
     return bus_error_success;
 }
 

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -4273,6 +4273,60 @@ void register_endpoint_components(wifi_ctrl_t *ctrl)
      return;
 }
 
+bus_error_t set_ignore_disassoc_timer(char *name, raw_data_t *p_data, bus_user_data_t *user_data)
+{
+    int ap_idx = 0;
+    ignore_11v_disassoc_cmd_t cmd;
+    const char *prefix = "Device.WiFi.AccessPoint.";
+    const char *suffix = ".X_RDKCENTRAL-COM_Ignore11vDisassoc";
+    char *endptr = NULL;
+    long ap_idx_long = 0;
+
+    (void)user_data;
+    if ((p_data == NULL) || (name == NULL)) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: NULL input\n", __func__, __LINE__);
+        return bus_error_invalid_input;
+    }
+
+    if (p_data->data_type != bus_data_type_boolean) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: wrong data type %d\n",
+                              __func__, __LINE__, p_data->data_type);
+        return bus_error_invalid_input;
+    }
+
+    /* name: "Device.WiFi.AccessPoint.<idx>.X_RDKCENTRAL-COM_Ignore11vDisassoc" */
+    if (strncmp(name, prefix, strlen(prefix)) != 0) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid name %s\n", __func__, __LINE__, name);
+        return bus_error_destination_not_found;
+    }
+
+    ap_idx_long = strtol(name + strlen(prefix), &endptr, 10);
+    if (endptr == (name + strlen(prefix)) || ap_idx_long < 1 || ap_idx_long > INT_MAX || strcmp(endptr, suffix) != 0) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid vap index %ld\n",
+                              __func__, __LINE__, ap_idx_long);
+        return bus_error_destination_not_found;
+    }
+
+    ap_idx = (int)ap_idx_long;
+
+    ap_idx -= 1; /* convert 1-based DM index to 0-based vap index */
+    if (convert_vap_index_to_vap_array_index(&get_wifimgr_obj()->hal_cap.wifi_prop,
+            (unsigned int)ap_idx) < 0) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid vap index %d\n",
+                              __func__, __LINE__, ap_idx + 1);
+        return bus_error_destination_not_found;
+    }
+
+    memset(&cmd, 0, sizeof(cmd));
+    cmd.ap_idx = ap_idx;
+    cmd.ignore  = p_data->raw_data.b;
+
+    push_event_to_ctrl_queue(&cmd, sizeof(cmd),
+                             wifi_event_type_command,
+                             wifi_event_type_command_set_ignore_disassoc_timer,
+                             NULL);
+    return bus_error_success;
+}
 
 void bus_register_handlers(wifi_ctrl_t *ctrl)
 {
@@ -4447,6 +4501,9 @@ void bus_register_handlers(wifi_ctrl_t *ctrl)
                                 { WIFI_IGNITE_STATUS, bus_element_type_event,
                                     { NULL, NULL, NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
                                     { bus_data_type_string, false, 0, 0, 0, NULL } },
+                                { WIFI_IGNORE_11V_DISASSOC, bus_element_type_property,
+                                    { NULL, set_ignore_disassoc_timer, NULL, NULL, NULL, NULL }, slow_speed, ZERO_TABLE,
+                                    { bus_data_type_boolean, true, 0, 0, 0, NULL } },
     };
 
     rc = get_bus_descriptor()->bus_open_fn(&ctrl->handle, component_name);

--- a/source/core/wifi_ctrl_wifiapi_handlers.c
+++ b/source/core/wifi_ctrl_wifiapi_handlers.c
@@ -45,8 +45,8 @@ struct hal_api_info {
     {"wifi_getStationStats",                1, "<ap index>"},
     {"wifi_startScan",                      1, "<radio index>"},
     {"wifi_startNeighborScan",              3, "<vap index> <scan mode> <dwell time> [channels]"},
-    {"wifi_getNeighboringWiFiStatus",       1, "<radio index"},
-    {"wifi_setBTMRequest",                  3, "<vap index> <client mac> <candidate mac>"},
+    {"wifi_getNeighboringWiFiStatus",       1, "<radio index>"},
+    {"wifi_setBTMRequest",                  3, "<vap index> <client mac> <candidate mac> [disassoc imminent (0/1)] [disassoc timer (0-65535; used only if imminent=1)]"},
     {"wifi_setRMBeaconRequest",             3, "<vap index> <peer mac> <bssid>"},
     {"wifi_setNeighborReports",             2, "<vap index> <bssid>" },
     {"wifi_configNeighborReports",          3, "<vap index> <neighbor report enable> <neighbor report auto reply>" },
@@ -408,7 +408,34 @@ static void wifiapi_handle_set_btm_request(char **args, unsigned int num_args,
     str_to_mac_bytes(args[2], client_mac);
     str_to_mac_bytes(args[3], candidate_mac);
 
-    btm_request->requestMode = 0x1; // candidate list included
+    bool disassoc_imminent = false;
+
+    if (num_args > 4) {
+        char *end_imminent = NULL;
+        long v = strtol(args[4], &end_imminent, 10);
+        disassoc_imminent = !(end_imminent == args[4] || *end_imminent != '\0') && (v != 0);
+    }
+
+    btm_request->requestMode = BTM_REQMODE_PREF_LIST_INCL |
+        (disassoc_imminent ? BTM_REQMODE_DISASSOC_IMMINENT : 0);
+
+    if (disassoc_imminent && num_args > 5) {
+        char *end = NULL;
+        long t = strtol(args[5], &end, 10);
+        if (end == args[5] || *end != '\0') {
+            t = 0;
+        } else if (t < 0) {
+            t = 0;
+        } else if (t > 65535) {
+            t = 65535;
+        }
+        btm_request->timer = (USHORT)t;
+    } else {
+        btm_request->timer = 0;
+    }
+
+    /* Keep validityInterval at its default (0) unless it is explicitly exposed via CLI. */
+    btm_request->validityInterval = 0;
     btm_request->numCandidates = 1;
     memcpy(&btm_request->candidates[0].bssid, &candidate_mac, sizeof(mac_address_t));
 

--- a/source/core/wifi_ctrl_wifiapi_handlers.c
+++ b/source/core/wifi_ctrl_wifiapi_handlers.c
@@ -425,15 +425,21 @@ static void wifiapi_handle_set_btm_request(char **args, unsigned int num_args,
     btm_request->requestMode = BTM_REQMODE_PREF_LIST_INCL |
         (disassoc_imminent ? BTM_REQMODE_DISASSOC_IMMINENT : 0);
 
+    if (num_args > 5 && !disassoc_imminent) {
+        snprintf(result_buf, result_buf_size,
+            "Disassoc timer provided but disassoc imminent is 0; timer is only valid when imminent=1\n");
+        free(btm_request);
+        return;
+    }
+
     if (disassoc_imminent && num_args > 5) {
         char *end = NULL;
         long t = strtol(args[5], &end, 10);
-        if (end == args[5] || *end != '\0') {
-            t = 0;
-        } else if (t < 0) {
-            t = 0;
-        } else if (t > 65535) {
-            t = 65535;
+        if (end == args[5] || *end != '\0' || t < 0 || t > 65535) {
+            snprintf(result_buf, result_buf_size,
+                "Invalid disassoc timer value '%s' (expected 0-65535)\n", args[5]);
+            free(btm_request);
+            return;
         }
         btm_request->timer = (USHORT)t;
     } else {

--- a/source/core/wifi_ctrl_wifiapi_handlers.c
+++ b/source/core/wifi_ctrl_wifiapi_handlers.c
@@ -413,7 +413,13 @@ static void wifiapi_handle_set_btm_request(char **args, unsigned int num_args,
     if (num_args > 4) {
         char *end_imminent = NULL;
         long v = strtol(args[4], &end_imminent, 10);
-        disassoc_imminent = !(end_imminent == args[4] || *end_imminent != '\0') && (v != 0);
+        if (end_imminent == args[4] || *end_imminent != '\0' || (v != 0 && v != 1)) {
+            snprintf(result_buf, result_buf_size,
+                "Invalid disassoc imminent value '%s' (expected 0 or 1)\n", args[4]);
+            free(btm_request);
+            return;
+        }
+        disassoc_imminent = (v == 1);
     }
 
     btm_request->requestMode = BTM_REQMODE_PREF_LIST_INCL |

--- a/source/core/wifi_events.c
+++ b/source/core/wifi_events.c
@@ -202,6 +202,7 @@ const char *wifi_event_subtype_to_string(wifi_event_subtype_t type)
         DOC2S(wifi_event_type_wifiapi_max)
         DOC2S(wifi_event_webconfig_br_report)
         DOC2S(wifi_event_br_report)
+        DOC2S(wifi_event_type_command_set_ignore_disassoc_timer)
     default:
         wifi_util_error_print(WIFI_CTRL, "%s:%d: event not handle[%d]\r\n", __func__, __LINE__,
             type);

--- a/source/utils/wifi_util.h
+++ b/source/utils/wifi_util.h
@@ -194,6 +194,11 @@ typedef struct {
     char scan_mode_string[16];
 }__attribute__((packed, aligned(1))) wifi_scan_mode_mapper;
 
+typedef struct {
+    int  ap_idx;
+    bool ignore;
+} ignore_11v_disassoc_cmd_t;
+
 #define VAP_PREFIX_PRIVATE          "private_ssid"
 #define VAP_PREFIX_IOT              "iot_ssid"
 #define VAP_PREFIX_MESH_STA         "mesh_sta"


### PR DESCRIPTION
Add support to control the internal disassociation timer associated with BTM requests via a new TR-181 parameter:
Device.WiFi.AccessPoint.{i}.X_RDKCENTRAL-COM_Ignore11vDisassoc

Enhance wifi_setBTMRequest to allow configuring disassociation imminent and timer values, which were previously fixed to 0.

Changes:
• Added a TR-181 parameter for per-VAP configuration
• Propagated the configuration through the OneWifi control path to HAL (stubbed)
• Extended wifi_api2 command to accept disassociation imminent and timer inputs
• Added support to suppress the internal disassociation timer associated with BTM requests without modifying the Disassociation Imminent flag in outgoing BTM Request frames

Signed-off-by: sgunasekaran@maxlinear.com

Dep PR: https://github.com/rdkcentral/rdkb-halif-wifi/pull/113/ and https://github.com/rdkcentral/rdk-wifi-hal/pull/764