### PR TITLE
RDKBWIFI-513: Rbuscli getnames not working.

### DIFF
--- a/source/dml/wifi_ssp/ssp_main.c
+++ b/source/dml/wifi_ssp/ssp_main.c
@@ -717,8 +717,6 @@ void *ssp_func(void *arg)
 
 int start_dml_main(wifi_ssp_t *ssp)
 {
-    wifi_ctrl_t *ctrl =  NULL;
-
     if (pthread_create(&ssp->tid, NULL, ssp_func, ssp) != 0) {
         wifi_util_error_print(WIFI_MGR,"%s:%d:ssp_main create failed\n", __func__, __LINE__);
         return -1;
@@ -726,10 +724,15 @@ int start_dml_main(wifi_ssp_t *ssp)
 
     wifi_util_info_print(WIFI_MGR,"%s:%d:ssp_main thread started\n", __func__, __LINE__);
 
+/* Skip WFA Data Elements schema parsing in Easy Mesh builds;
+   the Easy Mesh Controller handles this. */
+#ifndef EASY_MESH_NODE
+    wifi_ctrl_t *ctrl = NULL;
     ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     wifi_util_info_print(WIFI_DMCLI, "%s:%d: Parsing WFA Data Elements schema: %s\n", 
                          __func__, __LINE__, BUS_WFA_DML_CONFIG_FILE);
     parse_and_register_wfa_schema(&ctrl->handle, BUS_WFA_DML_CONFIG_FILE);
+#endif
 
     return 0;
 }

--- a/source/platform/common/data_model/wifi_dml_api.c
+++ b/source/platform/common/data_model/wifi_dml_api.c
@@ -1345,9 +1345,13 @@ int start_dml_main(void *arg)
                          __func__, __LINE__, BUS_DML_CONFIG_FILE);
     parse_and_register_native_dml_schema(&ctrl->handle, BUS_DML_CONFIG_FILE);
 
+/* Skip WFA Data Elements schema parsing in Easy Mesh builds;
+   the Easy Mesh Controller handles this. */
+#ifndef EASY_MESH_NODE
     wifi_util_info_print(WIFI_DMCLI, "%s:%d: Parsing WFA Data Elements schema: %s\n", 
                          __func__, __LINE__, BUS_WFA_DML_CONFIG_FILE);
     parse_and_register_wfa_schema(&ctrl->handle, BUS_WFA_DML_CONFIG_FILE);
+#endif
 
     print_registered_elems(get_bus_mux_reg_cb_map(), 0);
 


### PR DESCRIPTION
Reason for change: Resolve Data Element GET/SET Failures Caused by Redundant Schema Parsing.
Risks: Medium
Test procedure: Flash the image and verify that the GET and SET operations function as expected.