### PR TITLE
RDKB-66073 : Observed OVSM memory leak during VIF_Config table update

### DIFF
--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -1160,6 +1160,7 @@ webconfig_error_t webconfig_ovsdb_encode(webconfig_t *config,
         *str = NULL;
         free_maclist_map(webconfig_ovsdb_data.u.decoded.num_radios, rdk_wifi_radio_state);
         free(rdk_wifi_radio_state);
+        webconfig_data_free(&webconfig_ovsdb_data);
         pthread_mutex_unlock(&webconfig_data_lock);
         return webconfig_error_translate_from_ovsdb_cfg_no_change;
     }


### PR DESCRIPTION
RDKB-66073 : Observed OVSM memory leak during VIF_Config table update

Reason for change: Observed OVSM memory leak during VIF_Config table update 
Test Procedure: Update the Wifi_VIF_Config table manually and ensure that no memory spike is observed during or after the update. 
Risks: Medium
Priority: P1
Signed-off-by:lavanya_chimmirivenkata@comcast.com