### PR TITLE
RDKBWIFI-517: Fix 2.4GHz 40MHz secondary channel in get_on_channel_sc…

### DIFF
--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -2537,17 +2537,17 @@ wifi_channelBandwidth_t string_to_channel_width_convert(const char *bandwidth_st
 int get_on_channel_scan_list(wifi_freq_bands_t band, wifi_channelBandwidth_t bandwidth, int primary_channel, int *channel_list, int *channels_num)
 {
     int channels_2g_40_mhz[11][2] = {
-        {1, 3},
-        {2, 4},
-        {3, 5},
-        {4, 6},
-        {5, 7},
-        {6, 8},
-        {7, 9},
-        {8, 6},
-        {9, 7},
-        {10, 8},
-        {11, 9}
+        {1, 5},
+        {2, 6},
+        {3, 7},
+        {4, 8},
+        {5, 9},
+        {6, 10},
+        {7, 11},
+        {8, 4},
+        {9, 5},
+        {10, 6},
+        {11, 7}
     };
     int channels_5g_40_mhz[12][2] = {
         {36, 40},


### PR DESCRIPTION
…an_list

The channels_2g_40_mhz[] table in get_on_channel_scan_list() used a +/-2 channel offset for the HT40 secondary channel (e.g. primary 1 -> {1,3}). In 2.4GHz the channel numbers are spaced 5 MHz apart, so the two non overlapping 20MHz halves of a 40MHz bond are 20 MHz = 4 channel numbers apart (secondary = primary +/-4). {1,3} are only 10 MHz apart and overlap, which is not a valid 40MHz pair. The 5GHz and 6GHz tables in the same function already use the correct +4 spacing.

With the wrong offset, get_on_channel_scan_list() returned an overlapping sub channel for every 2.4GHz 40MHz primary, so consumers that check the sub channels against an allowed list (e.g. channel scan, ACS) could not deploy a 2.4GHz 40MHz channel and fell back to 20MHz.

Correct the table to the standard 2.4GHz HT40 pairs (1+5, 6+10, 11+7, ...).