### PR TITLE
LTE-2853 DFS NOP fix for multi-radio platforms

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -545,7 +545,8 @@ int start_radios(rdk_dev_mode_type_t mode, unsigned int radio_index)
                 }
             }
 
-            if (strcmp(wifi_radio_oper_param->radarDetected, " ")) {
+            if (strcmp(wifi_radio_oper_param->radarDetected, " ") != 0 &&
+                strlen(wifi_radio_oper_param->radarDetected) != 0) {
                 dfs_nop_radio_index[index] = index;
                 wifi_util_info_print(WIFI_CTRL,
                     "%s:%d Triggering dfs_nop_start_timer for radio:%d radar:%s \n", __func__,

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -544,11 +544,18 @@ int start_radios(rdk_dev_mode_type_t mode, unsigned int radio_index)
             }
 
             if (strcmp(wifi_radio_oper_param->radarDetected, " ")) {
-                wifi_util_info_print(WIFI_CTRL,
-                    "%s:%d Triggering dfs_nop_start_timer for radar:%s \n", __func__, __LINE__,
-                    wifi_radio_oper_param->radarDetected);
-                scheduler_add_timer_task(ctrl->sched, FALSE, NULL, dfs_nop_start_timer, NULL,
-                    (60 * 1000), 1, FALSE);
+                unsigned int *dfs_radio_index = (unsigned int *)malloc(sizeof(unsigned int));
+                if (dfs_radio_index == NULL) {
+                    wifi_util_error_print(WIFI_CTRL, "%s:%d malloc failed for dfs_radio_index\n",
+                        __func__, __LINE__);
+                } else {
+                    *dfs_radio_index = index;
+                    wifi_util_info_print(WIFI_CTRL,
+                        "%s:%d Triggering dfs_nop_start_timer for radio:%d radar:%s \n", __func__,
+                        __LINE__, index, wifi_radio_oper_param->radarDetected);
+                    scheduler_add_timer_task(ctrl->sched, FALSE, NULL, dfs_nop_start_timer,
+                        dfs_radio_index, (60 * 1000), 1, FALSE);
+                }
             }
         }
 

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -462,6 +462,8 @@ int start_radios(rdk_dev_mode_type_t mode, unsigned int radio_index)
     uint8_t num_of_radios = getNumberRadios();
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     wifi_platform_property_t *wifi_prop = (wifi_platform_property_t *)get_wifi_hal_cap_prop();
+    /* Stable per-radio storage for the dfs_nop_start_timer arg (non-owning, must outlive the task) */
+    static unsigned int dfs_nop_radio_index[MAX_NUM_RADIOS];
 
     wifi_util_info_print(WIFI_CTRL, "%s(): Start radios %d\n", __FUNCTION__, num_of_radios);
     // Check for the number of radios
@@ -544,18 +546,12 @@ int start_radios(rdk_dev_mode_type_t mode, unsigned int radio_index)
             }
 
             if (strcmp(wifi_radio_oper_param->radarDetected, " ")) {
-                unsigned int *dfs_radio_index = (unsigned int *)malloc(sizeof(unsigned int));
-                if (dfs_radio_index == NULL) {
-                    wifi_util_error_print(WIFI_CTRL, "%s:%d malloc failed for dfs_radio_index\n",
-                        __func__, __LINE__);
-                } else {
-                    *dfs_radio_index = index;
-                    wifi_util_info_print(WIFI_CTRL,
-                        "%s:%d Triggering dfs_nop_start_timer for radio:%d radar:%s \n", __func__,
-                        __LINE__, index, wifi_radio_oper_param->radarDetected);
-                    scheduler_add_timer_task(ctrl->sched, FALSE, NULL, dfs_nop_start_timer,
-                        dfs_radio_index, (60 * 1000), 1, FALSE);
-                }
+                dfs_nop_radio_index[index] = index;
+                wifi_util_info_print(WIFI_CTRL,
+                    "%s:%d Triggering dfs_nop_start_timer for radio:%d radar:%s \n", __func__,
+                    __LINE__, index, wifi_radio_oper_param->radarDetected);
+                scheduler_add_timer_task(ctrl->sched, FALSE, NULL, dfs_nop_start_timer,
+                    &dfs_nop_radio_index[index], (60 * 1000), 1, FALSE);
             }
         }
 

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3454,9 +3454,13 @@ int dfs_nop_finish_timer(void *args)
     if (dfs_radio_index >= n) {
         wifi_util_error_print(WIFI_CTRL, "%s: ch=%d not found in any 5G radio radarDetected\n", __FUNCTION__, nop_fin_dfs_ch);
         return TIMER_TASK_COMPLETE;
-}
+    }
 
     radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
