### PR TITLE
RDKB-65984: /tmp folder flooding with core.prog_ovsm core file.

### DIFF
--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -3341,10 +3341,6 @@ int create_station_with_default_credentials(webconfig_subdoc_data_t *data, int n
                 .vaps.vap_map.vap_array[vap_array_index]
                 .u.sta_info.security.u.radius.eap_type = WIFI_EAP_TYPE_NONE;
         }
-        memset(&data->u.decoded.radios[radio_index].vaps.vap_map.vap_array[vap_array_index].u.sta_info.security.u.radius.ip, 0,
-                    sizeof(data->u.decoded.radios[radio_index].vaps.vap_map.vap_array[vap_array_index].u.sta_info.security.u.radius.ip));
-        memset(&data->u.decoded.radios[radio_index].vaps.vap_map.vap_array[vap_array_index].u.sta_info.security.u.radius.s_ip, 0,
-                    sizeof(data->u.decoded.radios[radio_index].vaps.vap_map.vap_array[vap_array_index].u.sta_info.security.u.radius.s_ip));
     }
 
     return status;


### PR DESCRIPTION
Impacted Platforms: All XB10 platforms.

Reason for change: On memset of radius.ip and radius_ip during station vap creation, u.key.key(passphrase) also cleared due to same union memory address used across radius configuration.

Test Procedure:
Load the above mentioned build
Factory reset the device.
After bootup, check for the ovsm crash core file generated in /tmp folder. If present, then issue reproduced.
Risks: Medium
Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com