### PR TITLE
RDKB-65811: Do not update rdk_vap_info in cache

### DIFF
--- a/source/core/services/vap_svc_public.c
+++ b/source/core/services/vap_svc_public.c
@@ -160,6 +160,9 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
     bool enabled;
     unsigned int i;
     wifi_vap_info_map_t *p_tgt_vap_map;
+#ifndef _PLATFORM_BANANAPI_R4_
+    wifi_vap_info_map_t *p_tgt_created_vap_map;
+#endif
     bool greylist_rfc = false;
     bool rfc_passpoint_enable = false;
     wifi_ctrl_t *ctrl;
@@ -176,6 +179,16 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
         wifi_util_error_print(WIFI_CTRL,"%s:%d Failed to allocate memory.\n", __func__,__LINE__);
         return -1;
     }
+#ifndef _PLATFORM_BANANAPI_R4_
+    p_tgt_created_vap_map = (wifi_vap_info_map_t *)malloc(sizeof(wifi_vap_info_map_t));
+    if (p_tgt_created_vap_map == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to allocate memory.\n", __func__, __LINE__);
+        free(p_tgt_vap_map);
+        return -1;
+    }
+    memset((unsigned char *)p_tgt_created_vap_map, 0, sizeof(wifi_vap_info_map_t));
+    p_tgt_created_vap_map->num_vaps = 0;
+#endif
     wifi_rfc_dml_parameters_t *rfc_info = (wifi_rfc_dml_parameters_t *)get_wifi_db_rfc_parameters();
     if (rfc_info) {
         greylist_rfc = rfc_info->radiusgreylist_rfc;
@@ -256,10 +269,16 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
                    p_tgt_vap_map->vap_array[0].u.bss_info.interworking.passpoint.enable = true;
                 }
         }
-        wifi_util_error_print(WIFI_CTRL,"%s: p_tgt_vap_map->passpoint.enable %d\n", __FUNCTION__,p_tgt_vap_map->vap_array[0].u.bss_info.interworking.passpoint.enable);
-        update_global_cache(p_tgt_vap_map, &rdk_vap_info[i]);
+        wifi_util_error_print(WIFI_CTRL, "%s: p_tgt_vap_map->passpoint.enable %d\n", __FUNCTION__,
+            p_tgt_vap_map->vap_array[0].u.bss_info.interworking.passpoint.enable);
         memcpy((unsigned char *)&map->vap_array[i], (unsigned char *)&p_tgt_vap_map->vap_array[0],
             sizeof(wifi_vap_info_t));
+#ifdef _PLATFORM_BANANAPI_R4_
+        update_global_cache(p_tgt_vap_map, &rdk_vap_info[i]);
+#else
+        memcpy((unsigned char *)&p_tgt_created_vap_map->vap_array[i],
+            (unsigned char *)&p_tgt_vap_map->vap_array[0], sizeof(wifi_vap_info_t));
+#endif
         get_wifidb_obj()->desc.update_wifi_vap_info_fn(map->vap_array[i].vap_name, &map->vap_array[i],
             &rdk_vap_info[i]);
         get_wifidb_obj()->desc.update_wifi_interworking_cfg_fn(map->vap_array[i].vap_name,
@@ -277,6 +296,9 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
             scheduler_add_timer_task(ctrl->sched, FALSE, NULL, update_managementFramePower, NULL, MFPC_TIMER * 1000, 1, FALSE);
         }
     }
+#ifndef _PLATFORM_BANANAPI_R4_
+    update_global_cache(p_tgt_created_vap_map, rdk_vap_info);
+#endif
 #if defined(_PLATFORM_BANANAPI_R4_)
     if (dml_cache_update_needed) {
         dml_cache_update_subdoc = (webconfig_subdoc_data_t *)malloc(
@@ -300,6 +322,9 @@ int vap_svc_public_update(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
     //Load all the Acl entries related to the created public vaps
     update_xfinity_acl_entries(p_tgt_vap_map->vap_array[0].vap_name);
     free(p_tgt_vap_map);
+#ifndef _PLATFORM_BANANAPI_R4_
+    free(p_tgt_created_vap_map);
+#endif
     return 0;
 }
 int update_xfinity_acl_entries(char* tgt_vap_name)

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -3823,9 +3823,11 @@ int update_global_cache(wifi_vap_info_map_t *tgt_vap_map, rdk_wifi_vap_info_t *r
     rdk_wifi_vap_info_t *rdk_vaps;
     wifi_vap_info_map_t *vap_map = NULL;
     uint8_t i = 0, vap_index = 0;
+    bool found = false;
 
     for (i = 0; i < tgt_vap_map->num_vaps; i++) {
         vap_index = tgt_vap_map->vap_array[i].vap_index;
+        found = false;
         vap_map = (wifi_vap_info_map_t *)get_wifidb_vap_map(tgt_vap_map->vap_array[i].radio_index);
         if (vap_map == NULL) {
             wifi_util_error_print(WIFI_CTRL, "%s:%d global vap_map null radio_index:%d\n", __func__,
@@ -3840,11 +3842,28 @@ int update_global_cache(wifi_vap_info_map_t *tgt_vap_map, rdk_wifi_vap_info_t *r
         }
         for (j = 0; j < vap_map->num_vaps; j++) {
             if (vap_map->vap_array[j].vap_index == vap_index) {
+                found = true;
                 memcpy((unsigned char *)&vap_map->vap_array[j],
                     (unsigned char *)&tgt_vap_map->vap_array[i], sizeof(wifi_vap_info_t));
+#ifdef _PLATFORM_BANANAPI_R4_
+                // Selective sync of rdk_vap_info fields only.
+                // DO NOT memcpy the entire structure because some apply paths use partial
+                // decoded structs and full-copy can skew the internal state for
+                // i.e. vap_names/index, hashmaps
+                rdk_vaps[j].exists = rdk_vap_info[i].exists;
+                rdk_vaps[j].force_apply = rdk_vap_info[i].force_apply;
+#else
                 memcpy(&rdk_vaps[j], &rdk_vap_info[i], sizeof(rdk_wifi_vap_info_t));
+#endif
                 break;
             }
+        }
+
+        if (found == false) {
+            wifi_util_error_print(WIFI_CTRL,
+                "%s:%d: Could not find target vap in manager cache for radio_index:%d "
+                "vap_index:%d\n",
+                __func__, __LINE__, tgt_vap_map->vap_array[i].radio_index, vap_index);
         }
     }
 


### PR DESCRIPTION
Reason for change: update_global_cache updates rdk_vap_info structures, however due to the mixed use this is invalid. Decoders only partially fill these structs when decoding and if copied, these partially filled structs will fill rdk_vap_info in cache with invalid data. Moreover, these structs seem to be updated internally in OneWifi and will not be modified by external libraries - thus only cache updates it might need is if during application relevant flags are changed due to internal logic.

Test Procedure: Ensure OneWifi does not send back invalid data in subdocs.
Risks:Medium
Priority:P1