+    if (radio_params == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: wrong index for radio map: %d\n", __FUNCTION__, __LINE__, dfs_radio_index);
+        return TIMER_TASK_COMPLETE;
+    }
     memset(&radio_channel_param, 0, sizeof(radio_channel_param));
     strncpy(radarDetected_temp, radio_params->radarDetected, sizeof(radarDetected_temp));
 

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -51,7 +51,6 @@
 
 static unsigned msg_id = 1000;
 
-#define RADIO_INDEX_DFS 1
 unsigned int temp_ch_list_5g[] = {36,40,44,48,52,56,60,64,100,104,108,112,116,120,124,128,132,136,140,144,149,153,157,161,165};
 
 typedef enum {
@@ -3298,14 +3297,17 @@ static int reset_radio_operating_parameters(void *args)
     return RETURN_OK;
 }
 
-int update_db_radar_detected(char *radar_detected_ch_time)
+int update_db_radar_detected(int radio_index, char *radar_detected_ch_time)
 {
     wifi_radio_operationParam_t *radio_params = NULL;
     wifi_mgr_t *g_wifidb;
     g_wifidb = get_wifimgr_obj();
 
-    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(RADIO_INDEX_DFS);
-
+    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(radio_index);
+    if (radio_params == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s: invalid radio_index %d\n", __FUNCTION__, radio_index);
+        return RETURN_ERR;
+    }
     char *pos_ch_radar_time = strstr(radio_params->radarDetected, radar_detected_ch_time);
     size_t len_ch_radar_time = strlen(radar_detected_ch_time);
     if( strlen(radio_params->radarDetected) == len_ch_radar_time ){
@@ -3333,7 +3335,17 @@ int dfs_nop_start_timer(void *args)
     wifi_channel_change_event_t radio_channel_param;
     wifi_radio_operationParam_t *radio_params = NULL;
 
-    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(RADIO_INDEX_DFS);
+    /* Process all 5G radios that have pending radarDetected entries */
+    unsigned int n = getNumberRadios();
+    for (unsigned int dfs_radio_index = 0; dfs_radio_index < n; dfs_radio_index++) {
+        wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
+        if (c == NULL) continue;
+        if (c->band != WIFI_FREQUENCY_5_BAND &&
+            c->band != WIFI_FREQUENCY_5L_BAND &&
+            c->band != WIFI_FREQUENCY_5H_BAND) continue;
+        if (strcmp(c->radarDetected, " ") == 0 || strlen(c->radarDetected) == 0) continue;
+
+    radio_params = c;
     memset(&radio_channel_param, 0, sizeof(radio_channel_param));
 
     char *str_r, *radar_detected_ch_time;
@@ -3354,9 +3366,9 @@ int dfs_nop_start_timer(void *args)
         unsigned int dfs_radar_channel, dfs_timer_secs = 0;
         wifi_channelBandwidth_t dfs_radar_ch_bw = 0;
         time_t time_now = time(NULL);
-        wifi_radio_feature_param_t *radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(RADIO_INDEX_DFS);
+        wifi_radio_feature_param_t *radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(dfs_radio_index);
         if (radio_feat == NULL) {
-            wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, RADIO_INDEX_DFS);
+            wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, dfs_radio_index);
             return RETURN_ERR;
         }
 
@@ -3364,8 +3376,8 @@ int dfs_nop_start_timer(void *args)
         while(radar_detected_ch_time[i] != ',') {
             if(radar_detected_ch_time[i] == '\0') {
                 wifi_util_error_print(WIFI_CTRL,"%s:%d Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, __LINE__, radio_params->radarDetected);
-                update_db_radar_detected(radar_detected_ch_time);
-                update_wifi_radio_config(RADIO_INDEX_DFS, radio_params, radio_feat);
+                update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+                update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
                 return RETURN_ERR;
             }
             i++;
@@ -3374,15 +3386,15 @@ int dfs_nop_start_timer(void *args)
         while(radar_detected_ch_time[i] != ',') {
             if(radar_detected_ch_time[i] == '\0') {
                 wifi_util_error_print(WIFI_CTRL,"%s: Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, radio_params->radarDetected);
-                update_db_radar_detected(radar_detected_ch_time);
-                update_wifi_radio_config(RADIO_INDEX_DFS, radio_params, radio_feat);
+                update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+                update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
                 return RETURN_ERR;
             }
             i++;
         }
         radar_detected_time = atol(&radar_detected_ch_time[++i]);
 
-        radio_channel_param.radioIndex = RADIO_INDEX_DFS;
+        radio_channel_param.radioIndex = dfs_radio_index;
         radio_channel_param.event = WIFI_EVENT_DFS_RADAR_DETECTED;
         radio_channel_param.sub_event = WIFI_EVENT_RADAR_DETECTED;
         radio_channel_param.channel = dfs_radar_channel;
@@ -3391,8 +3403,8 @@ int dfs_nop_start_timer(void *args)
 
         dfs_timer_secs = ((time_now - radar_detected_time) < ((long long)radio_params->DFSTimer * 60) && (time_now > radar_detected_time)) ? (((long long)radio_params->DFSTimer * 60) - (time_now - radar_detected_time)) : 0;
         if(dfs_timer_secs == 0) {
-            update_db_radar_detected(radar_detected_ch_time);
-            update_wifi_radio_config(RADIO_INDEX_DFS, radio_params, radio_feat);
+            update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+            update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
             wifi_util_dbg_print(WIFI_CTRL, "%s Radar event time-out for dfs_radar_channel:%d \n", __FUNCTION__, dfs_radar_channel);
         } else {
             bool is_nop_start_reboot = 1;
@@ -3403,10 +3415,10 @@ int dfs_nop_start_timer(void *args)
         radar_detected_ch_time = strtok_r(NULL, ";", &str_r);
     }
 
-    if(strlen(radio_params->radarDetected) == 0) {
+    if(radio_params != NULL && strlen(radio_params->radarDetected) == 0) {
         strncpy(radio_params->radarDetected, " ", sizeof(radio_params->radarDetected));
     }
-
+    } /* end for each 5G radio */
     return TIMER_TASK_COMPLETE;
 }
 
@@ -3415,7 +3427,7 @@ int dfs_nop_finish_timer(void *args)
     wifi_channel_change_event_t radio_channel_param;
     wifi_radio_operationParam_t *radio_params = NULL;
     char *str_re, *radar_detected_ch_time;
-    char radarDetected_temp[128];
+    char radarDetected_temp[256];
     unsigned int ch_temp;
 
     if (args == NULL) {
@@ -3424,7 +3436,33 @@ int dfs_nop_finish_timer(void *args)
     }
 
     unsigned int nop_fin_dfs_ch = *(unsigned int *) args;
-    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(RADIO_INDEX_DFS);
+
+    /* Find which 5G radio has this channel in its radarDetected */
+    unsigned int n = getNumberRadios();
+    unsigned int dfs_radio_index;
+    for (dfs_radio_index = 0; dfs_radio_index < n; dfs_radio_index++) {
+        wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
+        if (c == NULL) continue;
+        if (c->band != WIFI_FREQUENCY_5_BAND &&
+            c->band != WIFI_FREQUENCY_5L_BAND &&
+            c->band != WIFI_FREQUENCY_5H_BAND) continue;
+        char scan_tmp[256];
+        char *scan_tok, *scan_saveptr;
+        strncpy(scan_tmp, c->radarDetected, sizeof(scan_tmp));
+        scan_tmp[sizeof(scan_tmp) - 1] = '\0';
+        scan_tok = strtok_r(scan_tmp, ";", &scan_saveptr);
+        while (scan_tok != NULL) {
+            if ((unsigned int)atoi(scan_tok) == nop_fin_dfs_ch) break;
+            scan_tok = strtok_r(NULL, ";", &scan_saveptr);
+        }
+        if (scan_tok != NULL) break;
+    }
+    if (dfs_radio_index >= n) {
+        wifi_util_error_print(WIFI_CTRL, "%s: ch=%d not found in any 5G radio radarDetected\n", __FUNCTION__, nop_fin_dfs_ch);
+        return TIMER_TASK_COMPLETE;
+}
+
+    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
     memset(&radio_channel_param, 0, sizeof(radio_channel_param));
     strncpy(radarDetected_temp, radio_params->radarDetected, sizeof(radarDetected_temp));
 
@@ -3441,7 +3479,7 @@ int dfs_nop_finish_timer(void *args)
             while(radar_detected_ch_time[i] != ',' && radar_detected_ch_time[i] != '\0') i++;
             dfs_radar_ch_bw = (radar_detected_ch_time[i] != '\0') ? (wifi_channelBandwidth_t) atoi(&radar_detected_ch_time[++i]) : radio_params->channelWidth;
 
-            radio_channel_param.radioIndex = RADIO_INDEX_DFS;
+            radio_channel_param.radioIndex = dfs_radio_index;
             radio_channel_param.event = WIFI_EVENT_DFS_RADAR_DETECTED;
             radio_channel_param.sub_event = WIFI_EVENT_RADAR_NOP_FINISHED;
             radio_channel_param.channel = nop_fin_dfs_ch;
@@ -3649,7 +3687,7 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
                     while(radar_detected_ch_time != NULL) {
                         ch_temp = atoi(radar_detected_ch_time);
                         if(ch_temp == ch_chg->channel) {
-                            if(update_db_radar_detected(radar_detected_ch_time) != RETURN_OK) {
+                            if(update_db_radar_detected(ch_chg->radioIndex, radar_detected_ch_time) != RETURN_OK) {
                                 wifi_util_error_print(WIFI_CTRL, "%s update_db_radar_detected returned error for channel:%d \n", __FUNCTION__, ch_chg->channel);
                             }
                             break;

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3340,9 +3340,9 @@ int dfs_nop_start_timer(void *args)
         return RETURN_ERR;
     }
 
-    /* Process only the 5G radio this timer was scheduled for (index passed via args) */
+    /* Process only the 5G radio this timer was scheduled for. args points to stable
+       static storage owned by the caller (start_radios); it is non-owning, do not free it. */
     unsigned int dfs_radio_index = *(unsigned int *)args;
-    free(args);
 
     radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
     if (radio_params == NULL) {

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3335,84 +3335,90 @@ int dfs_nop_start_timer(void *args)
     wifi_channel_change_event_t radio_channel_param;
     wifi_radio_operationParam_t *radio_params = NULL;
 
-    /* Process all 5G radios that have pending radarDetected entries */
-    unsigned int n = getNumberRadios();
-    for (unsigned int dfs_radio_index = 0; dfs_radio_index < n; dfs_radio_index++) {
-        wifi_radio_operationParam_t *c = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
-        if (c == NULL) continue;
-        if (c->band != WIFI_FREQUENCY_5_BAND &&
-            c->band != WIFI_FREQUENCY_5L_BAND &&
-            c->band != WIFI_FREQUENCY_5H_BAND) continue;
-        if (strcmp(c->radarDetected, " ") == 0 || strlen(c->radarDetected) == 0) continue;
+    if (args == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d NULL Pointer\r\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
 
-        radio_params = c;
-        memset(&radio_channel_param, 0, sizeof(radio_channel_param));
+    /* Process only the 5G radio this timer was scheduled for (index passed via args) */
+    unsigned int dfs_radio_index = *(unsigned int *)args;
+    free(args);
 
-        char *str_r, *radar_detected_ch_time;
-        char radarDetected_temp[256];
-        strncpy(radarDetected_temp, radio_params->radarDetected, sizeof(radarDetected_temp));
+    radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(dfs_radio_index);
+    if (radio_params == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d wrong index for radio map: %d\n", __func__, __LINE__, dfs_radio_index);
+        return RETURN_ERR;
+    }
 
-        radarDetected_temp[sizeof(radarDetected_temp) - 1] = '\0';
+    if (strcmp(radio_params->radarDetected, " ") == 0 || strlen(radio_params->radarDetected) == 0) {
+        return TIMER_TASK_COMPLETE;
+    }
 
-        radar_detected_ch_time = strtok_r(radarDetected_temp, ";", &str_r);
-        while(radar_detected_ch_time != NULL) {
-            int i = 0; long long int radar_detected_time = 0;
-            unsigned int dfs_radar_channel, dfs_timer_secs = 0;
-            wifi_channelBandwidth_t dfs_radar_ch_bw = 0;
-            time_t time_now = time(NULL);
-            wifi_radio_feature_param_t *radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(dfs_radio_index);
-            if (radio_feat == NULL) {
-                wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, dfs_radio_index);
-                return RETURN_ERR;
-            }
+    memset(&radio_channel_param, 0, sizeof(radio_channel_param));
 
-            dfs_radar_channel = atoi(radar_detected_ch_time);
-            while(radar_detected_ch_time[i] != ',') {
-                if(radar_detected_ch_time[i] == '\0') {
-                    wifi_util_error_print(WIFI_CTRL,"%s:%d Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, __LINE__, radio_params->radarDetected);
-                    update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
-                    update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
-                    return RETURN_ERR;
-                }
-                i++;
-            }
-            dfs_radar_ch_bw = (wifi_channelBandwidth_t) atoi(&radar_detected_ch_time[++i]);
-            while(radar_detected_ch_time[i] != ',') {
-                if(radar_detected_ch_time[i] == '\0') {
-                    wifi_util_error_print(WIFI_CTRL,"%s: Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, radio_params->radarDetected);
-                    update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
-                    update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
-                    return RETURN_ERR;
-                }
-                i++;
-            }
-            radar_detected_time = atol(&radar_detected_ch_time[++i]);
+    char *str_r, *radar_detected_ch_time;
+    char radarDetected_temp[256];
+    strncpy(radarDetected_temp, radio_params->radarDetected, sizeof(radarDetected_temp));
+    radarDetected_temp[sizeof(radarDetected_temp) - 1] = '\0';
 
-            radio_channel_param.radioIndex = dfs_radio_index;
-            radio_channel_param.event = WIFI_EVENT_DFS_RADAR_DETECTED;
-            radio_channel_param.sub_event = WIFI_EVENT_RADAR_DETECTED;
-            radio_channel_param.channel = dfs_radar_channel;
-            radio_channel_param.channelWidth = dfs_radar_ch_bw;
-            radio_channel_param.op_class = radio_params->operatingClass;
+    radar_detected_ch_time = strtok_r(radarDetected_temp, ";", &str_r);
+    while(radar_detected_ch_time != NULL) {
+        int i = 0; long long int radar_detected_time = 0;
+        unsigned int dfs_radar_channel, dfs_timer_secs = 0;
+        wifi_channelBandwidth_t dfs_radar_ch_bw = 0;
+        time_t time_now = time(NULL);
+        wifi_radio_feature_param_t *radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(dfs_radio_index);
+        if (radio_feat == NULL) {
+            wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, dfs_radio_index);
+            return RETURN_ERR;
+        }
 
-            dfs_timer_secs = ((time_now - radar_detected_time) < ((long long)radio_params->DFSTimer * 60) && (time_now > radar_detected_time)) ? (((long long)radio_params->DFSTimer * 60) - (time_now - radar_detected_time)) : 0;
-            if(dfs_timer_secs == 0) {
+        dfs_radar_channel = atoi(radar_detected_ch_time);
+        while(radar_detected_ch_time[i] != ',') {
+            if(radar_detected_ch_time[i] == '\0') {
+                wifi_util_error_print(WIFI_CTRL,"%s:%d Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, __LINE__, radio_params->radarDetected);
                 update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
                 update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
-                wifi_util_dbg_print(WIFI_CTRL, "%s Radar event time-out for dfs_radar_channel:%d \n", __FUNCTION__, dfs_radar_channel);
-            } else {
-                bool is_nop_start_reboot = 1;
-                wifi_util_dbg_print(WIFI_CTRL, "%s dfs_radar_channel:%d bw:%d radar_detected_time:%lld radar_detected_ch_time[%d]:%c dfs_timer_secs:%d \n", __FUNCTION__, dfs_radar_channel, dfs_radar_ch_bw, radar_detected_time, i, radar_detected_ch_time[i], dfs_timer_secs);
-                process_channel_change_event(&radio_channel_param, is_nop_start_reboot, dfs_timer_secs);
+                return RETURN_ERR;
             }
+            i++;
+        }
+        dfs_radar_ch_bw = (wifi_channelBandwidth_t) atoi(&radar_detected_ch_time[++i]);
+        while(radar_detected_ch_time[i] != ',') {
+            if(radar_detected_ch_time[i] == '\0') {
+                wifi_util_error_print(WIFI_CTRL,"%s: Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, radio_params->radarDetected);
+                update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+                update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
+                return RETURN_ERR;
+            }
+            i++;
+        }
+        radar_detected_time = atol(&radar_detected_ch_time[++i]);
 
-            radar_detected_ch_time = strtok_r(NULL, ";", &str_r);
+        radio_channel_param.radioIndex = dfs_radio_index;
+        radio_channel_param.event = WIFI_EVENT_DFS_RADAR_DETECTED;
+        radio_channel_param.sub_event = WIFI_EVENT_RADAR_DETECTED;
+        radio_channel_param.channel = dfs_radar_channel;
+        radio_channel_param.channelWidth = dfs_radar_ch_bw;
+        radio_channel_param.op_class = radio_params->operatingClass;
+
+        dfs_timer_secs = ((time_now - radar_detected_time) < ((long long)radio_params->DFSTimer * 60) && (time_now > radar_detected_time)) ? (((long long)radio_params->DFSTimer * 60) - (time_now - radar_detected_time)) : 0;
+        if(dfs_timer_secs == 0) {
+            update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+            update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
+            wifi_util_dbg_print(WIFI_CTRL, "%s Radar event time-out for dfs_radar_channel:%d \n", __FUNCTION__, dfs_radar_channel);
+        } else {
+            bool is_nop_start_reboot = 1;
+            wifi_util_dbg_print(WIFI_CTRL, "%s dfs_radar_channel:%d bw:%d radar_detected_time:%lld radar_detected_ch_time[%d]:%c dfs_timer_secs:%d \n", __FUNCTION__, dfs_radar_channel, dfs_radar_ch_bw, radar_detected_time, i, radar_detected_ch_time[i], dfs_timer_secs);
+            process_channel_change_event(&radio_channel_param, is_nop_start_reboot, dfs_timer_secs);
         }
 
-        if(strlen(radio_params->radarDetected) == 0) {
-            strncpy(radio_params->radarDetected, " ", sizeof(radio_params->radarDetected));
-        }
-    } /* end for each 5G radio */
+        radar_detected_ch_time = strtok_r(NULL, ";", &str_r);
+    }
+
+    if(strlen(radio_params->radarDetected) == 0) {
+        strncpy(radio_params->radarDetected, " ", sizeof(radio_params->radarDetected));
+    }
     return TIMER_TASK_COMPLETE;
 }
 

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3345,79 +3345,73 @@ int dfs_nop_start_timer(void *args)
             c->band != WIFI_FREQUENCY_5H_BAND) continue;
         if (strcmp(c->radarDetected, " ") == 0 || strlen(c->radarDetected) == 0) continue;
 
-    radio_params = c;
-    memset(&radio_channel_param, 0, sizeof(radio_channel_param));
+        radio_params = c;
+        memset(&radio_channel_param, 0, sizeof(radio_channel_param));
 
-    char *str_r, *radar_detected_ch_time;
-    char radarDetected_temp[128];
-    strncpy(radarDetected_temp, radio_params->radarDetected, sizeof(radarDetected_temp));
+        char *str_r, *radar_detected_ch_time;
+        char radarDetected_temp[256];
+        strncpy(radarDetected_temp, radio_params->radarDetected, sizeof(radarDetected_temp));
 
-    radarDetected_temp[sizeof(radarDetected_temp) - 1] = '\0';
+        radarDetected_temp[sizeof(radarDetected_temp) - 1] = '\0';
 
-    if (!strcmp(radarDetected_temp, " ") )
-    {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d No radar detected \n", __func__, __LINE__);
-        return RETURN_ERR;
-    }
-
-    radar_detected_ch_time = strtok_r(radarDetected_temp, ";", &str_r);
-    while(radar_detected_ch_time != NULL) {
-        int i = 0; long long int radar_detected_time = 0;
-        unsigned int dfs_radar_channel, dfs_timer_secs = 0;
-        wifi_channelBandwidth_t dfs_radar_ch_bw = 0;
-        time_t time_now = time(NULL);
-        wifi_radio_feature_param_t *radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(dfs_radio_index);
-        if (radio_feat == NULL) {
-            wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, dfs_radio_index);
-            return RETURN_ERR;
-        }
-
-        dfs_radar_channel = atoi(radar_detected_ch_time);
-        while(radar_detected_ch_time[i] != ',') {
-            if(radar_detected_ch_time[i] == '\0') {
-                wifi_util_error_print(WIFI_CTRL,"%s:%d Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, __LINE__, radio_params->radarDetected);
-                update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
-                update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
+        radar_detected_ch_time = strtok_r(radarDetected_temp, ";", &str_r);
+        while(radar_detected_ch_time != NULL) {
+            int i = 0; long long int radar_detected_time = 0;
+            unsigned int dfs_radar_channel, dfs_timer_secs = 0;
+            wifi_channelBandwidth_t dfs_radar_ch_bw = 0;
+            time_t time_now = time(NULL);
+            wifi_radio_feature_param_t *radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(dfs_radio_index);
+            if (radio_feat == NULL) {
+                wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, dfs_radio_index);
                 return RETURN_ERR;
             }
-            i++;
-        }
-        dfs_radar_ch_bw = (wifi_channelBandwidth_t) atoi(&radar_detected_ch_time[++i]);
-        while(radar_detected_ch_time[i] != ',') {
-            if(radar_detected_ch_time[i] == '\0') {
-                wifi_util_error_print(WIFI_CTRL,"%s: Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, radio_params->radarDetected);
+
+            dfs_radar_channel = atoi(radar_detected_ch_time);
+            while(radar_detected_ch_time[i] != ',') {
+                if(radar_detected_ch_time[i] == '\0') {
+                    wifi_util_error_print(WIFI_CTRL,"%s:%d Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, __LINE__, radio_params->radarDetected);
+                    update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+                    update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
+                    return RETURN_ERR;
+                }
+                i++;
+            }
+            dfs_radar_ch_bw = (wifi_channelBandwidth_t) atoi(&radar_detected_ch_time[++i]);
+            while(radar_detected_ch_time[i] != ',') {
+                if(radar_detected_ch_time[i] == '\0') {
+                    wifi_util_error_print(WIFI_CTRL,"%s: Invalid radarDetected:%s, Removing entry\n",__FUNCTION__, radio_params->radarDetected);
+                    update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
+                    update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
+                    return RETURN_ERR;
+                }
+                i++;
+            }
+            radar_detected_time = atol(&radar_detected_ch_time[++i]);
+
+            radio_channel_param.radioIndex = dfs_radio_index;
+            radio_channel_param.event = WIFI_EVENT_DFS_RADAR_DETECTED;
+            radio_channel_param.sub_event = WIFI_EVENT_RADAR_DETECTED;
+            radio_channel_param.channel = dfs_radar_channel;
+            radio_channel_param.channelWidth = dfs_radar_ch_bw;
+            radio_channel_param.op_class = radio_params->operatingClass;
+
+            dfs_timer_secs = ((time_now - radar_detected_time) < ((long long)radio_params->DFSTimer * 60) && (time_now > radar_detected_time)) ? (((long long)radio_params->DFSTimer * 60) - (time_now - radar_detected_time)) : 0;
+            if(dfs_timer_secs == 0) {
                 update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
                 update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
-                return RETURN_ERR;
+                wifi_util_dbg_print(WIFI_CTRL, "%s Radar event time-out for dfs_radar_channel:%d \n", __FUNCTION__, dfs_radar_channel);
+            } else {
+                bool is_nop_start_reboot = 1;
+                wifi_util_dbg_print(WIFI_CTRL, "%s dfs_radar_channel:%d bw:%d radar_detected_time:%lld radar_detected_ch_time[%d]:%c dfs_timer_secs:%d \n", __FUNCTION__, dfs_radar_channel, dfs_radar_ch_bw, radar_detected_time, i, radar_detected_ch_time[i], dfs_timer_secs);
+                process_channel_change_event(&radio_channel_param, is_nop_start_reboot, dfs_timer_secs);
             }
-            i++;
-        }
-        radar_detected_time = atol(&radar_detected_ch_time[++i]);
 
-        radio_channel_param.radioIndex = dfs_radio_index;
-        radio_channel_param.event = WIFI_EVENT_DFS_RADAR_DETECTED;
-        radio_channel_param.sub_event = WIFI_EVENT_RADAR_DETECTED;
-        radio_channel_param.channel = dfs_radar_channel;
-        radio_channel_param.channelWidth = dfs_radar_ch_bw;
-        radio_channel_param.op_class = radio_params->operatingClass;
-
-        dfs_timer_secs = ((time_now - radar_detected_time) < ((long long)radio_params->DFSTimer * 60) && (time_now > radar_detected_time)) ? (((long long)radio_params->DFSTimer * 60) - (time_now - radar_detected_time)) : 0;
-        if(dfs_timer_secs == 0) {
-            update_db_radar_detected(dfs_radio_index, radar_detected_ch_time);
-            update_wifi_radio_config(dfs_radio_index, radio_params, radio_feat);
-            wifi_util_dbg_print(WIFI_CTRL, "%s Radar event time-out for dfs_radar_channel:%d \n", __FUNCTION__, dfs_radar_channel);
-        } else {
-            bool is_nop_start_reboot = 1;
-            wifi_util_dbg_print(WIFI_CTRL, "%s dfs_radar_channel:%d bw:%d radar_detected_time:%lld radar_detected_ch_time[%d]:%c dfs_timer_secs:%d \n", __FUNCTION__, dfs_radar_channel, dfs_radar_ch_bw, radar_detected_time, i, radar_detected_ch_time[i], dfs_timer_secs);
-            process_channel_change_event(&radio_channel_param, is_nop_start_reboot, dfs_timer_secs);
+            radar_detected_ch_time = strtok_r(NULL, ";", &str_r);
         }
 
-        radar_detected_ch_time = strtok_r(NULL, ";", &str_r);
-    }
-
-    if(radio_params != NULL && strlen(radio_params->radarDetected) == 0) {
-        strncpy(radio_params->radarDetected, " ", sizeof(radio_params->radarDetected));
-    }
+        if(strlen(radio_params->radarDetected) == 0) {
+            strncpy(radio_params->radarDetected, " ", sizeof(radio_params->radarDetected));
+        }
     } /* end for each 5G radio */
     return TIMER_TASK_COMPLETE;
 }
@@ -3677,7 +3671,7 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
                 }
                 if (strcmp(radio_params->radarDetected, " ")) {
                     char *str_re, *radar_detected_ch_time;
-                    char radarDetected_temp[128];
+                    char radarDetected_temp[256];
                     unsigned int ch_temp;
 
                     strncpy(radarDetected_temp, radio_params->radarDetected, sizeof(radarDetected_temp));


### PR DESCRIPTION
Reason for change: ensure NOP state clears on the correct 5GHz radio by using the detected radio_index instead of hardcoding RADIO_INDEX_DFS.
Test Procedure: verify radar event handling and NOP_FINISHED in logs.
Risks: Medium
Priority: P2
Signed-off-by: poornakumar_mezhiselvam@comcast.com