### PR TITLE
XB10-2702 BCOMB-3619: Update default wl_mlo_config nvram setting (#1206)

### DIFF
--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -1,6 +1,6 @@
 {
   "name": "Wifi_Rdk_Database",
-  "version": "1.00.050",
+  "version": "1.00.051",
   "cksum": "2353365742 523",
   "tables": {
     "Wifi_Device_Config": {

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -293,6 +293,21 @@ static int init_interworking_config_default(int vapIndex,
     return 0;
 }
 
+int wifidb_get_default_mld_link_id(int band)
+{
+#if defined(CONFIG_IEEE80211BE) && defined(_XB10_PRODUCT_REQ_)
+    switch (band) {
+    case WIFI_FREQUENCY_2_4_BAND: return 2;
+    case WIFI_FREQUENCY_5_BAND:   return 1;
+    case WIFI_FREQUENCY_6_BAND:   return 0;
+    default:                      return UNDEFINED_MLD_LINK_ID;
+    }
+#else
+    (void)band;
+    return UNDEFINED_MLD_LINK_ID;
+#endif /* CONFIG_IEEE80211BE && _XB10_PRODUCT_REQ_ */
+}
+
 static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
     rdk_wifi_vap_info_t *rdk_config)
 {
@@ -541,11 +556,10 @@ static int init_vap_config_default(int vap_index, wifi_vap_info_t *config,
             cfg.u.bss_info.mld_info.common_info.mld_id = 0;
         }
 #else
-        /*TODO: Are values correct?  */
         cfg.u.bss_info.mld_info.common_info.mld_enable = 0;
         cfg.u.bss_info.mld_info.common_info.mld_id = 255;
-#endif
-        cfg.u.bss_info.mld_info.common_info.mld_link_id = 255;
+#endif /* _PLATFORM_BANANAPI_R4_ */
+        cfg.u.bss_info.mld_info.common_info.mld_link_id = wifidb_get_default_mld_link_id(band);
         if (isVapPrivate(vap_index)) {
             cfg.u.bss_info.showSsid = true;
             cfg.u.bss_info.wps.methods = WIFI_ONBOARDINGMETHODS_PUSHBUTTON;
@@ -978,6 +992,7 @@ int get_all_param_from_psm_and_set_into_db(void)
    return 0;
 }
 #endif
+
 void wifidb_init(wifi_db_t *db)
 {
     db->desc.init_fn = init_wifidb;

--- a/source/db/wifi_db.h
+++ b/source/db/wifi_db.h
@@ -154,6 +154,8 @@ int init_wifidb_tables();
 int wifidb_update_wifi_vap_config(int radio_index, wifi_vap_info_map_t *config,
     rdk_wifi_vap_info_t *rdk_config);
 
+int wifidb_get_default_mld_link_id(int band);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -96,6 +96,7 @@
 #define ONEWIFI_DB_VERSION_ENCR_GCMP_FLAG 100048
 #define ONEWIFI_DB_VERSION_ENCR_NEW_FLAG 100049
 #define ONEWIFI_DB_VERSION_HOSTAP_MGMT_FRAME_CTRL_NEW_FLAG 100050
+#define ONEWIFI_DB_VERSION_MLD_LINK_ID_FLAG 100051
 
 #define IGNITE_MIN_CHUTIL_THRESHOLD  50
 #define IGNITE_MAX_CHUTIL_THRESHOLD 100
@@ -5038,6 +5039,22 @@ static void wifidb_radio_config_upgrade(unsigned int index, wifi_radio_operation
 #endif /* CONFIG_IEEE80211BE */
 }
 
+int wifidb_get_default_mld_link_id(int band)
+{
+#if defined(CONFIG_IEEE80211BE) && defined(_XB10_PRODUCT_REQ_)
+    switch (band) {
+    case WIFI_FREQUENCY_2_4_BAND: return 2;
+    case WIFI_FREQUENCY_5_BAND:   return 1;
+    case WIFI_FREQUENCY_6_BAND:   return 0;
+    default:                      return UNDEFINED_MLD_LINK_ID;
+    }
+#else
+    (void)band;
+    return UNDEFINED_MLD_LINK_ID;
+#endif /* CONFIG_IEEE80211BE && _XB10_PRODUCT_REQ_ */
+}
+
+
 /************************************************************************************
  ************************************************************************************
   Function    : wifidb_vap_config_upgrade
@@ -5255,6 +5272,29 @@ static void wifidb_vap_config_upgrade(wifi_vap_info_map_t *config, rdk_wifi_vap_
                     __func__, __LINE__, config->vap_array[i].vap_name);
             }
         }
+#ifdef _XB10_PRODUCT_REQ_
+        if (g_wifidb->db_version < ONEWIFI_DB_VERSION_MLD_LINK_ID_FLAG) {
+            wifi_util_info_print(WIFI_DB, "%s:%d upgrade vap's MLO configuration, db version %d\n",
+                __func__, __LINE__, g_wifidb->db_version);
+            if (!isVapSTAMesh(config->vap_array[i].vap_index)) {
+                int band = 0;
+                if (convert_radio_index_to_freq_band(&g_wifidb->hal_cap.wifi_prop,
+                        config->vap_array[i].radio_index, &band) != RETURN_OK) {
+                    wifi_util_error_print(WIFI_DB,
+                        "%s:%d radio index %d, failed to get band\n",
+                        __func__, __LINE__, config->vap_array[i].radio_index);
+                } else {
+                    config->vap_array[i].u.bss_info.mld_info.common_info.mld_link_id =
+                        wifidb_get_default_mld_link_id(band);
+                    is_vap_info_upgrade_needed = true;
+                    wifi_util_info_print(WIFI_DB,
+                        "%s:%d vap %s mld_link_id set to %d for band %d\n", __func__, __LINE__,
+                        config->vap_array[i].vap_name,
+                        config->vap_array[i].u.bss_info.mld_info.common_info.mld_link_id, band);
+                }
+            }
+        }
+#endif /* _XB10_PRODUCT_REQ_ */
 #endif /* CONFIG_IEEE80211BE */
         if (is_vap_info_upgrade_needed) {
             int ret = wifidb_update_wifi_vap_info(config->vap_array[i].vap_name,
@@ -7753,13 +7793,11 @@ int wifidb_init_vap_config_default(int vap_index, wifi_vap_info_t *config,
             cfg->u.bss_info.mld_info.common_info.mld_enable = 1;
             cfg->u.bss_info.mld_info.common_info.mld_id = 0;
         }
-        /*TODO: Are values correct? */
-#else
+#else /* _PLATFORM_BANANAPI_R4_ */
         cfg->u.bss_info.mld_info.common_info.mld_enable = 0;
         cfg->u.bss_info.mld_info.common_info.mld_id = 255;
-#endif
-        cfg->u.bss_info.mld_info.common_info.mld_link_id = 255;
-
+#endif /* _PLATFORM_BANANAPI_R4_ */
+        cfg->u.bss_info.mld_info.common_info.mld_link_id = wifidb_get_default_mld_link_id(band);
         memset(&cfg->u.bss_info.mld_info.common_info.mld_addr, 0, sizeof(cfg->u.bss_info.mld_info.common_info.mld_addr));
         if (isVapPrivate(vap_index)) {
             cfg->u.bss_info.showSsid = true;


### PR DESCRIPTION
Reason for change: [MLO] Set MLD_Link_ID by default to "2 1 0 -1" Test Procedure: On boot after upgrade "WL MLO AP IDS assignment 2 1 0 -1".
                MLO can be configured without reboots.
Risks: Low
Priority: P1



(cherry picked from commit cf53b7a5b94a546203a6cd9f20a4b2e3adbaa41f)