### PR TITLE
[LTE-2973] Blaster Failure (#1196)

### DIFF
--- a/source/apps/blaster/wifi_blaster.c
+++ b/source/apps/blaster/wifi_blaster.c
@@ -294,7 +294,7 @@ static void active_msmt_log_message( blaster_log_level_t level,char *fmt, ...)
     wifi_util_dbg_print(WIFI_BLASTER, msg);
 }
 
-static char *active_msmt_status_to_str(active_msmt_status_t status)
+char *active_msmt_status_to_str(active_msmt_status_t status)
 {
     switch (status)
     {

--- a/source/apps/blaster/wifi_blaster.h
+++ b/source/apps/blaster/wifi_blaster.h
@@ -151,7 +151,7 @@ void process_active_msmt_diagnostics (int ap_index);
 
 void stream_client_msmt_data(bool ActiveMsmtFlag);
 wifi_actvie_msmt_t *get_wifi_blaster();
-
+char *active_msmt_status_to_str(active_msmt_status_t status);
 #ifdef __cplusplus
 }
 #endif

--- a/source/apps/blaster/wifi_single_client_msmt.c
+++ b/source/apps/blaster/wifi_single_client_msmt.c
@@ -1936,9 +1936,11 @@ void stream_client_msmt_data(bool ActiveMsmtFlag)
             return;
         }
 
+	    wifi_util_info_print(WIFI_BLASTER,"%s:%d status of blaster: %s\n", __func__, __LINE__,  active_msmt_status_to_str(act_monitor->status));
+
         if (ctrl->network_mode == rdk_dev_mode_type_gw) {
             upload_single_client_active_msmt_data(sta);
-        } else if (act_monitor->status != ACTIVE_MSMT_STATUS_SUCCEED && ctrl->network_mode == rdk_dev_mode_type_ext) {
+        } else if (ctrl->network_mode == rdk_dev_mode_type_ext) {
             pod_upload_single_client_active_msmt_data(sta);
         }
     }


### PR DESCRIPTION
LTE-2973: Upload successful blast results for XLE clients

Reason for change:
Enable upload of successful WiFi Blast measurement results for XLE clients. Previously, the measurement data was not being sent to QM for successful blast executions on extender devices.

Test Procedure:
Triggered WiFi Blast on XLE clients.
Verified the logs sent successfully from onewifi to QM

Risks:
Low

Signed-off-by: Dharmalakshmi A [Dharmalakshmi_Annamalai@comcast.com]