### PR TITLE
RDKB-65508, RDKB-65530: Crash with cJSON_Delete as signature

### DIFF
--- a/source/platform/common/data_model/wifi_dml_json_parser.c
+++ b/source/platform/common/data_model/wifi_dml_json_parser.c
@@ -182,9 +182,6 @@ static cJSON* merge_with_references(cJSON* base, cJSON* ref_node)
             if (!copy) {
                 wifi_util_error_print(WIFI_DMCLI, "%s:%d: Failed to duplicate schema node for key '%s'\n",
                                     __func__, __LINE__, child->string ? child->string : "(null)");
-            } else if (!child->string) {
-                wifi_util_error_print(WIFI_DMCLI, "%s:%d: Cannot add schema node with NULL key\n", __func__, __LINE__);
-                cJSON_Delete(copy);
             } else {
                 cJSON_AddItemToObject(base, child->string, copy);
             }

--- a/source/platform/common/data_model/wifi_dml_json_parser.c
+++ b/source/platform/common/data_model/wifi_dml_json_parser.c
@@ -182,6 +182,9 @@ static cJSON* merge_with_references(cJSON* base, cJSON* ref_node)
             if (!copy) {
                 wifi_util_error_print(WIFI_DMCLI, "%s:%d: Failed to duplicate schema node for key '%s'\n",
                                     __func__, __LINE__, child->string ? child->string : "(null)");
+            } else if (!child->string) {
+                wifi_util_error_print(WIFI_DMCLI, "%s:%d: Cannot add schema node with NULL key\n", __func__, __LINE__);
+                cJSON_Delete(copy);
             } else {
                 cJSON_AddItemToObject(base, child->string, copy);
             }

--- a/source/platform/common/data_model/wifi_dml_json_parser.c
+++ b/source/platform/common/data_model/wifi_dml_json_parser.c
@@ -178,7 +178,7 @@ static cJSON* merge_with_references(cJSON* base, cJSON* ref_node)
         if (!existing) {
             /* Deep copy instead of reference to avoid dangling child pointer
                when follow_ref_if_any deletes $ref through the wrapper */
-            cJSON* copy = cJSON_Duplicate(child, 1);
+            cJSON* copy = cJSON_Duplicate(child, true);
             if (!copy) {
                 wifi_util_error_print(WIFI_DMCLI, "%s:%d: Failed to duplicate schema node for key '%s'\n",
                                     __func__, __LINE__, child->string ? child->string : "(null)");

--- a/source/platform/common/data_model/wifi_dml_json_parser.c
+++ b/source/platform/common/data_model/wifi_dml_json_parser.c
@@ -176,8 +176,15 @@ static cJSON* merge_with_references(cJSON* base, cJSON* ref_node)
         cJSON* existing = cJSON_GetObjectItem(base, child->string);
 
         if (!existing) {
-            /* Key doesn't exist - add reference */
-            cJSON_AddItemReferenceToObject(base, child->string, child);
+            /* Deep copy instead of reference to avoid dangling child pointer
+               when follow_ref_if_any deletes $ref through the wrapper */
+            cJSON* copy = cJSON_Duplicate(child, 1);
+            if (!copy) {
+                wifi_util_error_print(WIFI_DMCLI, "%s:%d: Failed to duplicate schema node for key '%s'\n",
+                                    __func__, __LINE__, child->string ? child->string : "(null)");
+            } else {
+                cJSON_AddItemToObject(base, child->string, copy);
+            }
         } else if (strcmp(child->string, "properties") == 0 &&
                    cJSON_IsObject(existing) && cJSON_IsObject(child)) {
             /* Both have "properties" object - recursively merge them */


### PR DESCRIPTION
Reason for change: Crash occurs because of accessing dangling pointer.
Test Procedure: Build should be successful, Crash shouldn't occur.
Risks: Low
Priority: P1