### PR TITLE
RDKB-63887  MFPConfig is not set to "Optional" on all secure vAPs using WPA2-Personal by default when FeatureMFPConfig is enabled.

### DIFF
--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -736,6 +736,7 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
             return RETURN_ERR;
         }
         strncpy(radius_info->s_key, value, sizeof(radius_info->s_key) - 1);
+        }
     }
     return RETURN_OK;
 }

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -408,7 +408,7 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
         vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_psk;
     } else if (!strcmp(value, "WPA-WPA2-Personal")) {
         vap_info->u.bss_info.security.mode = wifi_security_mode_wpa_wpa2_personal;
-        vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
+        vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
         vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_psk;
     } else if (!strcmp(value, "WPA3-Personal")) {
         vap_info->u.bss_info.security.mode = wifi_security_mode_wpa3_personal;
@@ -458,10 +458,10 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
         }
         return RETURN_ERR;
     }
-
-    if (isVapHotspot(vap_info->vap_index)) {
-        param = cJSON_GetObjectItem(security, "MFPConfig");
-        if (!param) {
+    
+    param = cJSON_GetObjectItem(security, "MFPConfig"); 
+    if (!param) {
+        if (isVapHotspot(vap_info->vap_index)) {
             wifi_util_error_print(WIFI_CTRL, "%s: missing \"MFPConfig\"\n", __func__);
             if (execRetVal) {
                 strncpy(execRetVal->ErrorMsg, "Invalid MFPConfig",
@@ -469,7 +469,24 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
             }
             return RETURN_ERR;
         }
+    } else {
+        if (!cJSON_IsString(param)) {
+            wifi_util_error_print(WIFI_CTRL, "%s: \"MFPConfig\" is not a string\n", __func__);
+            if (execRetVal) {
+                strncpy(execRetVal->ErrorMsg, "Invalid MFPConfig type",
+                    sizeof(execRetVal->ErrorMsg) - 1);
+            }
+            return RETURN_ERR;
+        }
         value = cJSON_GetStringValue(param);
+        if (value == NULL) {
+            wifi_util_error_print(WIFI_CTRL, "%s: \"MFPConfig\" value is NULL\n", __func__);
+            if (execRetVal) {
+                strncpy(execRetVal->ErrorMsg, "Invalid MFPConfig",
+                    sizeof(execRetVal->ErrorMsg) - 1);
+            }
+            return RETURN_ERR;
+        }
         wifi_util_info_print(WIFI_CTRL, "   \"MFPConfig\": %s\n", value);
         if (!strcmp(value, "Disabled")) {
             vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
@@ -486,6 +503,7 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
             return RETURN_ERR;
         }
 
+        if (isVapHotspot(vap_info->vap_index)) {
         radius_param = cJSON_GetObjectItem(security, "RadiusSettings");
         if (!radius_param) {
             wifi_util_error_print(WIFI_CTRL, "%s: missing \"RadiusSettings\"\n", __func__);

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -502,7 +502,7 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
             }
             return RETURN_ERR;
         }
-
+    }
         if (isVapHotspot(vap_info->vap_index)) {
         radius_param = cJSON_GetObjectItem(security, "RadiusSettings");
         if (!radius_param) {
@@ -737,7 +737,6 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
         }
         strncpy(radius_info->s_key, value, sizeof(radius_info->s_key) - 1);
         }
-    }
     return RETURN_OK;
 }
 

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -736,7 +736,7 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
             return RETURN_ERR;
         }
         strncpy(radius_info->s_key, value, sizeof(radius_info->s_key) - 1);
-        }
+    }
     return RETURN_OK;
 }
 

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -404,11 +404,11 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
         vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_psk;
     } else if (!strcmp(value, "WPA2-Personal")) {
         vap_info->u.bss_info.security.mode = wifi_security_mode_wpa2_personal;
-        vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
+        vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
         vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_psk;
     } else if (!strcmp(value, "WPA-WPA2-Personal")) {
         vap_info->u.bss_info.security.mode = wifi_security_mode_wpa_wpa2_personal;
-        vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
+        vap_info->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;
         vap_info->u.bss_info.security.u.key.type = wifi_security_key_type_psk;
     } else if (!strcmp(value, "WPA3-Personal")) {
         vap_info->u.bss_info.security.mode = wifi_security_mode_wpa3_personal;

--- a/source/core/wifi_multidoc_webconfig.c
+++ b/source/core/wifi_multidoc_webconfig.c
@@ -503,7 +503,7 @@ static int decode_security_blob(wifi_vap_info_t *vap_info, cJSON *security, pErr
             return RETURN_ERR;
         }
     }
