### PR TITLE
XB10-2720: /tmp folder flooding with core.prog_ovsm core file.

### DIFF
--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -40,7 +40,7 @@
 #define ASSOCIATED_DEVICE_DIAG_INTERVAL_MS 5000 //5 seconds
 #define MAX_RESET_RADIO_PARAMS_RETRY_COUNTER  (5000 / 100)
 
-#define MAC_FMT "%02x:%02x:%02x:%02x:%02x:%02x"
+#define MAC_FMT "%02x:%02x:%02x:%02x:%02x:%02x" // FOR DUMMY PR
 #define MAC_ARG(arg) \
     arg[0], \
     arg[1], \

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -40,7 +40,7 @@
 #define ASSOCIATED_DEVICE_DIAG_INTERVAL_MS 5000 //5 seconds
 #define MAX_RESET_RADIO_PARAMS_RETRY_COUNTER  (5000 / 100)
 
-#define MAC_FMT "%02x:%02x:%02x:%02x:%02x:%02x" // FOR DUMMY PR
+#define MAC_FMT "%02x:%02x:%02x:%02x:%02x:%02x"
 #define MAC_ARG(arg) \
     arg[0], \
     arg[1], \

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -3189,10 +3189,6 @@ int create_station_with_default_credentials(webconfig_subdoc_data_t *data, int n
                 .vaps.vap_map.vap_array[vap_array_index]
                 .u.sta_info.security.u.radius.eap_type = WIFI_EAP_TYPE_NONE;
         }
-        memset(&data->u.decoded.radios[radio_index].vaps.vap_map.vap_array[vap_array_index].u.sta_info.security.u.radius.ip, 0,
-                    sizeof(data->u.decoded.radios[radio_index].vaps.vap_map.vap_array[vap_array_index].u.sta_info.security.u.radius.ip));
-        memset(&data->u.decoded.radios[radio_index].vaps.vap_map.vap_array[vap_array_index].u.sta_info.security.u.radius.s_ip, 0,
-                    sizeof(data->u.decoded.radios[radio_index].vaps.vap_map.vap_array[vap_array_index].u.sta_info.security.u.radius.s_ip));
     }
 
     return status;


### PR DESCRIPTION
Impacted Platforms: All XB10 platforms.

Reason for change: On memset of radius.ip and radius_ip during station vap creation, u.key.key(passphrase) also cleared due to same union memory address used across radius configuration.

Test Procedure:

1. Load the above mentioned build
2. Factory reset the device.
3. After bootup, check for the ovsm crash core file generated in /tmp folder.
4. If present, then issue reproduced.
Risks: Medium

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com