### PR TITLE
RDKBWIFI-538: Reject webconfig set when the owning handler is not registered yet

### DIFF
--- a/source/platform/common/bus_common.h
+++ b/source/platform/common/bus_common.h
@@ -140,7 +140,8 @@ typedef enum bus_error
     bus_error_nosubscribers,                   /**< No subscribers present   */
     bus_error_subscription_already_exist,      /**< The subscription already exists*/
     bus_error_invalid_namespace,               /**< Invalid namespace as per standard */
-    bus_error_direct_con_not_exist             /**< Direct connection not exist */
+    bus_error_direct_con_not_exist,            /**< Direct connection not exist */
+    bus_error_not_writable                     /**< Element exists but cannot be modified */
 } bus_error_t;
 
 typedef enum child_node_ref {

--- a/source/platform/rdkb/bus.c
+++ b/source/platform/rdkb/bus.c
@@ -218,6 +218,9 @@ bus_error_t convert_rbus_to_bus_error_code(rbusError_t rbus_error)
         case RBUS_ERROR_DIRECT_CON_NOT_EXIST:
             bus_error = bus_error_direct_con_not_exist;
         break;
+        case RBUS_ERROR_NOT_WRITABLE:
+            bus_error = bus_error_not_writable;
+        break;
         default:
             bus_error = bus_error_general;
             wifi_util_error_print(WIFI_BUS, "%s:%d unsupported rbus error code:%02x\r\n", __func__, __LINE__, rbus_error);
@@ -312,6 +315,9 @@ rbusError_t convert_bus_to_rbus_error_code(bus_error_t bus_error)
         break;
         case bus_error_direct_con_not_exist:
             rbus_error = RBUS_ERROR_DIRECT_CON_NOT_EXIST;
+        break;
+        case bus_error_not_writable:
+            rbus_error = RBUS_ERROR_NOT_WRITABLE;
         break;
         default:
             rbus_error = RBUS_ERROR_BUS_ERROR;
@@ -931,6 +937,12 @@ rbusError_t rbus_set_handler(rbusHandle_t handle, rbusProperty_t property, rbusS
                     __LINE__, ret, event_name);
             }
         }
+    } else {
+        /* Handler not mapped yet (startup window): the payload is not delivered,
+         * so do not report success. */
+        wifi_util_error_print(WIFI_BUS,"%s:%d rbus event:%s set handler not registered yet, rejecting set\n",
+            __func__, __LINE__, event_name);
+        ret = bus_error_not_writable;
     }
 
     return convert_bus_to_rbus_error_code(ret);


### PR DESCRIPTION
During startup the webconfig south element is registered with the bus mux before the WifiCtrl component maps its user set handler. A set arriving in that window hit "if (user_cb->set_handler != NULL)" with no else branch, so rbus_set_handler returned success while silently dropping the payload. The EasyMesh agent's Vap subdocs sent right after WSC M2 were lost this way and onboarding deadlocked. Return bus_error_destination_not_found so the setter learns the delivery failed.