### PR TITLE
RDKBWIFI-494: Prevent TransitionDisable configuration in unsupported …

### DIFF
--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -8916,7 +8916,13 @@ Security_SetParamBoolValue
     /* check the parameter name and set the corresponding value */
     if (AnscEqualString(ParamName, "X_RDKCENTRAL-COM_TransitionDisable", TRUE))
     {
-        if (l_security_cfg->wpa3_transition_disable != bValue) {
+            if (l_security_cfg->mode != wifi_security_mode_wpa3_transition) {
+                char secModeStr[64] = {0};
+                convert_sec_mode_enable_int_str(l_security_cfg->mode, secModeStr);
+                wifi_util_error_print(WIFI_DMCLI, "%s:%d TransitionDisable cannot be set when mode is %s\n", __func__, __LINE__, secModeStr);
+                return FALSE;
+            }
+	    if (l_security_cfg->wpa3_transition_disable != bValue) {
             l_security_cfg->wpa3_transition_disable = bValue;
             wifi_util_dbg_print(WIFI_DMCLI,"%s:%d:wpa3_transition_disable=%d Value=%d\n",
                 __func__, __LINE__, l_security_cfg->wpa3_transition_disable, bValue);

--- a/source/utils/wifi_util.h
+++ b/source/utils/wifi_util.h
@@ -313,6 +313,7 @@ int convert_radio_name_to_radio_index(char *name);
 int convert_radio_index_to_radio_name(int index, char *name);
 int convert_security_mode_integer_to_string(int m, char *mode);
 int convert_security_mode_string_to_integer(int *m, char *mode);
+int convert_sec_mode_enable_int_str(int sec_mode_enable, char *secModeStr);
 int convert_freq_band_to_radio_index(int band, int *radio_index);
 BOOL is_radio_band_5G(int band);
 int convert_ifname_to_radio_index(wifi_platform_property_t *wifi_prop, char *if_name,


### PR DESCRIPTION
RDKBWIFI-494 Transition Disable parameter accepts SET operations in security modes other than WPA3-Personal-Transition

- Added security mode validation before updating TransitionDisable parameter
- Restricted TransitionDisable SET operation to WPA3-Personal-Transition mode only
- Added error logging for invalid SET requests in unsupported security modes
- Prevented configuration updates when the current security mode does not support TransitionDisable
 
This ensures TransitionDisable parameter is accepted only for WPA3-Personal-Transition security mode, aligning behavior with expected functionality and preventing invalid configuration changes.
Signed-off-by: 
Shaik, Shaheeda <shaheeda.shaik@capgemini.com>
Sangram Babar, Snehal <snehal.sangram-babar@capgemini.com>
