### PR TITLE
XB10-2872: Add per radio-level MLD link ID

### DIFF
--- a/config/TR181-WiFi-USGv2.XML
+++ b/config/TR181-WiFi-USGv2.XML
@@ -1183,6 +1183,12 @@ INSTMSMT_PH2 -->
                             <writable>true</writable>
                         </parameter>
                         <parameter>
+                            <name>X_RDK_MLDLinkID</name>
+                            <type>unsignedInt[0:255]</type>
+                            <syntax>uint32</syntax>
+                            <writable>true</writable>
+                        </parameter>
+                        <parameter>
                             <name>OperatingChannelBandwidth</name>
                             <type>string: Auto(0),20MHz(1),40MHz(2),80MHz(3),160MHz(4),80_80MHz(5),320MHz(6)</type>
                             <syntax>uint32/mapped</syntax>
@@ -1970,12 +1976,6 @@ INSTMSMT_PH2 -->
                             <name>MLDUnit</name>
                             <type>int[-1:24]</type>
                             <syntax>int</syntax>
-                            <writable>true</writable>
-                        </parameter>
-                        <parameter>
-                            <name>X_RDK_MLDLinkID</name>
-                            <type>unsignedInt[0:255]</type>
-                            <syntax>uint32</syntax>
                             <writable>true</writable>
                         </parameter>
                         <parameter>

--- a/config/bus_dml_config.json
+++ b/config/bus_dml_config.json
@@ -1084,6 +1084,10 @@
 										"$ref": "#/definitions/uint32_t",
 										"writable": true
 									},
+									"X_RDK_MLDLinkID": {
+										"$ref": "#/definitions/linkid_t",
+										"writable": true
+									},
 									"AutoChannelSupported": {
 										"type": "boolean",
 										"writable": false
@@ -1327,10 +1331,6 @@
 									"X_COMCAST-COM_DefaultSSID": {
 										"type": "string",
 										"writable": false
-									},
-									"X_RDK_MLDLinkID": {
-										"$ref": "#/definitions/linkid_t",
-										"writable": true
 									}
 								}
 							}

