### PR TITLE
RDKB-65569 :  [XB10][RDKB] WiFi management service crashes with finge…

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1025,6 +1025,9 @@ static int reset_interop_sta_data(void *arg) {
 int harvester_get_associated_device_info(int vap_index, char **harvester_buf)
 {
     unsigned int pos = 0;
+    int written = 0;
+    unsigned int remaining = 0;
+    const unsigned int json_trailer_len = sizeof("]}]}");
     sta_data_t *sta_data = NULL;
     unsigned int sta_count = 0;
     unsigned int buf_size = CLIENTDIAG_JSON_BUFFER_SIZE * (sizeof(char)) * BSS_MAX_NUM_STATIONS;
@@ -1043,18 +1046,19 @@ int harvester_get_associated_device_info(int vap_index, char **harvester_buf)
     pthread_mutex_lock(&g_monitor_module.data_lock);
     sta_data = hash_map_get_first(g_monitor_module.bssid_data[vap_index].sta_map);
     while (sta_data != NULL) {
-            /* Bounds check: stop serializing if we are approaching buffer limit.
-             * Reserve 64 bytes for the closing JSON brackets and null terminator.
-             */
-            if (pos >= (buf_size - 64)) {
-                wifi_util_error_print(WIFI_MON,
-                    "%s %d Buffer overflow prevented for vap %d, pos=%u buf_size=%u sta_count=%u\n",
-                    __func__, __LINE__, vap_index, pos, buf_size, sta_count);
-                break;
-            }
-            sta_count++;
-            pos += snprintf(&harvester_buf[vap_index][pos],
-                        buf_size - pos, "{"
+
+        if (pos >= buf_size || (buf_size - pos) <= json_trailer_len) {
+            wifi_util_error_print(WIFI_MON,
+                "%s %d Buffer limit reached for vap %d, pos=%u buf_size=%u sta_count=%u\n",
+                __func__, __LINE__, vap_index, pos, buf_size, sta_count);
+            break;
+        }
+
+        remaining = buf_size - pos;
+        sta_count++;
+
+        written = snprintf(&harvester_buf[vap_index][pos],
+                remaining, "{"
                         "\"MAC\":\"%02x%02x%02x%02x%02x%02x\","
                         "\"MLDMAC\":\"%02x%02x%02x%02x%02x%02x\","
                         "\"MLDEnable\":\"%d\","
@@ -1121,8 +1125,24 @@ int harvester_get_associated_device_info(int vap_index, char **harvester_buf)
                         sta_data->dev_stats.cli_Disassociations,
                         sta_data->dev_stats.cli_Retransmissions);
 
+        if (written < 0) {
+            wifi_util_error_print(WIFI_MON,
+                "%s %d snprintf failed for vap %d at sta_count=%u\n",
+               __func__, __LINE__, vap_index, sta_count);
+            break;
+        }
 
-        sta_data = hash_map_get_next(g_monitor_module.bssid_data[vap_index].sta_map, sta_data);
+        if ((unsigned int)written >= remaining) {
+            wifi_util_error_print(WIFI_MON,
+                "%s %d STA entry truncated for vap %d, stopping serialization pos=%u remaining=%u sta_count=%u\n",
+               __func__, __LINE__, vap_index, pos, remaining, sta_count);
+            harvester_buf[vap_index][pos] = '\0';
+           break;
+        }
+
+        pos += (unsigned int)written;
+
+	sta_data = hash_map_get_next(g_monitor_module.bssid_data[vap_index].sta_map, sta_data);
 
     }
     pthread_mutex_unlock(&g_monitor_module.data_lock);

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1026,12 +1026,13 @@ int harvester_get_associated_device_info(int vap_index, char **harvester_buf)
 {
     unsigned int pos = 0;
     sta_data_t *sta_data = NULL;
+    unsigned int sta_count = 0;
+    unsigned int buf_size = CLIENTDIAG_JSON_BUFFER_SIZE * (sizeof(char)) * BSS_MAX_NUM_STATIONS;
     if (harvester_buf[vap_index] == NULL) {
         wifi_util_dbg_print(WIFI_MON, "%s %d Harvester Buffer is NULL\n", __func__, __LINE__);
         return RETURN_ERR;
     }
-    pos = snprintf(harvester_buf[vap_index],
-                CLIENTDIAG_JSON_BUFFER_SIZE*(sizeof(char))*BSS_MAX_NUM_STATIONS,
+    pos = snprintf(harvester_buf[vap_index], buf_size,
                 "{"
                 "\"Version\":\"1.0\","
                 "\"AssociatedClientsDiagnostics\":["
@@ -1042,8 +1043,18 @@ int harvester_get_associated_device_info(int vap_index, char **harvester_buf)
     pthread_mutex_lock(&g_monitor_module.data_lock);
     sta_data = hash_map_get_first(g_monitor_module.bssid_data[vap_index].sta_map);
     while (sta_data != NULL) {
-        pos += snprintf(&harvester_buf[vap_index][pos],
-                (CLIENTDIAG_JSON_BUFFER_SIZE*(sizeof(char))*BSS_MAX_NUM_STATIONS)-pos, "{"
+            /* Bounds check: stop serializing if we are approaching buffer limit.
+             * Reserve 64 bytes for the closing JSON brackets and null terminator.
+             */
+            if (pos >= (buf_size - 64)) {
+                wifi_util_error_print(WIFI_MON,
+                    "%s %d Buffer overflow prevented for vap %d, pos=%u buf_size=%u sta_count=%u\n",
+                    __func__, __LINE__, vap_index, pos, buf_size, sta_count);
+                break;
+            }
+            sta_count++;
+            pos += snprintf(&harvester_buf[vap_index][pos],
+                        buf_size - pos, "{"
                         "\"MAC\":\"%02x%02x%02x%02x%02x%02x\","
                         "\"MLDMAC\":\"%02x%02x%02x%02x%02x%02x\","
                         "\"MLDEnable\":\"%d\","

--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -248,6 +248,42 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
             free(dev_array);
             dev_array = NULL;
         }
+
+        /* wifi_getApAssociatedDeviceDiagnosticResult3 failed - still perform stale entry cleanup on sta_map to prevent
+         * unbounded growth, entries added by process_connect() would never be cleaned up, eventually
+         * causing buffer overflow in harvester_get_associated_device_info().
+         */
+        pthread_mutex_lock(&mon_data->data_lock);
+        sta_map = mon_data->bssid_data[vap_array_index].sta_map;
+        if (sta_map != NULL) {
+            struct timespec tv_now_err;
+            clock_gettime(CLOCK_MONOTONIC, &tv_now_err);
+            sta = hash_map_get_first(sta_map);
+            while (sta != NULL) {
+                tmp_sta = NULL;
+                if (sta->dev_stats.cli_Active == false &&
+                    timespecisset(&(sta->last_disconnected_time))) {
+                    unsigned int disc_time = tv_now_err.tv_sec - sta->last_disconnected_time.tv_sec;
+                    if (disc_time > mon_data->bssid_data[vap_array_index].ap_params.rapid_reconnect_threshold) {
+                        tmp_sta = sta;
+                    }
+                }
+                sta = hash_map_get_next(sta_map, sta);
+                if (tmp_sta != NULL) {
+                    sta_key_t rm_key;
+                    to_sta_key(tmp_sta->sta_mac, rm_key);
+                    wifi_util_info_print(WIFI_MON,
+                        "%s:%d wifi_getApAssociatedDeviceDiagnosticResult3 failed: removing stale device %s from map of ap:%d\n",
+                        __func__, __LINE__, rm_key, args->vap_index);
+                    tmp_sta = hash_map_remove(sta_map, rm_key);
+                    if (tmp_sta != NULL) {
+                        free(tmp_sta);
+                        tmp_sta = NULL;
+                    }
+                }
+            }
+        }
+        pthread_mutex_unlock(&mon_data->data_lock);
         return RETURN_ERR;
     }
 

--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -249,34 +249,73 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
             dev_array = NULL;
         }
 
-        /* wifi_getApAssociatedDeviceDiagnosticResult3 failed - still perform stale entry cleanup on sta_map to prevent
-         * unbounded growth, entries added by process_connect() would never be cleaned up, eventually
-         * causing buffer overflow in harvester_get_associated_device_info().
-         */
+        /* HAL call failed: still clean stale sta_map entries and preserve disconnect semantics. */
+        disconnect_event_queue = queue_create();
+        if (disconnect_event_queue == NULL) {
+            wifi_util_error_print(WIFI_MON, "%s:%d Failed to create queue\n", __func__, __LINE__);
+        }
+
         pthread_mutex_lock(&mon_data->data_lock);
         sta_map = mon_data->bssid_data[vap_array_index].sta_map;
         if (sta_map != NULL) {
             struct timespec tv_now_err;
             clock_gettime(CLOCK_MONOTONIC, &tv_now_err);
+
+            wifi_util_info_print(WIFI_MON,
+                "%s:%d HAL failure cleanup start vap:%d sta_map_count:%u\n",
+                __func__, __LINE__, args->vap_index, hash_map_count(sta_map));
+
             sta = hash_map_get_first(sta_map);
             while (sta != NULL) {
+                int send_disconnect_event = 1;
                 tmp_sta = NULL;
-                if (sta->dev_stats.cli_Active == false &&
-                    timespecisset(&(sta->last_disconnected_time))) {
-                    unsigned int disc_time = tv_now_err.tv_sec - sta->last_disconnected_time.tv_sec;
-                    if (disc_time > mon_data->bssid_data[vap_array_index].ap_params.rapid_reconnect_threshold) {
+
+                if (timespecisset(&(sta->total_connected_time))) {
+                    if ((sta->dev_stats.cli_Active == false) &&
+                        timespecisset(&(sta->last_disconnected_time))) {
+                        disconnected_time =
+                            (tv_now_err.tv_sec - sta->last_disconnected_time.tv_sec);
+                        if (disconnected_time > mon_data->bssid_data[vap_array_index]
+                                                    .ap_params.rapid_reconnect_threshold) {
+                            tmp_sta = sta;
+                        }
+                    }
+                } else {
+                    /* Assoc-request-only: remove stale entries after 5 seconds, no disconnect event. */
+                    if ((sta->assoc_frame_data.frame_timestamp != 0) &&
+                        (tv_now_err.tv_sec - sta->assoc_frame_data.frame_timestamp > 5)) {
+                        send_disconnect_event = 0;
                         tmp_sta = sta;
                     }
                 }
+
                 sta = hash_map_get_next(sta_map, sta);
+
                 if (tmp_sta != NULL) {
-                    sta_key_t rm_key;
-                    to_sta_key(tmp_sta->sta_mac, rm_key);
-                    wifi_util_info_print(WIFI_MON,
-                        "%s:%d wifi_getApAssociatedDeviceDiagnosticResult3 failed: removing stale device %s from map of ap:%d\n",
-                        __func__, __LINE__, rm_key, args->vap_index);
-                    tmp_sta = hash_map_remove(sta_map, rm_key);
+                    memset(sta_key, 0, sizeof(sta_key_t));
+                    to_sta_key(tmp_sta->sta_mac, sta_key);
+
+                    if ((send_disconnect_event == 1) && (disconnect_event_queue != NULL)) {
+                        mac_addr = (unsigned char *)malloc(sizeof(mac_address_t));
+                        if (mac_addr != NULL) {
+                            memcpy(mac_addr, tmp_sta->sta_mac, sizeof(mac_address_t));
+                            if (queue_push(disconnect_event_queue, mac_addr) == -1) {
+                                wifi_util_error_print(WIFI_MON,
+                                    "%s:%d Failed to push mac_addr %02x:%02x:%02x:%02x:%02x:%02x to queue\n",
+                                    __func__, __LINE__, mac_addr[0], mac_addr[1], mac_addr[2],
+                                    mac_addr[3], mac_addr[4], mac_addr[5]);
+                                free(mac_addr);
+                                mac_addr = NULL;
+                            }
+                        }
+                    }
+
+                    tmp_sta = hash_map_remove(sta_map, sta_key);
                     if (tmp_sta != NULL) {
+                        wifi_util_info_print(WIFI_MON,
+                            "%s:%d HAL failure cleanup removed vap:%d sta:%s reason:%s\n",
+                            __func__, __LINE__, args->vap_index, sta_key,
+                            (send_disconnect_event == 1) ? "stale_disconnected" : "stale_assoc_only");
                         free(tmp_sta);
                         tmp_sta = NULL;
                     }
@@ -284,6 +323,18 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
             }
         }
         pthread_mutex_unlock(&mon_data->data_lock);
+
+        if (disconnect_event_queue != NULL) {
+            while (queue_count(disconnect_event_queue) > 0) {
+                mac_addr = (unsigned char *)queue_pop(disconnect_event_queue);
+                if (mac_addr != NULL) {
+                    send_wifi_disconnect_event_to_ctrl(mac_addr, args->vap_index);
+                    free(mac_addr);
+                }
+            }
+            queue_destroy(disconnect_event_queue);
+        }
+
         return RETURN_ERR;
     }
 

--- a/source/stats/wifi_stats_assoc_client.c
+++ b/source/stats/wifi_stats_assoc_client.c
@@ -164,6 +164,7 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
     int mld_mac_present = 0;
     mac_address_t zero_mac = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
     wifi_platform_property_t *wifi_prop = get_wifi_hal_cap_prop();
+    time_t current_timestamp;
     struct timespec tv_now, t_diff, t_tmp;
     unsigned int disconnected_time;
     bool link_quality_measurement = false;
@@ -249,7 +250,17 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
             dev_array = NULL;
         }
 
-        /* HAL call failed: still clean stale sta_map entries and preserve disconnect semantics. */
+        /* wifi_getApAssociatedDeviceDiagnosticResult3 failure
+         * sta_map cleanup to mirroring success path behavior:
+         * 1) For previously connected clients: if cli_Active==false and
+         *    disconnected_time > rapid_reconnect_threshold, remove the entry
+         *    and enqueue disconnect_event for ctrl.
+	 *
+         * 2) For assoc-request-only entries (never connected): if
+         *    frame_timestamp is set and age > 5 seconds, remove the entry
+         *    without sending disconnect_event.
+         */
+
         disconnect_event_queue = queue_create();
         if (disconnect_event_queue == NULL) {
             wifi_util_error_print(WIFI_MON, "%s:%d Failed to create queue\n", __func__, __LINE__);
@@ -259,14 +270,17 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
         sta_map = mon_data->bssid_data[vap_array_index].sta_map;
         if (sta_map != NULL) {
             struct timespec tv_now_err;
+            time_t current_timestamp_err;
             clock_gettime(CLOCK_MONOTONIC, &tv_now_err);
+            time(&current_timestamp_err);
 
             wifi_util_info_print(WIFI_MON,
-                "%s:%d HAL failure cleanup start vap:%d sta_map_count:%u\n",
-                __func__, __LINE__, args->vap_index, hash_map_count(sta_map));
+                "%s:%d  wifi_getApAssociatedDeviceDiagnosticResult3 failure cleanup : start vap:%d sta_map_count:%u threshold:%u\n",
+                __func__, __LINE__, args->vap_index, hash_map_count(sta_map),
+                mon_data->bssid_data[vap_array_index].ap_params.rapid_reconnect_threshold);
 
             sta = hash_map_get_first(sta_map);
-            while (sta != NULL) {
+           while (sta != NULL) {
                 int send_disconnect_event = 1;
                 tmp_sta = NULL;
 
@@ -281,9 +295,11 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
                         }
                     }
                 } else {
-                    /* Assoc-request-only: remove stale entries after 5 seconds, no disconnect event. */
+                    /* Assoc-request-only entry: remove stale entries after 5 seconds,
+                     * but do not send disconnect event.
+                     */
                     if ((sta->assoc_frame_data.frame_timestamp != 0) &&
-                        (tv_now_err.tv_sec - sta->assoc_frame_data.frame_timestamp > 5)) {
+                        (current_timestamp_err - sta->assoc_frame_data.frame_timestamp > 5)) {
                         send_disconnect_event = 0;
                         tmp_sta = sta;
                     }
@@ -307,13 +323,17 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
                                 free(mac_addr);
                                 mac_addr = NULL;
                             }
+                        } else {
+                            wifi_util_error_print(WIFI_MON,
+                                "%s:%d Failed to allocate memory for disconnect event on vap:%d\n",
+                                __func__, __LINE__, args->vap_index);
                         }
                     }
 
                     tmp_sta = hash_map_remove(sta_map, sta_key);
                     if (tmp_sta != NULL) {
                         wifi_util_info_print(WIFI_MON,
-                            "%s:%d HAL failure cleanup removed vap:%d sta:%s reason:%s\n",
+                            "%s:%d  wifi_getApAssociatedDeviceDiagnosticResult3 failure cleanup : removed vap:%d sta:%s reason:%s\n",
                             __func__, __LINE__, args->vap_index, sta_key,
                             (send_disconnect_event == 1) ? "stale_disconnected" : "stale_assoc_only");
                         free(tmp_sta);
@@ -321,6 +341,10 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
                     }
                 }
             }
+        } else {
+            wifi_util_info_print(WIFI_MON,
+                "%s:%d  wifi_getApAssociatedDeviceDiagnosticResult3 failure cleanup : skipped vap:%d sta_map is NULL\n",
+                __func__, __LINE__, args->vap_index);
         }
         pthread_mutex_unlock(&mon_data->data_lock);
 
@@ -329,6 +353,11 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
                 mac_addr = (unsigned char *)queue_pop(disconnect_event_queue);
                 if (mac_addr != NULL) {
                     send_wifi_disconnect_event_to_ctrl(mac_addr, args->vap_index);
+                    wifi_util_info_print(WIFI_MON,
+                        "%s:%d  wifi_getApAssociatedDeviceDiagnosticResult3 failure cleanup : sent disconnect event vap:%d mac:%02x:%02x:%02x:%02x:%02x:%02x\n",
+                        __func__, __LINE__, args->vap_index,
+                        mac_addr[0], mac_addr[1], mac_addr[2],
+                        mac_addr[3], mac_addr[4], mac_addr[5]);
                     free(mac_addr);
                 }
             }
@@ -413,6 +442,7 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
     }
 
     clock_gettime(CLOCK_MONOTONIC, &tv_now);
