### PR TITLE
RDKCOM-5487: RDKBWIFI-206: add mocks, build, and limited platform ind…

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -67,7 +67,6 @@ jobs:
                                 gnupg \
                                 file \
                                 golang \
-                                libjson-c-dev \
                                 libgtest-dev \
                                 libgmock-dev
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -9,12 +9,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         platform:
           - name: "Raspberry Pi"
             makefile_path: "build/linux/rpi/makefile"
+          - name: "Platform Mock Unittests"
+            makefile_path: "build/linux/mockplatform/makefile"
       fail-fast: false
 
     name: Build for ${{ matrix.platform.name }}
@@ -64,7 +66,10 @@ jobs:
                                 mariadb-server \
                                 gnupg \
                                 file \
-                                golang
+                                golang \
+                                libjson-c-dev \
+                                libgtest-dev \
+                                libgmock-dev
 
     - name: Setup OneWiFi for ${{ matrix.platform.name }}
       working-directory: easymesh_project/OneWifi

--- a/build/linux/mockplatform/makefile
+++ b/build/linux/mockplatform/makefile
@@ -1,0 +1,541 @@
+#
+# The PROGRAM macro defines the name of the program or project.  It
+# allows the program name to be changed by editing in only one
+# location
+#
+
+#
+# Command line parameters: Edit these parameters so that you can
+# easily run the sample by typing "make -f Makefile.Linux run".
+#
+# You will need to:
+# (1) Describe parameters here. ex: IN_SHAPEFILE is the input shapefile
+# (2) Define parameters below this comment box.
+#       ex: IN_SHAPEFILE = /mycomp/data/shapefile.shp
+# (3) Add the parameters to the run target at the end of this file
+#       ex: ./$(PROGRAM) $(IN_SHAPEFILE)
+#
+
+#
+# The INCLUDEDIRS macro contains a list of include directories
+# to pass to the compiler so it can find necessary header files.
+#
+# The LIBDIRS macro contains a list of library directories
+# to pass to the linker so it can find necessary libraries.
+#
+# The LIBS macro contains a list of libraries that the the
+# executable must be linked against.
+#
+
+include build/linux/makefile.inc
+
+
+EASY_MESH_NODE = 1
+EM_APP = 1
+ONEWIFI_STA_MGR_APP_SUPPORT = 1
+
+# wifi hal rules
+HAL_LIBRARY = $(INSTALLDIR)/lib/libwifihal.a
+WEBCONFIG_LIBRARY = $(INSTALLDIR)/lib/libwebconfig.a
+HE_BUS_LIBRARY = $(INSTALLDIR)/lib/libhebus.a
+
+INCLUDE_HAL_LIB_DIRS = \
+	-I$(ONE_WIFI_HOME)/include \
+	-I$(WIFI_RDK_HAL)/src \
+	-I$(WIFI_RDK_HAL)/util_crypto \
+	-I$(WIFI_DEVICE_HAL)/  \
+	-I$(WIFI_SYSCALL_WRAPPER)/source/ \
+	-I$(WIFI_CJSON)/
+
+INCLUDE_HOSTAP_LIB_DIRS = \
+	-I$(WIFI_HOSTAP_BASE) \
+	-I$(WIFI_HOSTAP_SUPPLICANT) \
+	-I$(WIFI_HOSTAP_SRC) \
+	-I$(WIFI_HOSTAP_SRC)/ap \
+	-I$(WIFI_HOSTAP_SRC)/utils \
+	-I$(WIFI_HOSTAP_SRC)/drivers \
+
+EXCLUDE = $(WIFI_RDK_HAL)/src/wifi_hal_frame_test.c $(WIFI_RDK_HAL)/src/wifi_hal_dpp.c
+
+HAL_LIB_SOURCES = $(filter-out $(EXCLUDE),$(wildcard $(WIFI_RDK_HAL)/src/*.c)) \
+	$(wildcard $(WIFI_RDK_HAL)/platform/raspberry-pi/*.c) \
+	$(wildcard $(WIFI_DEVICE_HAL)/*.c) \
+	$(WIFI_HOSTAP_SRC)/ap/ieee802_11_auth.c \
+	$(WIFI_HOSTAP_SRC)/ap/ap_config.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ieee802_11.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ieee802_11_shared.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ieee802_11_vht.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ieee802_11_he.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ieee802_11_ht.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ieee802_1x.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ap_mlme.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ap_list.c   \
+	$(WIFI_HOSTAP_SRC)/ap/sta_info.c   \
+	$(WIFI_HOSTAP_SRC)/ap/wnm_ap.c \
+	$(WIFI_HOSTAP_SRC)/ap/wpa_auth.c   \
+	$(WIFI_HOSTAP_SRC)/ap/wpa_auth_ie.c   \
+	$(WIFI_HOSTAP_SRC)/ap/wpa_auth_glue.c   \
+	$(WIFI_HOSTAP_SRC)/ap/wps_hostapd.c   \
+	$(WIFI_HOSTAP_SRC)/ap/pmksa_cache_auth.c   \
+	$(WIFI_HOSTAP_SRC)/ap/eap_user_db.c   \
+	$(WIFI_HOSTAP_SRC)/ap/tkip_countermeasures.c   \
+	$(WIFI_HOSTAP_SRC)/ap/hostapd.c   \
+	$(WIFI_HOSTAP_SRC)/ap/beacon.c   \
+	$(WIFI_HOSTAP_SRC)/ap/hs20.c  \
+	$(WIFI_HOSTAP_SRC)/ap/rrm.c   \
+	$(WIFI_HOSTAP_SRC)/ap/wmm.c   \
+	$(WIFI_HOSTAP_SRC)/ap/authsrv.c   \
+	$(WIFI_HOSTAP_SRC)/ap/bss_load.c   \
+	$(WIFI_HOSTAP_SRC)/ap/vlan.c   \
+	$(WIFI_HOSTAP_SRC)/ap/vlan_init.c   \
+	$(WIFI_HOSTAP_SRC)/ap/vlan_ifconfig.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ap_drv_ops.c   \
+	$(WIFI_HOSTAP_SRC)/ap/accounting.c   \
+	$(WIFI_HOSTAP_SRC)/ap/neighbor_db.c   \
+	$(WIFI_HOSTAP_SRC)/ap/drv_callbacks.c   \
+	$(WIFI_HOSTAP_SRC)/ap/ctrl_iface_ap.c   \
+	$(WIFI_HOSTAP_SRC)/ap/hw_features.c   \
+	$(WIFI_HOSTAP_SRC)/ap/dfs.c   \
+	$(WIFI_HOSTAP_SRC)/ap/utils.c   \
+	$(WIFI_HOSTAP_SRC)/ap/greylist.c   \
+	$(WIFI_HOSTAP_SRC)/eapol_auth/eapol_auth_sm.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_methods.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_gtc.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_identity.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_md5.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_mschapv2.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_peap.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_tls_common.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_tls.c   \
+	$(WIFI_HOSTAP_SRC)/eap_server/eap_server_ttls.c \
+	$(WIFI_HOSTAP_SRC)/eap_common/chap.c   \
+	$(WIFI_HOSTAP_SRC)/eap_common/eap_peap_common.c   \
+	$(WIFI_HOSTAP_SRC)/eap_common/eap_common.c   \
+	$(WIFI_HOSTAP_SRC)/eap_common/eap_pwd_common.c   \
+	$(wildcard $(WIFI_HOSTAP_SRC)/eap_peer/*.c) \
+	$(WIFI_HOSTAP_SRC)/wps/wps.c   \
+	$(WIFI_HOSTAP_SRC)/wps/wps_attr_build.c   \
+	$(WIFI_HOSTAP_SRC)/wps/wps_attr_parse.c   \
+	$(WIFI_HOSTAP_SRC)/wps/wps_attr_process.c   \
+	$(WIFI_HOSTAP_SRC)/wps/wps_dev_attr.c   \
+	$(WIFI_HOSTAP_SRC)/wps/wps_common.c   \
+	$(WIFI_HOSTAP_SRC)/wps/wps_registrar.c   \
+	$(WIFI_HOSTAP_SRC)/wps/wps_enrollee.c   \
+	$(WIFI_HOSTAP_SRC)/radius/radius.c   \
+	$(WIFI_HOSTAP_SRC)/radius/radius_client.c   \
+	$(WIFI_HOSTAP_SRC)/radius/radius_das.c   \
+	$(WIFI_HOSTAP_SRC)/utils/wpabuf.c    \
+	$(WIFI_HOSTAP_SRC)/utils/wpa_debug.c    \
+	$(WIFI_HOSTAP_SRC)/utils/os_unix.c    \
+	$(WIFI_HOSTAP_SRC)/utils/eloop.c    \
+	$(WIFI_HOSTAP_SRC)/utils/common.c    \
+	$(WIFI_HOSTAP_SRC)/utils/ip_addr.c    \
+	$(WIFI_HOSTAP_SRC)/utils/uuid.c    \
+	$(WIFI_HOSTAP_SRC)/utils/radiotap.c    \
+	$(WIFI_HOSTAP_SRC)/utils/crc32.c    \
+	$(WIFI_HOSTAP_SRC)/common/wpa_common.c    \
+	$(WIFI_HOSTAP_SRC)/common/hw_features_common.c    \
+	$(WIFI_HOSTAP_SRC)/common/ieee802_11_common.c    \
+	$(WIFI_HOSTAP_SRC)/common/ctrl_iface_common.c    \
+	$(WIFI_HOSTAP_SRC)/common/dragonfly.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/crypto_openssl.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/ms_funcs.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/sha1-prf.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/sha1-pbkdf2.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/random.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/tls_internal.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/dh_groups.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/sha1.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/sha1-internal.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/sha256-internal.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/md5-internal.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/sha256.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/sha256-prf.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/aes-cbc.c    \
+	$(WIFI_HOSTAP_SRC)/crypto/aes-internal.c    \
+	$(WIFI_HOSTAP_SRC)/l2_packet/l2_packet_linux.c    \
+	$(WIFI_HOSTAP_SRC)/rsn_supp/wpa.c    \
+	$(WIFI_HOSTAP_SRC)/rsn_supp/wpa_ie.c    \
+	$(WIFI_HOSTAP_SRC)/rsn_supp/wpa_ft.c    \
+	$(WIFI_HOSTAP_SRC)/rsn_supp/pmksa_cache.c    \
+	$(WIFI_HOSTAP_SRC)/rsn_supp/preauth.c    \
+	$(WIFI_HOSTAP_SRC)/eapol_supp/eapol_supp_sm.c    \
+	$(WIFI_HOSTAP_BASE)/hostapd/ctrl_iface.c    \
+	$(WIFI_HOSTAP_BASE)/hostapd/config_file.c    \
+	$(WIFI_HOSTAP_BASE)/hostapd/eap_register.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/drivers.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/driver_common.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/driver_nl80211.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/driver_nl80211_event.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/driver_nl80211_monitor.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/driver_nl80211_scan.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/driver_nl80211_capa.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/linux_ioctl.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/netlink.c    \
+	$(WIFI_HOSTAP_SRC)/drivers/rfkill.c    \
+
+HAL_LIB_OBJECTS = $(HAL_LIB_SOURCES:.c=.o)  # expands to list of object files
+ALL_HAL_LIB_OBJECTS = $(HAL_LIB_OBJECTS)
+HAL_LIB_FLAGS = -g -fPIC $(INCLUDE_HAL_LIB_DIRS) -DENABLE_FEATURE_MESHWIFI -DRASPBERRY_PI_PORT -D_PLATFORM_RASPBERRYPI_ -DCONFIG_HW_CAPABILITIES -DEM_APP
+HOSTAP_LIB_FLAGS = -g -fPIC $(INCLUDE_HOSTAP_LIB_DIRS) -DHOSTAPD -DCONFIG_CRYPTO_INTERNAL -DCONFIG_DRIVER_NL80211 -DNEED_AP_MLME -DCONFIG_IEEE80211AC -DCONFIG_IEEE80211AX -DCONFIG_IEEE80211N -DCONFIG_WPS -DIEEE8021X_EAPOL -DEAP_SERVER_IDENTITY -DEAP_SERVER_MD5 -DEAP_SERVER_TLS -DEAP_SERVER_MSCHAPV2 -DEAP_SERVER_PEAP -DEAP_SERVER_TTLS -DCONFIG_ECC -DRDK_ONEWIFI -DCONFIG_IEEE80211W -DCONFIG_OPENSSL_CMAC -DCONFIG_LIBNL20 -DCONFIG_HS20 -DCONFIG_WNM_AP
+HOSTAP_LIB_FLAGS +=  -DHOSTAPD_2_10 -DCONFIG_WEP -DFEATURE_SUPPORT_RADIUSGREYLIST -DCONFIG_DRIVER_BRCM -DCONFIG_DRIVER_BRCM_MAP
+
+# wifi agent rules
+
+LDFLAGS = $(LIBDIRS) $(LIBS)
+
+PROGRAM = $(INSTALLDIR)/bin/OneWifi
+
+INCLUDEDIRS = \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/cosa/include \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/cosa/include/linux \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/cosa/package/slap/include \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/ccsp/components/include \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/ccsp/components/common/MessageBusHelper/include \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/ccsp/components/common/PoamIrepFolder \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/ccsp/custom \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/ccsp/include \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/debug_api/include \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/dm_pack \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/util_api/http/include \
+	-I$(WIFI_CCSP_COMMON_LIB)/source/util_api/ansc/include \
+	-I$(WIFI_CCSP_COMMON_LIB)/WebConfig_Framework \
+	-I$(WIFI_MSGPACK)/include \
+	-I$(WIFI_UTOPIA)/source/include \
+	-I$(WIFI_UTOPIA)/source/util/print_uptime \
+	-I$(WIFI_DBUS)/ \
+	-I$(BASE_DIR) \
+	-I$(ONE_WIFI_HOME)/source/dml/tr_181/sbapi \
+	-I$(ONE_WIFI_HOME)/source/sampleapps \
+	-I$(ONE_WIFI_HOME)/source/dml/tr_181/ml \
+	-I$(ONE_WIFI_HOME)/source/dml/wifi_ssp \
+	-I$(ONE_WIFI_HOME)/source/ccsp \
+	-I$(ONE_WIFI_HOME)/source/utils \
+	-I$(ONE_WIFI_HOME)/source/utils/mtrx/inc \
+	-I$(ONE_WIFI_HOME)/source/stats \
+	-I$(ONE_WIFI_HOME)/source/stubs \
+	-I$(ONE_WIFI_HOME)/source/dml/linux \
+	-I$(ONE_WIFI_HOME)/source/platform/linux \
+	-I$(ONE_WIFI_HOME)/source/platform/common \
+	-I$(ONE_WIFI_HOME)/lib/pktgen/ \
+	-I$(ONE_WIFI_HOME)/source/core \
+	-I$(ONE_WIFI_HOME)/source/apps \
+	-I$(ONE_WIFI_HOME)/source/apps/analytics \
+	-I$(ONE_WIFI_HOME)/source/apps/multi_ap \
+	-I$(ONE_WIFI_HOME)/source/apps/blaster \
+	-I$(ONE_WIFI_HOME)/source/apps/cac \
+	-I$(ONE_WIFI_HOME)/source/apps/csi \
+	-I$(ONE_WIFI_HOME)/source/apps/harvester \
+	-I$(ONE_WIFI_HOME)/source/apps/levl \
+	-I$(ONE_WIFI_HOME)/source/apps/memwraptool \
+	-I$(ONE_WIFI_HOME)/source/apps/sta_mgr \
+	-I$(ONE_WIFI_HOME)/source/apps/motion \
+	-I$(ONE_WIFI_HOME)/source/apps/ocs \
+	-I$(ONE_WIFI_HOME)/source/apps/sm \
+	-I$(ONE_WIFI_HOME)/source/apps/whix \
+	-I$(ONE_WIFI_HOME)/source/apps/easyconnect \
+	-I$(ONE_WIFI_HOME)/source/apps/em \
+	-I$(ONE_WIFI_HOME)/source/apps/linkquality \
+	-I$(ONE_WIFI_HOME)/source/apps/wifi_sensing/inc \
+	-I$(ONE_WIFI_HOME)/source/utils/quality_mgr/inc/ \
+	-I$(ONE_WIFI_HOME)/source/utils/math_utils/inc/ \
+	-I$(ONE_WIFI_HOME)/source/core/services \
+	-I$(ONE_WIFI_HOME)/include/tr_181/ml \
+	-I$(ONE_WIFI_HOME)/include \
+	-I$(ONE_WIFI_HOME)/source/db \
+	-I$(ONE_WIFI_HOME)/lib/common \
+	-I$(ONE_WIFI_HOME)/lib/log \
+	-I$(ONE_WIFI_HOME)/lib/ds \
+	-I$(ONE_WIFI_HOME)/lib/ovsdb \
+	-I$(ONE_WIFI_HOME)/lib/pjs \
+	-I$(ONE_WIFI_HOME)/lib/json_util \
+	-I$(ONE_WIFI_HOME)/lib/inc \
+	-I$(ONE_WIFI_HOME)/lib/osa \
+	-I$(ONE_WIFI_HOME)/lib/const \
+	-I$(ONE_WIFI_HOME)/lib/schema \
+	-I$(ONE_WIFI_HOME)/lib/datapipeline \
+	-I$(WIFI_HAL_INTERFACE) \
+	-I/usr/local/ssl/include/ \
+	-I/usr/include/libnl3 \
+	-I$(WIFI_HOSTAP_BASE) \
+	-I$(WIFI_HOSTAP_SRC) \
+	-I$(WIFI_HOSTAP_SRC)/ap \
+	-I$(WIFI_NETLINK)/include \
+	-I$(WIFI_TROWER_BASE) \
+
+LIBDIRS = \
+	-L$(INSTALLDIR)/lib \
+	-L/usr/local/lib    \
+	-L/usr/local/ssl/lib/ \
+
+ifneq ($(OS), Darwin)
+LIBDIRS += -L$(INSTALLDIR)/lib/platform/x86-64
+else
+LIBDIRS += -L$(INSTALLDIR)/lib/platform/darwin
+endif
+
+LIBS = -lm -luuid -lwifihal  -lpthread -ldl -ljansson -lev -lssl -lcrypto -lnl-3 -lnl-genl-3 -lnl-route-3 -lavro -lcjson
+
+#
+# The CXXSOURCES macro contains a list of source files.
+#
+# The CXXOBJECTS macro converts the CXXSOURCES macro into a list
+# of object files.
+#
+# The CFLAGS macro contains a list of options to be passed to
+# the compiler.  Adding "-g" to this line will cause the compiler
+# to add debugging information to the executable.
+#
+# The CXX macro defines the C++ compiler.
+#
+# The LDFLAGS macro contains all of the library and library
+# directory information to be passed to the linker.
+#
+
+CSOURCES = $(wildcard $(ONE_WIFI_HOME)/source/db/wifi_db.c) \
+	$(filter-out $(ONE_WIFI_HOME)/source/core/services/vap_svc_mesh_pod.c,$(wildcard $(ONE_WIFI_HOME)/source/core/services/*.c)) \
+	$(wildcard $(ONE_WIFI_HOME)/source/apps/*.c) \
+	$(wildcard $(ONE_WIFI_HOME)/source/apps/linkquality/*.c) \
+	$(wildcard $(ONE_WIFI_HOME)/source/stubs/*.c) \
+	$(wildcard $(ONE_WIFI_HOME)/source/stats/*.c)	\
+	$(ONE_WIFI_HOME)/lib/common/util.c		\
+	$(ONE_WIFI_HOME)/source/core/wifi_8021x.c	\
+	$(ONE_WIFI_HOME)/source/core/wifi_ctrl_wifiapi_handlers.c	\
+	$(ONE_WIFI_HOME)/source/core/wifi_ctrl.c	\
+	$(ONE_WIFI_HOME)/source/core/wifi_ctrl_rbus_handlers.c	\
+	$(ONE_WIFI_HOME)/source/core/wifi_ctrl_queue_handlers.c	\
+	$(ONE_WIFI_HOME)/source/core/wifi_ctrl_webconfig.c	\
+	$(ONE_WIFI_HOME)/source/core/wifi_multidoc_webconfig.c	\
+	$(ONE_WIFI_HOME)/source/core/wifi_mgr.c	\
+	$(ONE_WIFI_HOME)/source/core/wifi_events.c	\
+	$(ONE_WIFI_HOME)/source/ccsp/ccsp.c \
+	$(ONE_WIFI_HOME)/source/utils/collection.c	\
+	$(ONE_WIFI_HOME)/source/utils/scheduler.c	\
+	$(ONE_WIFI_HOME)/source/utils/mtrx/src/mtrx.c	\
+	$(ONE_WIFI_HOME)/source/dml/linux/wifi_dml.c \
+	$(ONE_WIFI_HOME)/source/platform/linux/misc.c 	\
+	$(ONE_WIFI_HOME)/source/platform/linux/bus.c	\
+	$(ONE_WIFI_HOME)/source/platform/common/common.c   \
+
+WEBCONFIG_SOURCES = $(ONE_WIFI_HOME)/source/webconfig/wifi_decoder.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_encoder.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_associated_client.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_dml.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_home.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_lnf.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_macfilter.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_mesh_backhaul.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_mesh_backhaul_sta.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_mesh.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_mesh_sta.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_null.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_private.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_radio.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_stats_config.c		\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_steering_clients.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_steering_config.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_vif_neighbors.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_wifiapi_radio.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_wifiapi_vap.c		\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_wifi_config.c		\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_xfinity.c		\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_radio_stats.c		\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_neighbor_stats.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_assocdevice_stats.c	\
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_radio_temperature.c    \
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_radiodiag_stats.c    \
+		$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_multivap.c    \
+		$(ONE_WIFI_HOME)/source/utils/wifi_util.c	\
+
+MATH_UTIL_SOURCES = $(wildcard $(ONE_WIFI_HOME)/source/utils/math_utils/src/*.cpp) \
+
+QUALITY_MANAGER_SOURCES = $(wildcard $(ONE_WIFI_HOME)/source/utils/quality_mgr/src/*.cpp) \
+
+HEBUS_SOURCES = $(wildcard $(ONE_WIFI_HOME)/source/platform/linux/he_bus/src/*.c)  \
+
+INCLUDE_HE_LIB_DIRS = \
+	-I$(ONE_WIFI_HOME)/source/platform/linux/he_bus/inc \
+
+ifdef EASY_MESH_NODE
+	INCLUDEDIRS +=  -I$(ONE_WIFI_EM_HOME)/inc
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_easymesh_translator.c
+endif
+
+ifdef ONEWIFI_CSI_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/csi/*.c)	\
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_csi.c
+endif
+
+
+ifdef ONEWIFI_CAC_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/cac/*.c) 	\
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_cac.c
+endif
+
+
+ifdef ONEWIFI_MOTION_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/motion/*.c)
+endif
+
+ifdef ONEWIFI_HARVESTER_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/harvester/*.c) 	\
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_harvester.c
+endif
+
+ifdef ONEWIFI_LEVL_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/levl/*.c) 	\
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_levl.c
+endif
+
+ifdef ONEWIFI_WHIX_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/whix/*.c)
+endif
+
+ifdef ONEWIFI_BLASTER_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/blaster/*.c) \
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_blaster.c
+endif
+
+ifdef ONEWIFI_EASYCONNECT_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/easyconnect/*.c)
+endif
+
+ifdef ONEWIFI_STA_MGR_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/sta_mgr/*.c)
+endif
+
+ifdef ONEWIFI_MEMWRAPTOOL_APP_SUPPORT
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/memwraptool/*.c)    \
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_memwraptool.c
+endif
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_ignite.c
+
+ifdef EM_APP
+	#INCLUDEDIRS +=  -I$(ONE_WIFI_HOME)/source/apps/em
+	CSOURCES += $(wildcard $(ONE_WIFI_HOME)/source/apps/em/*.c)
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_easymesh_config.c    \
+				$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_beacon_report.c  \
+				$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_em_channel_stats.c  \
+				$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_em_sta_link_metrics.c \
+				$(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_em_ap_metrics_report.c
+endif
+	WEBCONFIG_SOURCES += $(ONE_WIFI_HOME)/source/webconfig/wifi_webconfig_link_report.c
+
+COBJECTS = $(CSOURCES:.c=.o)  # expands to list of object files
+
+WEBCONFIG_OBJECTS = $(WEBCONFIG_SOURCES:.c=.o)  # expands to list of object files
+ALL_WEBCFG_LIB_OBJECTS = $(WEBCONFIG_OBJECTS)
+
+MATH_UTIL_OBJECTS = $(MATH_UTIL_SOURCES:.cpp=.o)  # expands to list of object files
+ALL_MATH_UTIL_LIB_OBJECTS = $(MATH_UTIL_OBJECTS)
+
+QUALITY_MANAGER_OBJECTS = $(QUALITY_MANAGER_SOURCES:.cpp=.o)  # expands to list of object files
+ALL_QUALITY_MANAGER_LIB_OBJECTS = $(QUALITY_MANAGER_OBJECTS)
+
+HEBUS_OBJECTS = $(HEBUS_SOURCES:.c=.o)  # expands to list of object files
+ALL_HEBUS_LIB_OBJECTS = $(HEBUS_OBJECTS)
+
+ALLOBJECTS = $(CXXOBJECTS) $(COBJECTS) $(WEBCONFIG_OBJECTS) $(MATH_UTIL_OBJECTS) $(QUALITY_MANAGER_OBJECTS) $(HEBUS_OBJECTS)
+
+CFLAGS = $(INCLUDEDIRS) $(INCLUDE_HE_LIB_DIRS) -g -fPIC -D_ANSC_LINUX -D_COSA_INTEL_USG_ATOM_ -DUSE_NOTIFY_COMPONENT -DCISCO_XB3_PLATFORM_CHANGES -DDUAL_CORE_XB3 -DFEATURE_ONE_WIFI -DWIFI_HAL_VERSION_3 -DFEATURE_SUPPORT_PASSPOINT -DFEATURE_SUPPORT_WEBCONFIG -DRASPBERRY_PI_PORT  -DNL80211_ACL -D_PLATFORM_RASPBERRYPI_ -DEASY_MESH_NODE  -DEM_APP \
+		-DONEWIFI_STA_MGR_APP_SUPPORT
+
+ifneq ($(OS), Darwin)
+CFLAGS += -DPLATFORM_LINUX
+else
+CFLAGS += -DPLATFORM_OSX
+endif
+
+LDFLAGS = $(LIBDIRS) $(LIBS)
+
+$(BUILD_DIR):
+	@mkdir -p $(INSTALLDIR)/lib
+	@mkdir -p $(INSTALLDIR)/bin
+#
+# Default target: the first target is the default target.
+# Just type "make -f Makefile.Linux" to build it.
+#
+
+
+all:  $(BUILD_DIR) $(CMN_LIBRARY) $(HAL_LIBRARY) $(WEBCONFIG_LIBRARY) $(HE_BUS_LIBRARY) $(PROGRAM) test
+
+$(CMN_LIBRARY): $(ALL_CMN_LIB_OBJECTS)
+	$(AR)  $@  $^
+
+$(HAL_LIBRARY): $(ALL_HAL_LIB_OBJECTS)
+	$(AR)  $@  $^
+
+$(WEBCONFIG_LIBRARY): $(ALL_WEBCFG_LIB_OBJECTS)
+	$(AR)  $@  $^
+
+$(HE_BUS_LIBRARY): $(ALL_HEBUS_LIB_OBJECTS)
+	$(AR)  $@  $^
+#
+# Link target: automatically builds its object dependencies before
+# executing its link command.
+#
+
+$(PROGRAM): $(ALLOBJECTS)
+	$(CXX) -o $@ $(ALLOBJECTS) $(LDFLAGS)
+
+#
+# Object targets: rules that define objects, their dependencies, and
+# a list of commands for compilation.
+#
+
+%.o: %.c
+	$(CC) $(CMN_LIB_FLAGS) $(CFLAGS) $(HAL_LIB_FLAGS) $(HOSTAP_LIB_FLAGS) -o $@ -c $<
+
+%.o: %.cpp
+	$(CXX) $(CFLAGS) -o $@ -c $<
+
+#
+# Clean target: "make -f Makefile.Linux clean" to remove unwanted objects and executables.
+#
+
+clean:
+	$(RM) $(ALLOBJECTS) $(ALL_CMN_LIB_OBJECTS) $(ALL_HAL_LIB_OBJECTS) $(CMN_LIBRARY) $(HE_BUS_LIBRARY) $(WEBCONFIG_LIBRARY) $(HAL_LIBRARY) $(HOSTAP_LIBRARY) $(PROGRAM) $(GTEST_BINARY)
+
+#
+# Run target: "make -f Makefile.Linux run" to execute the application
+#             You will need to add $(VARIABLE_NAME) for any command line parameters
+#             that you defined earlier in this file.
+#
+
+run:
+	./$(PROGRAM)
+
+setup:
+	./build/linux/rpi/setup.sh
+
+stamgrsetup:
+	./build/linux/stamgr_setup.sh
+
+vapsetup:
+	cp ./build/linux/MultiVap_InterfaceMap.json /nvram/InterfaceMap.json
+	cp ./build/linux/EasymeshCfg.json /nvram/EasymeshCfg.json
+	./build/linux/create_virtual_intf.sh wlan1 4
+
+# gtest build process: we keep the build otherwise identical to the rpi build with the following changes
+# - additional source files covering the gtest main, tests, and platform mocks
+# - replace wifi_mgr.o with wifi_mgr_nomain.o -- identical except that the main function is stripped out
+GTEST_SOURCES = $(ONE_WIFI_HOME)/source/test/gtest_main.cpp \
+				$(ONE_WIFI_HOME)/source/test/wifi_ctrl_webconfig_test.cpp 
+
+PLATFORM_MOCK_SOURCES = $(ONE_WIFI_HOME)/source/test/platform_mocks.c
+
+GTEST_OBJECTS = $(GTEST_SOURCES:.cpp=.o)
+GTEST_ALLOBJECTS = $(patsubst %wifi_mgr.o,%wifi_mgr_nomain.o, $(ALLOBJECTS))
+PLATFORM_MOCK_OBJECTS = $(PLATFORM_MOCK_SOURCES:.c=.o)
+GTEST_BINARY = OneWifi_gtest.bin
+
+$(GTEST_BINARY): $(GTEST_ALLOBJECTS) $(PLATFORM_MOCK_OBJECTS) $(GTEST_OBJECTS) $(CMN_LIBRARY) $(HAL_LIBRARY) $(WEBCONFIG_LIBRARY) $(HE_BUS_LIBRARY)
+	$(CXX) -o $@ $(GTEST_ALLOBJECTS) $(GTEST_OBJECTS) $(PLATFORM_MOCK_OBJECTS) $(LDFLAGS) --coverage -lgtest -lgmock
+
+%wifi_mgr_nomain.o: %wifi_mgr.o
+	objcopy --strip-symbol=main $^ $@
+
+test: OneWifi_gtest.bin
+	./OneWifi_gtest.bin

--- a/source/test/gtest_main.cpp
+++ b/source/test/gtest_main.cpp
@@ -1,15 +1,15 @@
 /************************************************************************************
   If not stated otherwise in this file or this component's LICENSE file the
   following copyright and licenses apply:
-  
+
   Copyright 2018 RDK Management
-  
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
   http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/source/test/platform_mocks.c
+++ b/source/test/platform_mocks.c
@@ -1,0 +1,98 @@
+/************************************************************************************
+  If not stated otherwise in this file or this component's LICENSE file the
+  following copyright and licenses apply:
+
+  Copyright 2025 RDK Management
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ **************************************************************************/
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include "wifi_hal.h"
+#include "wifi_hal_priv.h"
+
+
+#define NULL_CHAR '\0'
+#define NEW_LINE '\n'
+#define MAX_BUF_SIZE 128
+#define MAX_CMD_SIZE 1024
+#define MOCK_LEN_32 32
+#define MOCK_LEN_16 16
+#define MAX_KEYPASSPHRASE_LEN 129
+#define MAX_SSID_LEN 33
+#define INVALID_KEY  "12345678"
+
+
+int wifi_rrm_send_beacon_req(struct wifi_interface_info_t *interface, const u8 *addr,
+    u16 num_of_repetitions, u8 measurement_request_mode, u8 oper_class, u8 channel,
+    u16 random_interval, u16 measurement_duration, u8 mode, const u8 *bssid,
+    struct wpa_ssid_value *ssid, u8 *rep_cond, u8 *rep_cond_threshold, u8 *rep_detail,
+    const u8 *ap_ch_rep, unsigned int ap_ch_rep_len, const u8 *req_elem, unsigned int req_elem_len,
+    u8 *ch_width, u8 *ch_center_freq0, u8 *ch_center_freq1, u8 last_indication)
+{
+    return 0;
+}
+
+/* called by BTM API */
+int wifi_wnm_send_bss_tm_req(struct wifi_interface_info_t *interface, struct sta_info *sta,
+    u8 dialog_token, u8 req_mode, int disassoc_timer, u8 valid_int, const u8 *bss_term_dur,
+    const char *url, const u8 *nei_rep, size_t nei_rep_len, const u8 *mbo_attrs, size_t mbo_len)
+{
+    return 0;
+}
+
+int handle_wnm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
+    struct ieee80211_mgmt *mgmt, size_t len)
+{
+    return 0;
+}
+
+int handle_rrm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
+    const struct ieee80211_mgmt *mgmt, size_t len, int ssi_signal)
+{
+    return 0;
+}
+
+#ifdef CONFIG_IEEE80211BE
+int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
+    struct wpa_driver_ap_params *params)
+{
+    (void)msg;
+    (void)msg_mlo;
+    (void)priv;
+    (void)params;
+
+    return 0;
+}
+
+int nl80211_send_mlo_msg(struct nl_msg *msg)
+{
+    (void)msg;
+
+    return 0;
+}
+
+void wifi_drv_get_phy_eht_cap_mac(struct eht_capabilities *eht_capab, struct nlattr **tb)
+{
+    (void)eht_capab;
+    (void)tb;
+}
+
+int update_hostap_mlo(wifi_interface_info_t *interface)
+{
+    (void)interface;
+
+    return 0;
+}
+#endif /* CONFIG_IEEE80211BE */

