### PR TITLE
XB10-2782: Fix MLO related Data Model

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -3281,18 +3281,6 @@ UINT getNumberVAPsPerRadio(UINT radioIndex)
     return wifi_mgr->radio_config[radioIndex].vaps.num_vaps;
 }
 
-BOOL isRadioBeEnabled(UINT radio_index)
-{
-#ifdef CONFIG_IEEE80211BE
-    wifi_radio_operationParam_t *radio_param = getRadioOperationParam(radio_index);
-
-    if (radio_param != NULL && radio_param->variant & WIFI_80211_VARIANT_BE) {
-        return TRUE;
-    }
-#endif /* CONFIG_IEEE80211BE */
-    return FALSE;
-}
-
 #if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
 /* A radio is MLO-capable only if it is enabled, not in EcoPowerDown, and running 802.11be. */
 static bool is_radio_mlo_capable(unsigned int radio_index)
@@ -3458,6 +3446,11 @@ unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
                     mld_conf->mld_enable = false;
                 }
 
+                /* Skip disabled VAPs */
+                if (target_vap->u.bss_info.enabled == false) {
+                    continue;
+                }
+
                 /* Validate MLD configuration bounds */
                 if (mld_conf->mld_id >= MLD_UNIT_COUNT || mld_conf->mld_link_id >= MAX_NUM_MLD_LINKS) {
                     continue;
@@ -3478,7 +3471,7 @@ unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
                 }
 
                 /* Main link (link_id == 0) provides the shared MLD MAC address */