--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -1,6 +1,6 @@
 {
   "name": "Wifi_Rdk_Database",
-  "version": "1.00.051",
+  "version": "1.00.052",
   "cksum": "2353365742 523",
   "tables": {
     "Wifi_Device_Config": {
@@ -1250,6 +1250,17 @@
           "type": {
             "key": {
               "type": "boolean"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "mld_link_id": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 0,
+              "maxInteger": 255
             },
             "min": 0,
             "max": 1

--- a/lib/inc/schema_gen.h
+++ b/lib/inc/schema_gen.h
@@ -1597,6 +1597,7 @@
         PJS_OVS_INT(dfs_timer) \
         PJS_OVS_STRING(radar_detected, 256 + 1) \
         PJS_OVS_STRING(amsdu_tid, 128 + 1) \
+        PJS_OVS_INT(mld_link_id) \
     )
 
 #define PJS_SCHEMA_Wifi_Global_Config \
@@ -3299,7 +3300,8 @@
     COLUMN(Tidle) \
     COLUMN(dfs_timer) \
     COLUMN(radar_detected) \
-    COLUMN(amsdu_tid)
+    COLUMN(amsdu_tid) \
+    COLUMN(mld_link_id) \
 
 #define SCHEMA__Wifi_Global_Config "Wifi_Global_Config"
 #define SCHEMA_COLUMN__Wifi_Global_Config(COLUMN) \
@@ -4591,6 +4593,7 @@
 #define SCHEMA__Wifi_Radio_Config__dfs_timer "dfs_timer"
 #define SCHEMA__Wifi_Radio_Config__radar_detected "radar_detected"
 #define SCHEMA__Wifi_Radio_Config__amsdu_tid "amsdu_tid"
+#define SCHEMA__Wifi_Radio_Config__mld_link_id "mld_link_id"
 
 #define SCHEMA__Wifi_Global_Config__gas_config "gas_config"
 #define SCHEMA__Wifi_Global_Config__notify_wifi_changes "notify_wifi_changes"

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -3276,10 +3276,8 @@ UINT getNumberVAPsPerRadio(UINT radioIndex)
 
 #if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
 /* A radio is MLO-capable only if it is enabled, not in EcoPowerDown, and running 802.11be. */
-static bool is_radio_mlo_capable(unsigned int radio_index)
+static bool is_radio_mlo_capable(wifi_radio_operationParam_t *radio_param)
 {
-    wifi_radio_operationParam_t *radio_param = getRadioOperationParam(radio_index);
-
     if (radio_param == NULL) {
         return false;
     }
@@ -3394,9 +3392,13 @@ unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
         /* --- STEP 1: Seed MLD Address and Collect Candidates for this unit --- */
         for (r_idx = 0; r_idx < getNumberRadios(); r_idx++) {
             wifi_vap_info_map_t *mgr_vap_map = get_wifidb_vap_map(r_idx);
+            wifi_radio_operationParam_t *radio_oper = NULL;
+
             if (mgr_vap_map == NULL) {
                 continue;
             }
+
+            radio_oper = getRadioOperationParam(r_idx);
 
             for (k = 0; k < mgr_vap_map->num_vaps; k++) {
                 wifi_vap_info_t *mgr_vap = &mgr_vap_map->vap_array[k];
@@ -3432,6 +3434,11 @@ unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
                  * Subsequent group iterations must not overwrite values
                  * already propagated by an earlier group. */
                 if (i == 0) {
+                    /* MLD Link ID is radio-scoped: when the radio carries a valid link id,
+                     * it is the source of truth and is propagated to all of its VAPs. */
+                    if (radio_oper != NULL) {
+                        mld_conf->mld_link_id = radio_oper->mldLinkId;
+                    }
                     memcpy(mld_conf->mld_addr, mgr_vap->u.bss_info.bssid, sizeof(mac_address_t));
                     if (mld_conf->mld_enable) {
                         radio_bitmap |= (1u << mgr_vap->radio_index);
@@ -3455,7 +3462,7 @@ unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
                 }
 
                 /* Radio must be enabled and in 802.11be mode for MLO VAP */
-                if (is_radio_mlo_capable(mgr_vap->radio_index) == false) {
+                if (is_radio_mlo_capable(radio_oper) == false) {
                     wifi_util_info_print(log_type,
                         "%s:%d: vap_index=%d excluded from MLO unit %d "
                         "(radio %u not enabled/EDPD/BE)\n",

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -47,7 +47,7 @@ struct ow_conf_vif_config_cb_arg
 
 void print_wifi_hal_radio_data(wifi_dbg_type_t log_file_type, char *prefix, unsigned int radio_index, wifi_radio_operationParam_t *radio_config)
 {
-    wifi_util_info_print(log_file_type, "%s:%d: [%s] Wifi_Radio[%d]_Config data: enable = %d\n band = %d\n autoChannelEnabled = %d\n channel = %d\n numSecondaryChannels = %d\n channelSecondary = %s\n channelWidth = %d\n variant = %d\n csa_beacon_count = %d\n countryCode = %d\n DCSEnabled = %d\n dtimPeriod = %d\n beaconInterval = %d\n operatingClass = %d\n basicDataTransmitRates = %d\n operationalDataTransmitRates = %d\n fragmentationThreshold = %d\n guardInterval = %d\n transmitPower = %d\n rtsThreshold = %d\n factoryResetSsid = %d\n radioStatsMeasuringRate = %d\n radioStatsMeasuringInterval = %d\n ctsProtection = %d\n obssCoex = %d\n stbcEnable = %d\n greenFieldEnable = %d\n userControl = %d\n adminControl = %d\n chanUtilThreshold = %d\n chanUtilSelfHealEnable = %d\n EcoPowerDown = %d DFSTimer:%d \r\n", __func__, __LINE__, prefix, radio_index, radio_config->enable, radio_config->band, radio_config->autoChannelEnabled, radio_config->channel, radio_config->numSecondaryChannels, (char *)radio_config->channelSecondary, radio_config->channelWidth, radio_config->variant, radio_config->csa_beacon_count, radio_config->countryCode, radio_config->DCSEnabled, radio_config->dtimPeriod, radio_config->beaconInterval, radio_config->operatingClass, radio_config->basicDataTransmitRates, radio_config->operationalDataTransmitRates, radio_config->fragmentationThreshold, radio_config->guardInterval, radio_config->transmitPower, radio_config->rtsThreshold, radio_config->factoryResetSsid, radio_config->radioStatsMeasuringRate, radio_config->radioStatsMeasuringInterval, radio_config->ctsProtection, radio_config->obssCoex, radio_config->stbcEnable, radio_config->greenFieldEnable, radio_config->userControl, radio_config->adminControl, radio_config->chanUtilThreshold, radio_config->chanUtilSelfHealEnable, radio_config->EcoPowerDown, radio_config->DFSTimer);
+    wifi_util_info_print(log_file_type, "%s:%d: [%s] Wifi_Radio[%d]_Config data: enable = %d\n band = %d\n autoChannelEnabled = %d\n channel = %d\n numSecondaryChannels = %d\n channelSecondary = %s\n channelWidth = %d\n variant = %d\n csa_beacon_count = %d\n countryCode = %d\n DCSEnabled = %d\n dtimPeriod = %d\n beaconInterval = %d\n operatingClass = %d\n basicDataTransmitRates = %d\n operationalDataTransmitRates = %d\n fragmentationThreshold = %d\n guardInterval = %d\n transmitPower = %d\n rtsThreshold = %d\n factoryResetSsid = %d\n radioStatsMeasuringRate = %d\n radioStatsMeasuringInterval = %d\n ctsProtection = %d\n obssCoex = %d\n stbcEnable = %d\n greenFieldEnable = %d\n userControl = %d\n adminControl = %d\n chanUtilThreshold = %d\n chanUtilSelfHealEnable = %d\n EcoPowerDown = %d DFSTimer:%d mldLinkId = %d\r\n", __func__, __LINE__, prefix, radio_index, radio_config->enable, radio_config->band, radio_config->autoChannelEnabled, radio_config->channel, radio_config->numSecondaryChannels, (char *)radio_config->channelSecondary, radio_config->channelWidth, radio_config->variant, radio_config->csa_beacon_count, radio_config->countryCode, radio_config->DCSEnabled, radio_config->dtimPeriod, radio_config->beaconInterval, radio_config->operatingClass, radio_config->basicDataTransmitRates, radio_config->operationalDataTransmitRates, radio_config->fragmentationThreshold, radio_config->guardInterval, radio_config->transmitPower, radio_config->rtsThreshold, radio_config->factoryResetSsid, radio_config->radioStatsMeasuringRate, radio_config->radioStatsMeasuringInterval, radio_config->ctsProtection, radio_config->obssCoex, radio_config->stbcEnable, radio_config->greenFieldEnable, radio_config->userControl, radio_config->adminControl, radio_config->chanUtilThreshold, radio_config->chanUtilSelfHealEnable, radio_config->EcoPowerDown, radio_config->DFSTimer, radio_config->mldLinkId);
 }
 
 void print_wifi_hal_bss_vap_data(wifi_dbg_type_t log_file_type, char *prefix,
@@ -2166,6 +2166,9 @@ static bool is_radio_param_config_changed(wifi_radio_operationParam_t *old , wif
     if (IS_CHANGED(old->variant,new->variant)) return true;
     if (IS_CHANGED(old->EcoPowerDown,new->EcoPowerDown)) return true;
     if (IS_CHANGED(old->DFSTimer, new->DFSTimer)) return true;
+#if defined(CONFIG_IEEE80211BE) && !defined(CONFIG_GENERIC_MLO)
+    if (IS_CHANGED(old->mldLinkId, new->mldLinkId)) return true;
+#endif /* CONFIG_IEEE80211BE && !CONFIG_GENERIC_MLO */
     for (int i = 0; i < MAX_AMSDU_TID; ++i)
     {
         if (IS_CHANGED(old->amsduTid[i], new->amsduTid[i])) return true;
@@ -2253,7 +2256,8 @@ static bool is_radio_mlo_trigger_changed(wifi_radio_operationParam_t *old_p,
     bool old_enabled = old_p->enable && !old_p->EcoPowerDown;
     bool new_enabled = new_p->enable && !new_p->EcoPowerDown;
 
-    return (old_enabled != new_enabled) || (old_be != new_be);
+    return (old_enabled != new_enabled) || (old_be != new_be) ||
+        (old_p->mldLinkId != new_p->mldLinkId);
 }
 
 /* Re-encode the current mgr VAP config for one subdoc type and re-inject it
@@ -2345,8 +2349,7 @@ static void trigger_mlo_vap_reconfiguration(wifi_ctrl_t *ctrl, unsigned int radi
             mld_conf = &vap->u.bss_info.mld_info.common_info;
 
             /* Only VAPs with valid MLD config participate in MLO. */
-            if (mld_conf->mld_id >= MLD_UNIT_COUNT ||
-                mld_conf->mld_link_id >= MAX_NUM_MLD_LINKS) {
+            if (mld_conf->mld_id >= MLD_UNIT_COUNT) {
                 continue;
             }
 

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -201,6 +201,7 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
     cfg.chanUtilThreshold = 90;
     cfg.chanUtilSelfHealEnable = 0;
     cfg.EcoPowerDown = false;
+    cfg.mldLinkId = 255;
     cfg.factoryResetSsid = 0;
     cfg.basicDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_12MBPS | WIFI_BITRATE_24MBPS;
     cfg.operationalDataTransmitRates = WIFI_BITRATE_6MBPS | WIFI_BITRATE_9MBPS | WIFI_BITRATE_12MBPS | WIFI_BITRATE_18MBPS | WIFI_BITRATE_24MBPS | WIFI_BITRATE_36MBPS | WIFI_BITRATE_48MBPS | WIFI_BITRATE_54MBPS;

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -94,6 +94,7 @@
 #define ONEWIFI_DB_VERSION_ENCR_NEW_FLAG 100049
 #define ONEWIFI_DB_VERSION_TCM_PER_VAP_FLAG 100050
 #define ONEWIFI_DB_VERSION_HOSTAP_MGMT_FRAME_CTRL_NEW_FLAG 100051
+#define ONEWIFI_DB_VERSION_RADIO_MLD_LINK_ID_FLAG 100052
 
 #define IGNITE_MIN_CHUTIL_THRESHOLD  50
 #define IGNITE_MAX_CHUTIL_THRESHOLD 100
@@ -450,6 +451,7 @@ void callback_Wifi_Radio_Config(ovsdb_update_monitor_t *mon,
         }
 
         l_radio_cfg->autoChannelEnabled = new_rec->auto_channel_enabled;
+        l_radio_cfg->mldLinkId = new_rec->mld_link_id;
         l_radio_cfg->channel = new_rec->channel;
         l_radio_cfg->channelWidth = new_rec->channel_width;
         if ((new_rec->hw_mode != 0) && (validate_wifi_hw_variant(new_rec->freq_band, new_rec->hw_mode) == RETURN_OK)) {
@@ -2074,6 +2076,8 @@ int wifidb_update_wifi_radio_config(int radio_index, wifi_radio_operationParam_t
     cfg.chan_util_selfheal_enable = config->chanUtilSelfHealEnable;
     cfg.eco_power_down = config->EcoPowerDown;
     cfg.dfs_timer = config->DFSTimer;
+    cfg.mld_link_id = config->mldLinkId;
+
     if(strlen(config->radarDetected) != 0) {
         strncpy(cfg.radar_detected, config->radarDetected, sizeof(cfg.radar_detected));
     }
@@ -2207,6 +2211,7 @@ int wifidb_get_wifi_radio_config(int radio_index, wifi_radio_operationParam_t *c
     oper_radio->channel = cfg->channel;
     oper_radio->channelWidth = cfg->channel_width;
     oper_radio->DfsEnabled = cfg->dfs_enabled;
+    config->mldLinkId = cfg->mld_link_id;
 
     if (wifi_radio_operationParam_validation(&((wifi_mgr_t*) get_wifimgr_obj())->hal_cap, oper_radio) == RETURN_OK) {
         if((is_bootup) && (config->band == WIFI_FREQUENCY_5L_BAND
@@ -5067,6 +5072,35 @@ static void wifidb_radio_config_upgrade(unsigned int index, wifi_radio_operation
             return;
         }
     }
+
+    if (g_wifidb->db_version < ONEWIFI_DB_VERSION_RADIO_MLD_LINK_ID_FLAG) {
+        wifi_vap_info_map_t *vap_map = get_wifidb_vap_map(index);
+
+        wifi_util_info_print(WIFI_DB, "%s:%d upgrade radio=%d mldLinkId, old db version: %d\n",
+            __func__, __LINE__, index, g_wifidb->db_version);
+        if (vap_map == NULL) {
+            wifi_util_error_print(WIFI_DB, "%s:%d failed to get vap map for radio %d\n", __func__,
+                __LINE__, index);
+        } else {
+            unsigned int vap_idx;
+
+            for (vap_idx = 0; vap_idx < vap_map->num_vaps; vap_idx++) {
+                if (!isVapPrivate(vap_map->vap_array[vap_idx].vap_index)) {
+                    continue;
+                }
+                config->mldLinkId = vap_map->vap_array[vap_idx].u.bss_info.mld_info.common_info.mld_link_id;
+                wifi_util_info_print(WIFI_DB,
+                    "%s:%d radio %d mldLinkId set to %d from private vap %s\n", __func__, __LINE__,
+                    index, config->mldLinkId, vap_map->vap_array[vap_idx].vap_name);
+                break;
+            }
+            if (wifidb_update_wifi_radio_config(index, config, rdk_config) != RETURN_OK) {
+                wifi_util_error_print(WIFI_DB, "%s:%d error in updating radio config\n", __func__,
+                    __LINE__);
+                return;
+            }
+        }
+    }
 #endif /* CONFIG_IEEE80211BE */
 }
 
@@ -7439,6 +7473,7 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
     cfg->chanUtilThreshold = 90;
     cfg->chanUtilSelfHealEnable = 0;
     cfg->EcoPowerDown = false;
+    cfg->mldLinkId = 255;
     cfg->factoryResetSsid = 0;
     if ((is_device_type_sr213() == true) && (WIFI_FREQUENCY_2_4_BAND == cfg->band)) {
         cfg->basicDataTransmitRates = WIFI_BITRATE_1MBPS | WIFI_BITRATE_2MBPS |

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -2417,6 +2417,12 @@ Radio_GetParamUlongValue
         return TRUE;
     }
 
+    if( AnscEqualString(ParamName, "X_RDK_MLDLinkID", TRUE))
+    {
+        *puLong = pcfg->mldLinkId;
+        return TRUE;
+    }
+
     if( AnscEqualString(ParamName, "MaxBitRate", TRUE))
     {
         /* collect value */
@@ -3767,6 +3773,23 @@ Radio_SetParamUlongValue
     if( AnscEqualString(ParamName, "AutoChannelRefreshPeriod", TRUE))
     {
         rcfg->AutoChannelRefreshPeriod = uValue;
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "X_RDK_MLDLinkID", TRUE))
+    {
+        if (uValue != 255 && uValue >= MAX_NUM_MLD_LINKS) {
+            wifi_util_error_print(WIFI_DMCLI, "%s:%d Invalid X_RDK_MLDLinkID value %lu\n", __func__,
+                __LINE__, uValue);
+            return FALSE;
+        }
+        if (wifiRadioOperParam->mldLinkId == uValue) {
+            return TRUE;
+        }
+        wifiRadioOperParam->mldLinkId = uValue;
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d: mldLinkId=%lu radio_index=%d\n", __func__, __LINE__,
+            uValue, instance_number);
+        is_radio_config_changed = TRUE;
         return TRUE;
     }
 
@@ -5569,19 +5592,6 @@ SSID_GetParamUlongValue
         return TRUE;
     }
 
-    if( AnscEqualString(ParamName, "X_RDK_MLDLinkID", TRUE))
-    {
-        wifi_mld_common_info_t *mld_common_info = NULL;
-
-        if (isVapSTAMesh(pcfg->vap_index)) {
-            mld_common_info = &pcfg->u.sta_info.mld_info.common_info;
-        } else {
-            mld_common_info = &pcfg->u.bss_info.mld_info.common_info;
-        }
-        *puLong = (uint32_t)mld_common_info->mld_link_id;
-        return TRUE;
-    }
-
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */
     return FALSE;
 }
@@ -6078,53 +6088,6 @@ SSID_SetParamUlongValue
     {
         wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Null pointer get fail\n", __FUNCTION__,__LINE__);
         return FALSE;
-    }
-
-    uint8_t instance_number = (uint8_t)convert_vap_name_to_index(&((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop, pcfg->vap_name) +1;
-    wifi_vap_info_t *vapInfo = (wifi_vap_info_t *) get_dml_cache_vap_info(instance_number-1);
-
-    if (vapInfo == NULL)
-    {
-        wifi_util_dbg_print(WIFI_DMCLI,"%s:%d Unable to get VAP info for instance_number:%d\n", __FUNCTION__,__LINE__,instance_number);
-        return FALSE;
-    }
-
-    if( AnscEqualString(ParamName, "X_RDK_MLDLinkID", TRUE))
-    {
-        if (isVapSTAMesh(pcfg->vap_index)) {
-            wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
-            return TRUE;
-        }
-
-        /* MLD_Link_ID is per radio configuration. In current design, we store it in each VAP structure.
-         * So when MLD_Link_ID is updated for one VAP, we need to update it for all VAPs of the same radio.
-         */
-        unsigned int total_vaps = getTotalNumberVAPs();
-
-        for (unsigned int vap_idx = 0; vap_idx < total_vaps; vap_idx++) {
-            wifi_vap_info_t *temp_vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(vap_idx);
-            if (temp_vapInfo == NULL) {
-                wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Unable to get VAP info for vap index:%d\n",
-                    __FUNCTION__, __LINE__, vap_idx);
-                continue;
-            }
-            if (temp_vapInfo->radio_index != pcfg->radio_index) {
-                continue;
-            }
-            if (isVapSTAMesh(vap_idx)) {
-                continue;
-            }
-            wifi_util_dbg_print(WIFI_DMCLI,
-                "%s:%d Updating mld_link_id radio_index %d vap index:%d old val %u new val %u\n",
-                __FUNCTION__, __LINE__, temp_vapInfo->radio_index, vap_idx,
-                temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id, uValue);
-            if (temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id == (unsigned int)uValue) {
-                continue;
-            }
-            temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id = uValue;
-            set_dml_cache_vap_config_changed(vap_idx);
-        }
-        return TRUE;
     }
 
     /* CcspTraceWarning(("Unsupported parameter '%s'\n", ParamName)); */

--- a/source/platform/common/data_model/wifi_dml_cb.c
+++ b/source/platform/common/data_model/wifi_dml_cb.c
@@ -867,6 +867,8 @@ bool radio_get_param_uint_value(void *obj_ins_context, char *param_name, uint32_
         dml_radio_default *dm_radio_default = get_radio_default_obj(radio_index);
         DM_CHECK_NULL_WITH_RC(dm_radio_default, false);
         *output_value = dm_radio_default->ExtensionChannel;
+    } else if (STR_CMP(param_name, "X_RDK_MLDLinkID")) {
+        *output_value = pcfg->mldLinkId;
     } else {
         wifi_util_info_print(WIFI_DMCLI, "%s:%d: unsupported param name:%s\n", __func__, __LINE__,
             param_name);
@@ -1299,6 +1301,19 @@ bool radio_set_param_uint_value(void *obj_ins_context, char *param_name, uint32_
         if (dm_radio_default->ExtensionChannel != output_value) {
             dm_radio_default->ExtensionChannel = output_value;
         }
+    } else if (STR_CMP(param_name, "X_RDK_MLDLinkID")) {
+        if (output_value != 255 && output_value >= MAX_NUM_MLD_LINKS) {
+            wifi_util_error_print(WIFI_DMCLI, "%s:%d Invalid X_RDK_MLDLinkID value %u\n", __func__,
+                __LINE__, output_value);
+            return false;
+        }
+        if (dm_radio_param->mldLinkId == output_value) {
+            return true;
+        }
+        dm_radio_param->mldLinkId = output_value;
+        wifi_util_dbg_print(WIFI_DMCLI, "%s:%d: mldLinkId=%u radio_index=%d\n", __func__, __LINE__,
+            dm_radio_param->mldLinkId, radio_index);
+        is_radio_config_changed = true;
     } else {
         wifi_util_info_print(WIFI_DMCLI, "%s:%d: unsupported param name:%s\n", __func__, __LINE__,
             param_name);
@@ -2241,15 +2256,6 @@ bool ssid_get_param_uint_value(void *obj_ins_context, char *param_name, uint32_t
 
     if (STR_CMP(param_name, "LastChange")) {
         *output_value = (uint32_t)get_current_time_in_sec();
-    } else if (STR_CMP(param_name, "X_RDK_MLDLinkID")) {
-        wifi_mld_common_info_t *mld_common_info = NULL;
-
-        if (isVapSTAMesh(pcfg->vap_index)) {
-            mld_common_info = &pcfg->u.sta_info.mld_info.common_info;
-        } else {
-            mld_common_info = &pcfg->u.bss_info.mld_info.common_info;
-        }
-        *output_value = (uint32_t)mld_common_info->mld_link_id;
     } else {
         wifi_util_info_print(WIFI_DMCLI, "%s:%d: unsupported param name:%s\n", __func__, __LINE__,
             param_name);
@@ -2538,47 +2544,9 @@ bool ssid_set_param_uint_value(void *obj_ins_context, char *param_name, uint32_t
 
     DM_CHECK_NULL_WITH_RC(pcfg, false);
 
-   if (STR_CMP(param_name, "X_RDK_MLDLinkID")) {
-        if (isVapSTAMesh(pcfg->vap_index)) {
-            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
-            return TRUE;
-        }
-
-        /* MLD_Link_ID is per radio configuration. In current design, we store it in each VAP structure.
-         * So when MLD_Link_ID is updated for one VAP, we need to update it for all VAPs of the same radio.
-         */
-        unsigned int total_vaps = getTotalNumberVAPs();
-
-        for (unsigned int vap_idx = 0; vap_idx < total_vaps; vap_idx++) {
-            wifi_vap_info_t *temp_vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(vap_idx);
-            if (temp_vapInfo == NULL) {
-                wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Unable to get VAP info for vap index:%d\n",
-                    __FUNCTION__, __LINE__, vap_idx);
-                continue;
-            }
-            if (temp_vapInfo->radio_index != pcfg->radio_index) {
-                continue;
-            }
-            if (isVapSTAMesh(vap_idx)) {
-                continue;
-            }
-            wifi_util_dbg_print(WIFI_DMCLI,
-                "%s:%d Updating mld_link_id radio_index %d vap index:%d old val %u new val %u\n",
-                __FUNCTION__, __LINE__, temp_vapInfo->radio_index, vap_idx,
-                (uint32_t)temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id, output_value);
-            if (temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id == output_value) {
-                continue;
-            }
-            temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id = output_value;
-            set_dml_cache_vap_config_changed(vap_idx);
-        }
-        return true;
-    } else {
-        wifi_util_info_print(WIFI_DMCLI, "%s:%d: unsupported param name:%s\n",__func__, __LINE__, param_name);
-        return false;
-    }
-
-    return true;
+    wifi_util_info_print(WIFI_DMCLI, "%s:%d: unsupported param name:%s\n", __func__, __LINE__,
+        param_name);
+    return false;
 }
 
 bool ssid_set_param_string_value(void *obj_ins_context, char *param_name,

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -3309,6 +3309,9 @@ webconfig_error_t decode_radio_object(const cJSON *obj_radio, rdk_wifi_radio_t *
     }
 #endif // FEATURE_SUPPORT_ECOPOWERDOWN
 
+    decode_param_integer(obj_radio, "MldLinkId", param);
+    radio_info->mldLinkId = param->valuedouble;
+
     // Tscan
     decode_param_integer(obj_radio, "Tscan", param);
     radio_feat->OffChanTscanInMsec = param->valuedouble;

--- a/source/webconfig/wifi_encoder.c
+++ b/source/webconfig/wifi_encoder.c
@@ -336,6 +336,9 @@ webconfig_error_t encode_radio_object(const rdk_wifi_radio_t *radio, cJSON *radi
     // EcoPowerDown
     cJSON_AddBoolToObject(radio_object, "EcoPowerDown", radio_info->EcoPowerDown);
 
+    // MldLinkId
+    cJSON_AddNumberToObject(radio_object, "MldLinkId", radio_info->mldLinkId);
+
     //Tscan
     cJSON_AddNumberToObject(radio_object, "Tscan", radio_feat->OffChanTscanInMsec);
 


### PR DESCRIPTION
Reason for change: Move MLD link ID ownership to radio configuration
                   Optimize beacon update logic only when channel is changed
                   to avoid unnecessary beacon updates.
Test Procedure: Configure MLO and check client connectivity Risks: Medium
Priority: P1