### PR TITLE
XB10-2872: Allow MLO link ID to be set only for private VAPs

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -99,6 +99,10 @@ extern "C" {
 #define MAX_NUM_MLD_LINKS 15
 #endif /*MAX_NUM_MLD_LINKS*/
 
+#ifndef UNDEFINED_MLD_LINK_ID
+#define UNDEFINED_MLD_LINK_ID 255
+#endif
+
 #define UNDEFINED_MLD_ID 255
 #define MLD_UNIT_COUNT 8
 #define MIN_MLO_GROUP_SIZE 2

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -3353,6 +3353,47 @@ typedef struct {
 } mld_group_entry_t;
 
 /**
+ * get_radio_private_mld_link_id - Return the authoritative MLD link id for a radio.
+ *
+ * MLD_Link_ID is a per-radio configuration whose authoritative value lives on the
+ * private VAP; every other VAP on the radio inherits it. Resolve the private VAP's
+ * mld_link_id for the given radio, honoring the webconfig target data when present and
+ * falling back to the mgr cache otherwise.
+ *
+ * @return The private VAP's mld_link_id, or UNDEFINED_MLD_LINK_ID when no private VAP exists.
+ */
+static unsigned int get_radio_private_mld_link_id(wifi_vap_info_map_t *mgr_vap_map,
+    webconfig_subdoc_decoded_data_t *data, char **vap_names, unsigned int vap_names_size)
+{
+    unsigned int vap_idx, name_idx;
+
+    for (vap_idx = 0; vap_idx < mgr_vap_map->num_vaps; vap_idx++) {
+        wifi_vap_info_t *mgr_vap = &mgr_vap_map->vap_array[vap_idx];
+        wifi_vap_info_t *target_vap = mgr_vap;
+
+        if (!isVapPrivate(mgr_vap->vap_index)) {
+            continue;
+        }
+
+        if (data != NULL) {
+            for (name_idx = 0; name_idx < vap_names_size; name_idx++) {
+                if (strcmp(vap_names[name_idx], mgr_vap->vap_name) == 0) {
+                    wifi_vap_info_t *wc_vap = webconfig_find_vap_by_name(data, mgr_vap->vap_name);
+                    if (wc_vap != NULL) {
+                        target_vap = wc_vap;
+                    }
+                    break;
+                }
+            }
+        }
+
+        return target_vap->u.bss_info.mld_info.common_info.mld_link_id;
+    }
+
+    return UNDEFINED_MLD_LINK_ID;
+}
+
+/**
  * update_mld_groups - Common MLO group validation and propagation.
  *
  * Iterates all MLD units (0..MLD_UNIT_COUNT-1). For each unit, walks all
@@ -3394,9 +3435,14 @@ unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
         /* --- STEP 1: Seed MLD Address and Collect Candidates for this unit --- */
         for (r_idx = 0; r_idx < getNumberRadios(); r_idx++) {
             wifi_vap_info_map_t *mgr_vap_map = get_wifidb_vap_map(r_idx);
+            unsigned int radio_mld_link_id = UNDEFINED_MLD_LINK_ID;
+
             if (mgr_vap_map == NULL) {
                 continue;
             }
+
+            radio_mld_link_id = get_radio_private_mld_link_id(mgr_vap_map, data, vap_names,
+                vap_names_size);
 
             for (k = 0; k < mgr_vap_map->num_vaps; k++) {
                 wifi_vap_info_t *mgr_vap = &mgr_vap_map->vap_array[k];
@@ -3427,6 +3473,17 @@ unsigned int update_mld_groups(webconfig_subdoc_decoded_data_t *data,
                 }
 
                 mld_conf = &target_vap->u.bss_info.mld_info.common_info;
+
+                /* MLD link id is a per-radio setting; take the authoritative value from
+                 * the private VAP and apply it to every VAP on this radio. */
+                if (mld_conf->mld_link_id != radio_mld_link_id) {
+                    wifi_util_dbg_print(log_type,
+                        "%s:%d: vap_index=%d mld_link_id=%u overridden by private VAP value %u\n",
+                        __func__, __LINE__, mgr_vap->vap_index, mld_conf->mld_link_id, radio_mld_link_id);
+
+                    radio_bitmap |= (1u << mgr_vap->radio_index);
+                    mld_conf->mld_link_id = radio_mld_link_id;
+                }
 
                 /* Seed mld_addr and disable MLD on first pass only.
                  * Subsequent group iterations must not overwrite values

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -6091,39 +6091,29 @@ SSID_SetParamUlongValue
 
     if( AnscEqualString(ParamName, "X_RDK_MLDLinkID", TRUE))
     {
-        if (isVapSTAMesh(pcfg->vap_index)) {
+        /* MLD_Link_ID is per radio configuration. In current design, we store it in each VAP structure.
+         * MLD_Link_ID can be updated only for private VAP, other VAPs populated automatically from the same radio.
+         */
+        if (!isVapPrivate(pcfg->vap_index)) {
             wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
+            return FALSE;
+        }
+
+        if (uValue != UNDEFINED_MLD_LINK_ID && uValue >= MAX_NUM_MLD_LINKS) {
+            wifi_util_error_print(WIFI_DMCLI, "%s:%d Invalid X_RDK_MLDLinkID value %lu\n", __func__,
+                __LINE__, uValue);
+            return FALSE;
+        }
+
+        wifi_util_dbg_print(WIFI_DMCLI,
+            "%s:%d Updating mld_link_id radio_index %d vap name %s old val %u new val %lu\n",
+            __FUNCTION__, __LINE__, vapInfo->radio_index, pcfg->vap_name,
+            vapInfo->u.bss_info.mld_info.common_info.mld_link_id, uValue);
+        if (vapInfo->u.bss_info.mld_info.common_info.mld_link_id == (unsigned int)uValue) {
             return TRUE;
         }
-
-        /* MLD_Link_ID is per radio configuration. In current design, we store it in each VAP structure.
-         * So when MLD_Link_ID is updated for one VAP, we need to update it for all VAPs of the same radio.
-         */
-        unsigned int total_vaps = getTotalNumberVAPs();
-
-        for (unsigned int vap_idx = 0; vap_idx < total_vaps; vap_idx++) {
-            wifi_vap_info_t *temp_vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(vap_idx);
-            if (temp_vapInfo == NULL) {
-                wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Unable to get VAP info for vap index:%d\n",
-                    __FUNCTION__, __LINE__, vap_idx);
-                continue;
-            }
-            if (temp_vapInfo->radio_index != pcfg->radio_index) {
-                continue;
-            }
-            if (isVapSTAMesh(vap_idx)) {
-                continue;
-            }
-            wifi_util_dbg_print(WIFI_DMCLI,
-                "%s:%d Updating mld_link_id radio_index %d vap index:%d old val %u new val %u\n",
-                __FUNCTION__, __LINE__, temp_vapInfo->radio_index, vap_idx,
-                temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id, uValue);
-            if (temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id == (unsigned int)uValue) {
-                continue;
-            }
-            temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id = uValue;
-            set_dml_cache_vap_config_changed(vap_idx);
-        }
+        vapInfo->u.bss_info.mld_info.common_info.mld_link_id = uValue;
+        set_dml_cache_vap_config_changed(instance_number - 1);
         return TRUE;
     }
 

--- a/source/platform/common/data_model/wifi_dml_cb.c
+++ b/source/platform/common/data_model/wifi_dml_cb.c
@@ -2538,40 +2538,39 @@ bool ssid_set_param_uint_value(void *obj_ins_context, char *param_name, uint32_t
 
     DM_CHECK_NULL_WITH_RC(pcfg, false);
 
+    uint8_t instance_number = (uint8_t)convert_vap_name_to_index(&((webconfig_dml_t *)get_webconfig_dml())->hal_cap.wifi_prop, pcfg->vap_name) +1;
+    wifi_vap_info_t *vapInfo = (wifi_vap_info_t *) get_dml_cache_vap_info(instance_number-1);
+
+    if (vapInfo == NULL) {
+        wifi_util_error_print(WIFI_DMCLI, "%s:%d Unable to get VAP info for instance_number:%d\n",
+            __func__, __LINE__, instance_number);
+        return false;
+    }
+
    if (STR_CMP(param_name, "X_RDK_MLDLinkID")) {
-        if (isVapSTAMesh(pcfg->vap_index)) {
-            wifi_util_dbg_print(WIFI_DMCLI, "%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
-            return TRUE;
-        }
-
         /* MLD_Link_ID is per radio configuration. In current design, we store it in each VAP structure.
-         * So when MLD_Link_ID is updated for one VAP, we need to update it for all VAPs of the same radio.
+         * MLD_Link_ID can be updated only for private VAP, other VAPs populated automatically from the same radio.
          */
-        unsigned int total_vaps = getTotalNumberVAPs();
-
-        for (unsigned int vap_idx = 0; vap_idx < total_vaps; vap_idx++) {
-            wifi_vap_info_t *temp_vapInfo = (wifi_vap_info_t *)get_dml_cache_vap_info(vap_idx);
-            if (temp_vapInfo == NULL) {
-                wifi_util_dbg_print(WIFI_DMCLI, "%s:%d Unable to get VAP info for vap index:%d\n",
-                    __FUNCTION__, __LINE__, vap_idx);
-                continue;
-            }
-            if (temp_vapInfo->radio_index != pcfg->radio_index) {
-                continue;
-            }
-            if (isVapSTAMesh(vap_idx)) {
-                continue;
-            }
-            wifi_util_dbg_print(WIFI_DMCLI,
-                "%s:%d Updating mld_link_id radio_index %d vap index:%d old val %u new val %u\n",
-                __FUNCTION__, __LINE__, temp_vapInfo->radio_index, vap_idx,
-                (uint32_t)temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id, output_value);
-            if (temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id == output_value) {
-                continue;
-            }
-            temp_vapInfo->u.bss_info.mld_info.common_info.mld_link_id = output_value;
-            set_dml_cache_vap_config_changed(vap_idx);
+        if (!isVapPrivate(pcfg->vap_index)) {
+            wifi_util_dbg_print(WIFI_DMCLI,"%s:%d %s does not support configuration\n", __FUNCTION__,__LINE__,pcfg->vap_name);
+            return false;
         }
+
+        if (output_value != UNDEFINED_MLD_LINK_ID && output_value >= MAX_NUM_MLD_LINKS) {
+            wifi_util_error_print(WIFI_DMCLI, "%s:%d Invalid X_RDK_MLDLinkID value %u\n", __func__,
+                __LINE__, output_value);
+            return false;
+        }
+
+        wifi_util_dbg_print(WIFI_DMCLI,
+            "%s:%d Updating mld_link_id radio_index %d vap name %s old val %u new val %u\n",
+            __FUNCTION__, __LINE__, pcfg->radio_index, pcfg->vap_name,
+            vapInfo->u.bss_info.mld_info.common_info.mld_link_id, output_value);
+        if (vapInfo->u.bss_info.mld_info.common_info.mld_link_id == (unsigned int)output_value) {
+            return true;
+        }
+        vapInfo->u.bss_info.mld_info.common_info.mld_link_id = output_value;
+        set_dml_cache_vap_config_changed(instance_number - 1);
         return true;
     } else {
         wifi_util_info_print(WIFI_DMCLI, "%s:%d: unsupported param name:%s\n",__func__, __LINE__, param_name);


### PR DESCRIPTION
Reason for change: [MLO] MLD_Link_ID reconfiguration could break MLO
Test Procedure: Configure MLO, check MLO and client connectivity
Risks: Medium
Priority: P1