### PR TITLE
RDKB-65960:[Greylist] [2/3] Post Reboot Multiple Radius Requests and Rejects noticed in splunk logs and erouter capture

### DIFF
--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -2002,6 +2002,11 @@ int webconfig_hal_mac_filter_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_d
                 continue;
             }
 
+            if ((subdoc_type != webconfig_subdoc_type_mac_filter) &&
+                isVapHotspot(data->radios[radio_index].vaps.rdk_vap_array[vap_index].vap_index)) {
+                continue;
+            }
+
             if(current_config->is_mac_filter_initialized == true)  {
                 if (current_config->acl_map != NULL) {
                     current_acl_entry = hash_map_get_first(current_config->acl_map);


### PR DESCRIPTION
RDKB-65960:[Greylist] [2/3] Post Reboot Multiple Radius Requests and Rejects noticed in splunk logs and erouter capture

Reason for change: OVSM asks OneWifi to encode and decode mesh backhauk subdoc. During this time we encode and decode macfilter entries too. The catch here is that during encoding we populate the webconfig_subdoc_data_t entries from VIF_State. VIF_State does not know any configuration about Hotspot. So what's happening is that, the encoded mesh backhaul subdoc has 0 tries under hotspot vaps causing the webconfig_hal_mac_filter_apply function to remove those entries but not add them back in the successive functions.

Test Procedure: Flash the build and then perform greylist testing. Once the mac filter entries are added to the hotpsot VAP's ACL list, perform a reboot and check if the list persists and no more Access Request packets must be sent to the RADIUS server within the next 24 hours.

Priority: P0

Risks: Low

Signed-off by: [Srijeyarankesh_JS@comcast.com](mailto:Srijeyarankesh_JS@comcast.com)