### PR TITLE
RDKB-63475 [SKY-VL-QE][Sprint]:WIFI blaster is not working as expected

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -103,7 +103,7 @@ extern "C" {
 
 #define PLAN_ID_LENGTH     38
 #define MAX_STEP_COUNT  32 /*Active Measurement Step Count */
-#define  MAC_ADDRESS_LENGTH  13
+#define  MAC_ADDRESS_LENGTH  18
 #define WIFI_AP_MAX_WPSPIN_LEN  9
 #define MAX_BUF_LENGTH 128
 
@@ -963,7 +963,6 @@ typedef struct {
 //  schema_wifi_radio_state_t   radio_state;
 } rdk_wifi_radio_t;
 
-#define  MAC_ADDRESS_LENGTH  13
 typedef struct {
     bool                   b_inst_client_enabled;
     unsigned long          u_inst_client_reporting_period;


### PR DESCRIPTION
Reason for change: Changing the length of MAC address length as 18 to avoid this issue

Test Procedure:

Risks: Low

Priority:P1