-                if (mld_conf->mld_link_id == 0 && target_vap->u.bss_info.enabled == true) {
+                if (mld_conf->mld_link_id == 0) {
                     main_link_vap = target_vap;
                     memcpy(mlo_mac, mgr_vap->u.bss_info.bssid, sizeof(mac_address_t));
                 }

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -369,7 +369,6 @@ UINT getTotalNumberVAPs();
 UINT getNumberRadios();
 UINT getMaxNumberVAPsPerRadio(UINT radioIndex);
 UINT getNumberVAPsPerRadio(UINT radioIndex);
-BOOL isRadioBeEnabled(UINT radio_index);
 //getVAPArrayIndexFromVAPIndex() need to be used in case of VAPS considered as single array (from 0 to MAX_VAP)
 //In case of to get vap array index per radio, use convert_vap_index_to_vap_array_index()
 int getVAPArrayIndexFromVAPIndex(unsigned int apIndex, unsigned int *vap_array_index);

--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -155,11 +155,6 @@ void update_apmld_map()
     memset(mld_id_to_idx, -1, sizeof(mld_id_to_idx));
 
     for (unsigned int r_idx = 0; r_idx < num_radios; r_idx++) {
-        if (isRadioBeEnabled(r_idx) != TRUE) {
-            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Radio %d does not have BE mode enabled, skip\n", __func__, __LINE__, r_idx);
-            continue;
-        }
-
         mgr_vap_info_map = get_wifidb_vap_map(r_idx);
         if (mgr_vap_info_map == NULL) {
             wifi_util_error_print(WIFI_DMCLI, "%s:%d get_wifidb_vap_map failed for radio: %d\n", __func__, __LINE__, r_idx);
@@ -172,6 +167,11 @@ void update_apmld_map()
             wifi_mld_common_info_t *mld_info = &vap_config->u.bss_info.mld_info.common_info;
             unsigned int id = mld_info->mld_id;
             unsigned int mld_idx;
+
+            if (isVapSTAMesh(vap_config->vap_index)) {
+                wifi_util_dbg_print(WIFI_DMCLI, "%s:%d VAP %s is a STA mesh, skip\n", __func__, __LINE__, vap_config->vap_name);
+                continue;
+            }
 
             if (!mld_info->mld_enable) {
                 wifi_util_dbg_print(WIFI_DMCLI, "%s:%d MLD disabled for id %d, skip\n", __func__, __LINE__, id);

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -5470,8 +5470,7 @@ SSID_GetParamIntValue
             *pInt = -1;
             return TRUE;
         }
-        if (pcfg->u.bss_info.mld_info.common_info.mld_enable == FALSE ||
-            !isRadioBeEnabled(pcfg->radio_index)) {
+        if (pcfg->u.bss_info.mld_info.common_info.mld_enable == FALSE) {
             *pInt = -1;
         } else {
             *pInt = pcfg->u.bss_info.mld_info.common_info.mld_id;
@@ -6014,13 +6013,6 @@ SSID_SetParamIntValue
         }
         wifi_util_info_print(WIFI_DMCLI,"%s:%d MLD Unit %d\n", __FUNCTION__, __LINE__, iValue);
         tmp_mld_enable = (iValue == -1) ? FALSE : TRUE;
-
-        if (tmp_mld_enable == TRUE && !isRadioBeEnabled(pcfg->radio_index)) {
-            wifi_util_error_print(WIFI_DMCLI,
-                "%s:%d Cannot set MLDUnit on VAP %d: radio %d has no BE mode\n", __FUNCTION__,
-                __LINE__, pcfg->vap_index, pcfg->radio_index);
-            return FALSE;
-        }
 
         if (vapInfo->u.bss_info.mld_info.common_info.mld_enable == tmp_mld_enable) {
             if (!tmp_mld_enable && vapInfo->u.bss_info.mld_info.common_info.mld_id == UNDEFINED_MLD_ID)
@@ -6899,11 +6891,7 @@ AccessPoint_GetParamBoolValue
     if( AnscEqualString(ParamName, "MLD_Enable", TRUE))
     {
         /* collect value */
-        if (!isRadioBeEnabled(pcfg->radio_index)) {
-            *pBool = FALSE;
-        } else {
-            *pBool = pcfg->u.bss_info.mld_info.common_info.mld_enable;
-        }
+        *pBool = pcfg->u.bss_info.mld_info.common_info.mld_enable;
         return TRUE;
     }
 
@@ -7264,11 +7252,14 @@ AccessPoint_GetParamUlongValue
 
     if( AnscEqualString(ParamName, "MLD_ID", TRUE))
     {
-        if (!isRadioBeEnabled(pcfg->radio_index)) {
-            *puLong = UNDEFINED_MLD_ID;
+        wifi_mld_common_info_t *mld_common_info = NULL;
+
+        if (isVapSTAMesh(pcfg->vap_index)) {
+            mld_common_info = &pcfg->u.sta_info.mld_info.common_info;
         } else {
-            *puLong = pcfg->u.bss_info.mld_info.common_info.mld_id;
+            mld_common_info = &pcfg->u.bss_info.mld_info.common_info;
         }
+        *puLong = mld_common_info->mld_id;
         return TRUE;
     }
 
@@ -7440,10 +7431,8 @@ AccessPoint_GetParamStringValue
 
         if (isVapSTAMesh(pcfg->vap_index)) {
             mac = zero_mac;
-        } else if (isRadioBeEnabled(pcfg->radio_index)) {
-            mac = pcfg->u.bss_info.mld_info.common_info.mld_addr;
         } else {
-            mac = pcfg->u.bss_info.bssid;
+            mac = pcfg->u.bss_info.mld_info.common_info.mld_addr;
         }
 
         snprintf(pValue, *pUlSize, "%02X:%02X:%02X:%02X:%02X:%02X",

--- a/source/platform/common/data_model/wifi_dml_cb.c
+++ b/source/platform/common/data_model/wifi_dml_cb.c
@@ -2218,11 +2218,6 @@ bool ssid_get_param_int_value(void *obj_ins_context, char *param_name, int *outp
     if (STR_CMP(param_name, "MLDUnit")) {
         wifi_mld_common_info_t *mld_common_info = NULL;
 
-        if (!isRadioBeEnabled(pcfg->radio_index)) {
-            *output_value = -1;
-            return true;
-        }
-
         if (isVapSTAMesh(pcfg->vap_index)) {
             mld_common_info = &pcfg->u.sta_info.mld_info.common_info;
         } else {
@@ -2510,13 +2505,6 @@ bool ssid_set_param_int_value(void *obj_ins_context, char *param_name, int input
         wifi_util_info_print(WIFI_DMCLI, "%s:%d MLD Unit %d\n", __FUNCTION__, __LINE__,
             input_value);
         tmp_mld_enable = (input_value == -1) ? false : true;
-
-        if (tmp_mld_enable == true && !isRadioBeEnabled(pcfg->radio_index)) {
-            wifi_util_error_print(WIFI_DMCLI,
-                "%s:%d Cannot set MLDUnit on VAP %d: radio %d has no BE mode\n", __FUNCTION__,
-                __LINE__, pcfg->vap_index, pcfg->radio_index);
-            return false;
-        }
 
         if (vapInfo->u.bss_info.mld_info.common_info.mld_enable == tmp_mld_enable) {
             if (tmp_mld_enable == false &&


### PR DESCRIPTION
Reason for change: MLDUnit value in Data Model doesn't change to "-1" on disabling the VAP.
                   Cleanup the code to remove the check for BE mode in MLD related Data Model APIs.
Test Procedure: Disable one of the AAPs - 2.4 GHz private VAP.
                Check MLO configuration in driver and Data Mode.
                Enable VAP back. Disable BE mode on 2.4 GHz radio.
                Check MLO configuration in driver and Data Mode.
Risks: Low
Priority: P1