### PR TITLE
RDKB-63427: "WIFI_RXDELTA_17" is not available in wifihealth.txt (#942)

### DIFF
--- a/scripts/aphealth.sh
+++ b/scripts/aphealth.sh
@@ -36,6 +36,10 @@ if [ "$MODEL_NUM" == "$TG4" ]; then
 elif [ "$MODEL_NUM" == "VTER11QEL" ]; then
     ssid1="ath0"
     ssid2="ath1"
+elif [ "$MODEL_NUM" == "CGM4981COM" ] || [ "$MODEL_NUM" == "CGM601TCOM" ] || [ "$MODEL_NUM" == "SG417DBCT" ]; then
+    ssid1="wl0.1"
+    ssid2="wl1.1"
+    ssid3="wl2.1"
 else
     ssid1="wl0.1"
     ssid2="wl1.1"
@@ -100,6 +104,29 @@ echo_t "WIFI_RXDELTA_1:$rx1d_mb"
 echo_t "WIFI_RX_2:$rx2_mb"
 echo_t "WIFI_RXDELTA_2:$rx2d_mb"
 
+if [ -n "$ssid3" ]; then
+    rx17_0=`cat "$logfolder/rx17_0"`
+
+    if [ "$rx17_0" == "" ] ; then
+        rx17_0=0;
+    fi
+
+    rx17=`ifconfig "$ssid3" | grep "RX bytes" | cut -d':' -f2 | cut -d' ' -f1`
+
+    if [ "$rx17" == "" ] ; then
+        rx17=0;
+    fi
+
+    echo "$rx17" > $logfolder/rx17_0;
+
+    rx17d=$(($rx17-$rx17_0))
+
+    rx17_mb=$(($rx17/$oneMB))
+    rx17d_mb=$(($rx17d/$oneMB))
+
+    echo_t "WIFI_RX_17:$rx17_mb"
+    echo_t "WIFI_RXDELTA_17:$rx17d_mb"
+fi
 
 if [ -e "/sbin/iwconfig" ] ; then
 	l1=`iwconfig $ssid1 | grep "Link Quality"`


### PR DESCRIPTION
Reason for change:
Add support for logging RXDELTA for the 6GHz private VAP in aphealth.sh, previously RX statistics were logged only for 2.4 & 5GHz private VAP interfaces, hence RXDELTA marker for 6GHz was not reflected in wifihealth.txt

Test Procedure:
-- Load the device with build having the fix.

-- /rdklogs/logs/wifihealth.txt will not be created as soon as the device boots up
   aphealth.sh will be launched by aphealth_log.sh (cron job on 35th minute of every hour)

-- Either wait until the 35th minute of the hour and ensure system uptime is > 1800 (OR)
   manually launch the aphealth.sh like the aphealth_log.sh does by executing
   /usr/ccsp/wifi/aphealth.sh >> /rdklogs/logs/wifihealth.txt

-- Check whether /tmp/wifihealth/ directory is created and also check the directory contains rx17_0 file

-- Check whether /rdklogs/logs/wifihealth.txt is created and check for the WIFI_RXDELTA_17 marker

UT Logs: 
[RDKB-63427_UT_Stable2.txt](https://github.com/user-attachments/files/29592016/RDKB-63427_UT_Stable2.txt)


Risks: Low
Priority: P1