### PR TITLE
RDKB-65570: HAL Unable to Add 5th Sensing Link

### DIFF
--- a/source/apps/motion/wifi_motion.c
+++ b/source/apps/motion/wifi_motion.c
@@ -829,7 +829,7 @@ bus_error_t csi_set_handler(char *event_name, raw_data_t *p_data, bus_user_data_
                     str_to_mac_bytes(str, l_client_list[itr]);
                     str = strtok_r(NULL, ",", &cptr);
                     itr++;
-                    if (itr >= MAX_NUM_CSI_CLIENTS) {
+                    if (itr > MAX_NUM_CSI_CLIENTS) {
                         wifi_util_error_print(WIFI_APPS,"%s:%d client list is big %d\n", __func__, __LINE__, itr);
                         if (str_dup) {
                             free(str_dup);


### PR DESCRIPTION
Reason for change: HAL Unable to Add 5th Sensing Link
Test Procedure: Build should be successful and the regression test should also succeed.

Risks: Low
Priority: P1
Signed-off-by: Navya_Sheregar@comcast.com

Signed-off-by: Navya_Sheregar@comcast.com