### PR TITLE
RDKBWIFI-531: Report radio metrics as spec fractions, not raw counters

### DIFF
--- a/source/apps/em/wifi_em.c
+++ b/source/apps/em/wifi_em.c
@@ -107,6 +107,18 @@ typedef struct {
     uint16_t reason;
 } wifi_em_failed_conn_t;
 
+/* Previous survey counters per radio, to turn cumulative HAL times into per-window deltas. */
+typedef struct {
+    int chan;
+    unsigned long long total;
+    unsigned long long busy;
+    unsigned long long busy_tx;
+    unsigned long long busy_self;
+    unsigned long long busy_rx;
+} em_chan_survey_prev_t;
+
+static em_chan_survey_prev_t em_chan_survey_prev[MAX_NUM_RADIOS] = { 0 };
+
 static int em_rssi_to_rcpi(int rssi)
 {
     if (!rssi)
@@ -1243,6 +1255,17 @@ int vap_stats_response(wifi_provider_response_t *provider_response)
     return RETURN_OK;
 }
 
+static unsigned char em_survey_fraction(unsigned long long delta, unsigned long long total)
+{
+    unsigned long long frac;
+
+    if (total == 0) {
+        return 0;
+    }
+    frac = (delta * 255) / total;
+    return (frac > 255) ? 255 : (unsigned char)frac;
+}
+
 static int radio_chan_stats_response(wifi_provider_response_t *provider_response)
 {
     int radio_index = -1;
@@ -1261,9 +1284,13 @@ static int radio_chan_stats_response(wifi_provider_response_t *provider_response
     wifi_platform_property_t *wifi_prop = &wifi_mgr->hal_cap.wifi_prop;
     unsigned int i = 0, k = 0;
     radio_metrics_t *radio_metrics = NULL;
+    em_chan_survey_prev_t *survey_prev = NULL;
+    unsigned long long d_total = 0, d_tx = 0, d_self = 0, d_rx = 0, d_busy = 0;
+    int anpi = 0;
+    unsigned char util255 = 0;
 
     radio_index = provider_response->args.radio_index;
-    if (radio_index > MAX_NUM_RADIOS) {
+    if (radio_index >= MAX_NUM_RADIOS) {
         wifi_util_error_print(WIFI_EM, "%s:%d Invalid radio index %d\n", __func__, __LINE__,
             radio_index);
         return RETURN_ERR;
@@ -1326,16 +1353,55 @@ static int radio_chan_stats_response(wifi_provider_response_t *provider_response
 
         radio_metrics = &em_ap_metrics_report_cache.radio_report[radio_index].radio_metrics;
         memcpy(radio_metrics->ruid, radio_mac, sizeof(mac_addr_t));
-        radio_metrics->noise = channel_stats[count].ch_noise;
-        radio_metrics->transmit = channel_stats[count].ch_utilization_busy_tx;
-        radio_metrics->receive_self = channel_stats[count].ch_utilization_busy_self;
-        /*
-         * RX other: the fraction of the measurement window during which the AP's radio was receiving
-         * frames that are not from the AP's own associated stations.
-         * That is: all RX minus own RX time = busy_rx − busy_self.
-         */
-        radio_metrics->receive_other = (channel_stats[count].ch_utilization_busy_rx > channel_stats[count].ch_utilization_busy_self) ?
-                                       (channel_stats[count].ch_utilization_busy_rx - channel_stats[count].ch_utilization_busy_self) : 0;
+
+        /* EasyMesh wants 1/255 fractions of the window; the HAL counters are
+         * cumulative, so use the delta. First sample, channel change or counter
+         * reset reports 0. */
+        survey_prev = &em_chan_survey_prev[radio_index];
+        if (survey_prev->total != 0 &&
+            survey_prev->chan == channel_stats[count].ch_number &&
+            channel_stats[count].ch_utilization_total > survey_prev->total &&
+            channel_stats[count].ch_utilization_busy >= survey_prev->busy &&
+            channel_stats[count].ch_utilization_busy_tx >= survey_prev->busy_tx &&
+            channel_stats[count].ch_utilization_busy_self >= survey_prev->busy_self &&
+            channel_stats[count].ch_utilization_busy_rx >= survey_prev->busy_rx) {
+            d_total = channel_stats[count].ch_utilization_total - survey_prev->total;
+            d_tx = channel_stats[count].ch_utilization_busy_tx - survey_prev->busy_tx;
+            d_self = channel_stats[count].ch_utilization_busy_self - survey_prev->busy_self;
+            d_rx = channel_stats[count].ch_utilization_busy_rx - survey_prev->busy_rx;
+            d_busy = channel_stats[count].ch_utilization_busy - survey_prev->busy;
+
+            radio_metrics->transmit = em_survey_fraction(d_tx, d_total);
+            radio_metrics->receive_self = em_survey_fraction(d_self, d_total);
+            /*
+             * RX other: the fraction of the measurement window during which the AP's radio was receiving
+             * frames that are not from the AP's own associated stations.
+             * That is: all RX minus own RX time = busy_rx − busy_self.
+             */
+            radio_metrics->receive_other = em_survey_fraction((d_rx > d_self) ? (d_rx - d_self) : 0, d_total);
+            /* Some drivers exclude own TX from busy, so cover at least TX+RX. */
+            util255 = em_survey_fraction((d_busy > d_tx + d_rx) ? d_busy : d_tx + d_rx, d_total);
+        } else {
+            radio_metrics->transmit = 0;
+            radio_metrics->receive_self = 0;
+            radio_metrics->receive_other = 0;
+            util255 = 0;
+        }
+        survey_prev->chan = channel_stats[count].ch_number;
+        survey_prev->total = channel_stats[count].ch_utilization_total;
+        survey_prev->busy = channel_stats[count].ch_utilization_busy;
+        survey_prev->busy_tx = channel_stats[count].ch_utilization_busy_tx;
+        survey_prev->busy_self = channel_stats[count].ch_utilization_busy_self;
+        survey_prev->busy_rx = channel_stats[count].ch_utilization_busy_rx;
+
+        /* ANPI: 0..220 in steps of 0.5 dB starting at -110 dBm. */
+        anpi = (channel_stats[count].ch_noise + 110) * 2;
+        if (anpi < 0) {
+            anpi = 0;
+        } else if (anpi > 220) {
+            anpi = 220;
+        }
+        radio_metrics->noise = (unsigned char)anpi;
 
         // now save radio channel util for each vap
         for (j = 0; j < radio->vaps.num_vaps; j++) {
@@ -1354,7 +1420,7 @@ static int radio_chan_stats_response(wifi_provider_response_t *provider_response
 
                 ap_metrics = &ap_data->ap_metrics;
                 if (ap_metrics != NULL) {
-                    ap_metrics->channel_util = channel_stats[count].ch_utilization;
+                    ap_metrics->channel_util = util255;
                 } else {
                     wifi_util_dbg_print(WIFI_EM,
                         "%s:%d ap metrics report data update to cache error\r\n", __func__, __LINE__);
@@ -1372,7 +1438,7 @@ static int radio_chan_stats_response(wifi_provider_response_t *provider_response
 
                 ap_metrics = &ap_data->ap_metrics;
                 if (ap_metrics != NULL) {
-                    ap_metrics->channel_util = channel_stats[count].ch_utilization;
+                    ap_metrics->channel_util = util255;
                 } else {
                     wifi_util_dbg_print(WIFI_EM,
                         "%s:%d ap metrics report data update to cache error\r\n", __func__, __LINE__);


### PR DESCRIPTION
The EasyMesh Radio Metrics TLV carries time fractions in units of 1/255 over the reporting window and noise as ANPI, but the radio metrics were filled from the raw cumulative HAL survey counters, so the decoded values were out of range.

Convert the delta since the previous sample into 1/255 fractions and encode noise as ANPI. Derive the channel utilization from the same window as max(busy, tx + rx): the spec defines it as the time spent transmitting and receiving, and some drivers do not include own TX time in the busy counter. Report zero on the first sample, a counter reset or a channel change. Also fix the radio index bound check, which allowed radio_index == MAX_NUM_RADIOS.