-        if (isVapHotspot(vap_info->vap_index)) {
+    if (isVapHotspot(vap_info->vap_index)) {
         radius_param = cJSON_GetObjectItem(security, "RadiusSettings");
         if (!radius_param) {
             wifi_util_error_print(WIFI_CTRL, "%s: missing \"RadiusSettings\"\n", __func__);

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -9256,8 +9256,8 @@ Security_SetParamStringValue
                 break;
             case wifi_security_mode_wpa_personal:
                 l_security_cfg->u.key.type = wifi_security_key_type_psk;
-				l_security_cfg->mfp = wifi_mfp_cfg_disabled;
-				break;
+                l_security_cfg->mfp = wifi_mfp_cfg_disabled;
+                break;
             case wifi_security_mode_wpa2_personal:
             	l_security_cfg->u.key.type = wifi_security_key_type_psk;
 				l_security_cfg->mfp = wifi_mfp_cfg_optional;

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -9255,7 +9255,13 @@ Security_SetParamStringValue
                 l_security_cfg->mfp = wifi_mfp_cfg_disabled;
                 break;
             case wifi_security_mode_wpa_personal:
+                l_security_cfg->u.key.type = wifi_security_key_type_psk;
+				l_security_cfg->mfp = wifi_mfp_cfg_disabled;
+				break;
             case wifi_security_mode_wpa2_personal:
+            	l_security_cfg->u.key.type = wifi_security_key_type_psk;
+				l_security_cfg->mfp = wifi_mfp_cfg_optional;
+				break;
             case wifi_security_mode_wpa_wpa2_personal:
                 l_security_cfg->u.key.type = wifi_security_key_type_psk;
                 l_security_cfg->mfp = wifi_mfp_cfg_disabled;

--- a/source/webconfig/wifi_ovsdb_translator.c
+++ b/source/webconfig/wifi_ovsdb_translator.c
@@ -607,7 +607,8 @@ void get_translator_config_wpa_mfp(
 {
     if (vap->u.bss_info.security.mode == wifi_security_mode_wpa3_personal || vap->u.bss_info.security.mode == wifi_security_mode_wpa3_enterprise) {
         vap->u.bss_info.security.mfp = wifi_mfp_cfg_required;
-    } else if (vap->u.bss_info.security.mode == wifi_security_mode_wpa3_transition) {
+    } else if (vap->u.bss_info.security.mode == wifi_security_mode_wpa3_transition ||
+        vap->u.bss_info.security.mode == wifi_security_mode_wpa2_personal) {
         vap->u.bss_info.security.mfp = wifi_mfp_cfg_optional;
     } else {
         vap->u.bss_info.security.mfp = wifi_mfp_cfg_disabled;


### PR DESCRIPTION
RDKB-63887 MFPConfig is not set to "Optional" on all secure vAPs using WPA2-Personal by default when FeatureMFPConfig is enabled.

Reason For Change: WPA2personal should have mfp as optional
Test Procedure:

load custom image
check mfp RFC is true
change the current security mode as wpa2-personal
check mfp for the specific VAP, it should be Optional
dmcli eRT getv Device.WiFi.FeatureMFPConfig
dmcli eRT setv Device.WiFi.AccessPoint.1.Security.ModeEnabled string "WPA2-Personal"
dmcli eRT setv Device.WiFi.ApplyAccessPointSettings bool 1
dmcli eRT getv Device.WiFi.AccessPoint.1.Security.MFPConfig

Priority: P1
Risks: Low
Signed-off-by: Sneha Kannan , [sneha_kannan@comcast.com](mailto:sneha_kannan@comcast.com)