+    time(&current_timestamp);
     sta_map = mon_data->bssid_data[vap_array_index].sta_map;
 
     if (num_devs != 0) {
@@ -614,7 +644,7 @@ int execute_assoc_client_stats_api(wifi_mon_collector_element_t *c_elem, wifi_mo
                 }
             } else {
                 // client never connected, only storing the assoc request.
-                if (tv_now.tv_sec - sta->assoc_frame_data.frame_timestamp > 5) {
+                if (current_timestamp - sta->assoc_frame_data.frame_timestamp > 5) {
                     // remove this entry after 5 seconds, should not trigger a disconnect event.
                     send_disconnect_event = 0;
                     tmp_sta = sta;


### PR DESCRIPTION
RDKB-65569 : WiFi management service crashes with fingerprint 58928292 on XB10 and XER10 gateways, which can cause brief WiFi interruptions for customers each time it restart


Reason for Change:

--> wifi_getApAssociatedDeviceDiagnosticResult3() was failing continuously as the driver returns early since /tmp/sta_assoc_count is greater than 8096 bytes 

--> wifi_getApAssociatedDeviceDiagnosticResult3() is invoked every 5000ms.

--> When wifi_getApAssociatedDeviceDiagnosticResult3() fails, clean up logic never hits and stale entries in sta_map are never cleaned. This causes  harvester_get_associated_device_info() to overflow its fixed 66,500 bytes harvester_buf when serializing all entries to JSON when populating the harvester_buf on harvester reporting interval.


Fix:

When wifi_getApAssociatedDeviceDiagnosticResult3() fails, we now still clean sta_map the same way as normal flow so stale entries do not keep growing:

1. Old disconnected clients are removed only after they stay inactive longer than rapid_reconnect_threshold.
2. Assoc-request-only entries (never fully connected) are removed after timeout.
3. Disconnect events are sent only for true stale disconnected clients, not for assoc-only cleanup.
4. Assoc timestamp aging now compares epoch time with epoch time (removed epoch vs CLOCK_MONOTONIC comparision).
5. Harvester JSON building is made safe by:
    --> Checking remaining buffer space before each client entry.
    --> Checking snprintf return for error and truncation.
    --> Stop safely on truncation to avoid pointer jump and unsigned underflow.
    --> Keep full per-client buffer budget, reserving only exact bytes needed for JSON closing trailer.

Unit Testing:

1. Connected 42 clients to 5GHz private SSID 

2. Confirmed that all the connected clients are listed under wl -i wl1.1 assoclist

3. Made the /tmp/sta_assoc_count greater than 8096 to simulate the stats fetch failure (as observed in the issue devices in field)

4. Checked /rdklogs/logs/messages.txt and observed 

"2026 Jul 28 07:52:57 Docsis-Gateway kernel: CFG80211-ERROR) wl_cfgvendor_get_assoc_num : Failed to read whole file /tmp/sta_assoc_count

2026 Jul 28 07:52:57 Docsis-Gateway kernel: CFG80211-ERROR) wl_cfgvendor_get_station_reply : Failed to get assoc num, error: -1 

 reply handler return early due to /tmp/sta_assoc_count being more than 8098 bytes and as a result in /rdklogs/logs/wifiMon.txt observe "Failed to get AP Associated Devices statistics for vap index 1" every 5 seconds  

5. Disconnected 15 connected clients

6. Out of 15 disconnected clients, reconnected 5 clients within rapid disconnect threshold (180s) 

7. Checked in /rdklogs/logs/wifiMon.txt.0 that exactly after 180s the 10 disconnected clients (that were not reconnected within 180s) are removed from the sta_map by checking the logs

8. Waited for the next harvester report and saw that there is no disconnected entry in the report. But the reconnected client entries are present as expected.
 
9. Left the device in this state for more than 17 hours, harvester report does not contain any stale entries.

Attaching relevant logs:

[65569_Disconnected_Clients_&_Reconnected_Clients.txt](https://github.com/user-attachments/files/30534252/65569_Disconnected_Clients_._Reconnected_Clients.txt)

[65569_RG_Console_logs.txt](https://github.com/user-attachments/files/30534255/65569_RG_Console_logs.txt)

[harvester_buf_contents.txt](https://github.com/user-attachments/files/30534256/harvester_buf_contents.txt)

 
Priority: P1
Risk: Medium

Signed-off-by: Sake Victor Daniel <VictorDaniel_Sake@comcast.com>