### PR TITLE
RDKB-66448, XB10-2992: Fix boot delay issue in wifi controller

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -636,6 +636,7 @@ void bus_get_vap_init_parameter(const char *name, unsigned int *ret_val)
 
     int rc = bus_error_success;
     unsigned int total_slept = 0;
+    unsigned int max_retries = 5;
     char *pTmp = NULL;
     // rdk_dev_mode_type_t mode;
     wifi_global_param_t global_param = { 0 };
@@ -699,6 +700,7 @@ void bus_get_vap_init_parameter(const char *name, unsigned int *ret_val)
 #endif
     } else if (strcmp(name, WIFI_DEVICE_TUNNEL_STATUS) == 0) {
         *ret_val = DEVICE_TUNNEL_DOWN; // tunnel down
+        max_retries = 0; // don't wait for tunnel status to be up at boot
     }
 
 #if defined EASY_MESH_NODE
@@ -711,16 +713,17 @@ void bus_get_vap_init_parameter(const char *name, unsigned int *ret_val)
 
    while ((rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle, name, &data)) !=
         bus_error_success) {
-        sleep(1);
-        total_slept++;
-        if (total_slept >= 5) {
+        if (total_slept >= max_retries) {
             wifi_util_dbg_print(WIFI_CTRL, "%s:%d bus: Giving up on bus_data_get_fn for %s\n",
                 __func__, __LINE__, name);
+            get_bus_descriptor()->bus_data_free_fn(&data);
             return;
         }
 
-        get_bus_descriptor()->bus_data_free_fn(&data);
+        sleep(1);
+        total_slept++;
 
+        get_bus_descriptor()->bus_data_free_fn(&data);
         memset(&data, 0, sizeof(raw_data_t));
     }
 

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2081,10 +2081,29 @@ static void meshStatusHandler(char *event_name, bus_data_prop_t *p_data, void *u
         wifi_event_type_command_mesh_status, NULL);
 }
 
+static void process_device_tunnel_status(const char *status)
+{
+    bool tunnel_status = false;
+    wifi_event_subtype_t ces_t;
+
+    if (strcmp(status, "Up") == 0) {
+        tunnel_status = true;
+    } else if (strcmp(status, "Down") == 0) {
+        tunnel_status = false;
+    } else {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Received Unsupported value:%s\n", __func__,
+            __LINE__, status);
+        return;
+    }
+
+    ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up : wifi_event_type_xfinity_tunnel_down;
+    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
+        NULL);
+}
+
 static void eventReceiveHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
-    bool tunnel_status = false;
     char *pTmp = NULL;
 
     wifi_util_dbg_print(WIFI_CTRL, " %s:%d Recvd Event\n", __func__, __LINE__);
@@ -2097,26 +2116,46 @@ static void eventReceiveHandler(char *event_name, bus_data_prop_t *p_data, void 
             return;
         }
 
-        if (strcmp(pTmp, "Up") == 0) {
-            tunnel_status = true;
-        } else if (strcmp(pTmp, "Down") == 0) {
-            tunnel_status = false;
-        } else {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d: Received Unsupported value\n", __func__,
-                __LINE__);
-            return;
-        }
-        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: event:%s: value:%d\n", __func__, __LINE__,
-            event_name, tunnel_status);
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: event:%s: value:%s\n", __func__, __LINE__,
+            event_name, pTmp);
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Unsupported event:%s:%x\n", __func__, __LINE__,
             event_name, p_data->value.data_type);
         return;
     }
-    wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
-                                                 wifi_event_type_xfinity_tunnel_down;
-    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
-        NULL);
+
+    process_device_tunnel_status(pTmp);
+}
+
+// Reads the current tunnel status directly so a late subscriber does not miss the
+// state transition that hotspotfd published before this subscription existed.
+static void sync_device_tunnel_status(wifi_ctrl_t *ctrl)
+{
+    bus_error_t rc;
+    char *status = NULL;
+    raw_data_t data;
+
+    memset(&data, 0, sizeof(raw_data_t));
+    rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS, &data);
+    if (rc != bus_error_success || data.data_type != bus_data_type_string) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d '%s' bus_data_get_fn failed with data_type:0x%x, rc:%d\n", __func__, __LINE__,
+            WIFI_DEVICE_TUNNEL_STATUS, data.data_type, rc);
+        get_bus_descriptor()->bus_data_free_fn(&data);
+        return;
+    }
+
+    status = (char *)data.raw_data.bytes;
+    if (status == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d NULL tunnel status value\n", __func__, __LINE__);
+        get_bus_descriptor()->bus_data_free_fn(&data);
+        return;
+    }
+
+    wifi_util_info_print(WIFI_CTRL, "%s:%d synced current tunnel status:%s\n", __func__, __LINE__,
+        status);
+    process_device_tunnel_status(status);
+    get_bus_descriptor()->bus_data_free_fn(&data);
 }
 
 static void frame_802_11_injector_Handler(char *event_name, bus_data_prop_t *p_data, void *userData)
@@ -2555,6 +2594,7 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
             ctrl->device_tunnel_status_subscribed = true;
             wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe success\n",
                 __FUNCTION__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS);
+            sync_device_tunnel_status(ctrl);
         }
     }
 


### PR DESCRIPTION
Reason for change: Optimize wifi_ctrl initialization to reduce boot time.
        TunnelStatus is always not available during boot due to RDKB-60325.
Test Procedure: Verify boot time improvement on target device Risks: Low
Priority: P1