--- a/source/test/wifi_ctrl_webconfig_test.cpp
+++ b/source/test/wifi_ctrl_webconfig_test.cpp
@@ -1,0 +1,226 @@
+/************************************************************************************
+  If not stated otherwise in this file or this component's LICENSE file the
+  following copyright and licenses apply:
+
+  Copyright 2025 RDK Management
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ **************************************************************************/
+#include <gtest/gtest.h>
+#include "wifi_webconfig.h"
+#include "source/core/wifi_ctrl.h"
+#include "source/core/wifi_mgr.h"
+
+
+extern "C" {
+    int webconfig_vif_neighbors_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data);
+    // note: the ctrl argument is not used in this function
+}
+
+// test covering NULL argument case from RDKBWIFI-201
+TEST(WifiCtrlWebconfig, VifNeighborsApplyNullArguments)
+{
+    ASSERT_EXIT((webconfig_vif_neighbors_apply(NULL, NULL), exit(0)), ::testing::ExitedWithCode(0), ".*");
+    // expected that RETURN_ERR is -1, but use the macro if possible
+    ASSERT_EQ(webconfig_vif_neighbors_apply(NULL, NULL), RETURN_ERR);
+}
+
+TEST(WifiCtrlWebconfig, VifNeighborsApplyNullNeighborsMap)
+{
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.vif_neighbors_map = NULL;
+    ASSERT_EXIT((webconfig_vif_neighbors_apply(NULL, &data), exit(0)), ::testing::ExitedWithCode(0), ".*");
+
+    // expected that RETURN_ERR is -1, but use the macro if possible
+    ASSERT_EQ(webconfig_vif_neighbors_apply(NULL, &data), RETURN_ERR);
+}
+
+TEST(WifiCtrlWebconfig, VifNeighborsApplyHappyPathEmptyHashMap)
+{
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.vif_neighbors_map = hash_map_create();
+
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+    mgr->vif_neighbors_map = hash_map_create();
+
+    ASSERT_EQ(webconfig_vif_neighbors_apply(NULL, &data), RETURN_OK);
+
+    hash_map_destroy(mgr->vif_neighbors_map);
+    mgr->vif_neighbors_map = NULL;
+}
+
+/**
+    data.vif_neighbors_map is destroyed by webconfig_vif_neighbors_apply, but the
+    pointer is not set to NULL -- which is dangerous! this test should replace the
+    above test when this issue is fixed
+**/
+TEST(WifiCtrlWebconfig, DISABLED_VifNeighborsApplyHappyPathCheckDestroyedMapPtr)
+{
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.vif_neighbors_map = hash_map_create();
+
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+    mgr->vif_neighbors_map = hash_map_create();
+
+    ASSERT_EQ(webconfig_vif_neighbors_apply(NULL, &data), RETURN_OK);
+
+    // this should really be null, since it's been destroyed!
+    ASSERT_EQ(data.vif_neighbors_map, nullptr);
+
+    hash_map_destroy(mgr->vif_neighbors_map);
+    mgr->vif_neighbors_map = NULL;
+}
+
+extern "C" {
+    int webconfig_steering_config_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data);
+}
+
+// test covering NULL argument case from RDKBWIFI-200
+TEST(WifiCtrlWebconfig, SteeringConfigApplyNullArguments)
+{
+    ASSERT_EXIT((webconfig_steering_config_apply(NULL, NULL), exit(0)), ::testing::ExitedWithCode(0), ".*");
+    // expected that RETURN_ERR is -1, butuse the macro if possible
+    ASSERT_EQ(webconfig_steering_config_apply(NULL, NULL), RETURN_ERR);
+}
+
+TEST(WifiCtrlWebconfig, SteeringConfigApplyNullSteeringConfigMap)
+{
+    // expected that RETURN_ERR is -1, butuse the macro if possible
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.steering_config_map = NULL;
+
+    ASSERT_EQ(webconfig_steering_config_apply(NULL, &data), RETURN_ERR);
+}
+
+TEST(WifiCtrlWebconfig, SteeringConfigApplySameSteeringConfigMap)
+{
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.steering_config_map = hash_map_create();
+    mgr->steering_config_map = data.steering_config_map;
+
+    ASSERT_EQ(webconfig_steering_config_apply(NULL, &data), RETURN_OK);
+
+    mgr->steering_config_map = NULL;
+}
+
+TEST(WifiCtrlWebconfig, SteeringConfigApplyEmptySteeringConfigMap)
+{
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.steering_config_map = hash_map_create();
+    mgr->steering_config_map = hash_map_create();
+
+    ASSERT_EQ(webconfig_steering_config_apply(NULL, &data), RETURN_OK);
+
+    hash_map_destroy(mgr->steering_config_map);
+    mgr->steering_config_map = NULL;
+}
+
+extern "C" {
+    int webconfig_steering_clients_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data);
+}
+
+// test covering NULL argument case from RDKBWIFI-199
+TEST(WifiCtrlWebconfig, SteeringClientsApplyNullArguments)
+{
+    ASSERT_EXIT((webconfig_steering_clients_apply(NULL, NULL), exit(0)), ::testing::ExitedWithCode(0), ".*");
+    // expected that RETURN_ERR is -1, butuse the macro if possible
+    ASSERT_EQ(webconfig_steering_clients_apply(NULL, NULL), RETURN_ERR);
+}
+
+TEST(WifiCtrlWebconfig, SteeringClientsApplyNullClientMap)
+{
+    // expected that RETURN_ERR is -1, butuse the macro if possible
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.steering_client_map = NULL;
+
+    ASSERT_EQ(webconfig_steering_clients_apply(NULL, &data), RETURN_ERR);
+}
+
+TEST(WifiCtrlWebconfig, SteeringClientsApplyEmptyClientMap)
+{
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.steering_client_map = hash_map_create();
+    mgr->steering_client_map = data.steering_client_map;
+
+    ASSERT_EQ(webconfig_steering_clients_apply(NULL, &data), RETURN_OK);
+
+    mgr->steering_client_map = NULL;
+}
+
+TEST(WifiCtrlWebconfig, SteeringClientsSameClientMap)
+{
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.steering_client_map = hash_map_create();
+    mgr->steering_client_map = hash_map_create();
+
+    ASSERT_EQ(webconfig_steering_clients_apply(NULL, &data), RETURN_OK);
+
+    hash_map_destroy(mgr->steering_client_map);
+    mgr->steering_client_map = NULL;
+}
+
+extern "C" {
+    int webconfig_stats_config_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t *data);
+}
+
+// test covering NULL argument case from RDKBWIFI-198
+TEST(WifiCtrlWebconfig, StatsConfigApplyNullArguments)
+{
+    ASSERT_EXIT((webconfig_stats_config_apply(NULL, NULL), exit(0)), ::testing::ExitedWithCode(0), ".*");
+    // expected that RETURN_ERR is -1, butuse the macro if possible
+    ASSERT_EQ(webconfig_stats_config_apply(NULL, NULL), RETURN_ERR);
+}
+
+TEST(WifiCtrlWebconfig, StatsConfigsApplyNullStatsConfigMap)
+{
+    // expected that RETURN_ERR is -1, butuse the macro if possible
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.stats_config_map = NULL;
+
+    ASSERT_EQ(webconfig_stats_config_apply(NULL, &data), RETURN_ERR);
+}
+
+TEST(WifiCtrlWebconfig, StatsConfigApplyEmptyStatsConfigMap)
+{
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.stats_config_map = hash_map_create();
+    mgr->stats_config_map = data.stats_config_map;
+
+    ASSERT_EQ(webconfig_stats_config_apply(NULL, &data), RETURN_OK);
+
+    mgr->stats_config_map = NULL;
+}
+
+TEST(WifiCtrlWebconfig, StatsConfigSameStatsConfigMap)
+{
+    wifi_mgr_t *mgr = get_wifimgr_obj();
+
+    webconfig_subdoc_decoded_data_t data = {0};
+    data.stats_config_map = hash_map_create();
+    mgr->stats_config_map = hash_map_create();
+
+    ASSERT_EQ(webconfig_stats_config_apply(NULL, &data), RETURN_OK);
+
+    hash_map_destroy(mgr->stats_config_map);
+    mgr->stats_config_map = NULL;
+}


### PR DESCRIPTION
…ependent L1 tests (#702)

* RDKBWIFI-206: add mocks and build for platform independent L1 tests

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

* RDKBWIFI-206: add unittests for wifi_ctrl_webconfig.c

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

* remove symbols that are no longer necessary to mock

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

* update mockplatform/makefile to match recent updates

* remove wifi_sensing from the Makefile again to work with latest changes

* more explicitly use the rpi setup.sh script as the intent is to be identical

* minor naming conventions and typo updates

* update mockplatform makefile for multi_ap includes
Signed-off-by:   Fritz Heckel <fwph@fwph.net>
