### PR TITLE
RDKB-65569 : WiFi management service crashes with fingerprint 5892829…

### DIFF
--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -1025,106 +1025,139 @@ static int reset_interop_sta_data(void *arg) {
 int harvester_get_associated_device_info(int vap_index, char **harvester_buf)
 {
     unsigned int pos = 0;
+    int written = 0;
+    unsigned int remaining = 0;
+    const unsigned int json_trailer_len = sizeof("]}]}");
     sta_data_t *sta_data = NULL;
+    unsigned int sta_count = 0;
+    unsigned int buf_size = CLIENTDIAG_JSON_BUFFER_SIZE * (sizeof(char)) * BSS_MAX_NUM_STATIONS;
     if (harvester_buf[vap_index] == NULL) {
         wifi_util_dbg_print(WIFI_MON, "%s %d Harvester Buffer is NULL\n", __func__, __LINE__);
         return RETURN_ERR;
     }
-    pos = snprintf(harvester_buf[vap_index],
-                CLIENTDIAG_JSON_BUFFER_SIZE*(sizeof(char))*BSS_MAX_NUM_STATIONS,
-                "{"
-                "\"Version\":\"1.0\","
-                "\"AssociatedClientsDiagnostics\":["
-                "{"
-                "\"VapIndex\":\"%d\","
-                "\"AssociatedClientDiagnostics\":[",
-                (vap_index+1));
+    int header_written = snprintf(harvester_buf[vap_index], buf_size,
+        "{"
+        "\"Version\":\"1.0\","
+        "\"AssociatedClientsDiagnostics\":["
+        "{"
+        "\"VapIndex\":\"%d\","
+        "\"AssociatedClientDiagnostics\":[",
+        (vap_index + 1));
+    if (header_written < 0 || (unsigned int)header_written >= buf_size) {
+        return RETURN_ERR;
+    }
+    pos = (unsigned int)header_written;
     pthread_mutex_lock(&g_monitor_module.data_lock);
     sta_data = hash_map_get_first(g_monitor_module.bssid_data[vap_index].sta_map);
     while (sta_data != NULL) {
-        pos += snprintf(&harvester_buf[vap_index][pos],
-                (CLIENTDIAG_JSON_BUFFER_SIZE*(sizeof(char))*BSS_MAX_NUM_STATIONS)-pos, "{"
-                        "\"MAC\":\"%02x%02x%02x%02x%02x%02x\","
-                        "\"MLDMAC\":\"%02x%02x%02x%02x%02x%02x\","
-                        "\"MLDEnable\":\"%d\","
-                        "\"AssociationLink\":\"%d\","
-                        "\"DownlinkDataRate\":\"%d\","
-                        "\"UplinkDataRate\":\"%d\","
-                        "\"BytesSent\":\"%lu\","
-                        "\"BytesReceived\":\"%lu\","
-                        "\"PacketsSent\":\"%lu\","
-                        "\"PacketsRecieved\":\"%lu\","
-                        "\"Errors\":\"%lu\","
-                        "\"RetransCount\":\"%lu\","
-                        "\"Acknowledgements\":\"%lu\","
-                        "\"SignalStrength\":\"%d\","
-                        "\"SNR\":\"%d\","
-                        "\"OperatingStandard\":\"%s\","
-                        "\"OperatingChannelBandwidth\":\"%s\","
-                        "\"AuthenticationFailures\":\"%d\","
-                        "\"AuthenticationState\":\"%d\","
-                        "\"Active\":\"%d\","
-                        "\"InterferenceSources\":\"%s\","
-                        "\"DataFramesSentNoAck\":\"%lu\","
-                        "\"RSSI\":\"%d\","
-                        "\"MinRSSI\":\"%d\","
-                        "\"MaxRSSI\":\"%d\","
-                        "\"Disassociations\":\"%u\","
-                        "\"Retransmissions\":\"%u\""
-                        "},",
-                        sta_data->dev_stats.cli_MACAddress[0],
-                        sta_data->dev_stats.cli_MACAddress[1],
-                        sta_data->dev_stats.cli_MACAddress[2],
-                        sta_data->dev_stats.cli_MACAddress[3],
-                        sta_data->dev_stats.cli_MACAddress[4],
-                        sta_data->dev_stats.cli_MACAddress[5],
-                        sta_data->dev_stats.cli_MLDAddr[0],
-                        sta_data->dev_stats.cli_MLDAddr[1],
-                        sta_data->dev_stats.cli_MLDAddr[2],
-                        sta_data->dev_stats.cli_MLDAddr[3],
-                        sta_data->dev_stats.cli_MLDAddr[4],
-                        sta_data->dev_stats.cli_MLDAddr[5],
-                        sta_data->dev_stats.cli_MLDEnable,
-                        sta_data->assoc_link,
-                        sta_data->dev_stats.cli_MaxDownlinkRate,
-                        sta_data->dev_stats.cli_MaxUplinkRate,
-                        sta_data->dev_stats.cli_BytesSent,
-                        sta_data->dev_stats.cli_BytesReceived,
-                        sta_data->dev_stats.cli_PacketsSent,
-                        sta_data->dev_stats.cli_PacketsReceived,
-                        sta_data->dev_stats.cli_ErrorsSent,
-                        sta_data->dev_stats.cli_RetransCount,
-                        sta_data->dev_stats.cli_DataFramesSentAck,
-                        sta_data->dev_stats.cli_SignalStrength,
-                        sta_data->dev_stats.cli_SNR,
-                        sta_data->dev_stats.cli_OperatingStandard,
-                        sta_data->dev_stats.cli_OperatingChannelBandwidth,
-                        sta_data->dev_stats.cli_AuthenticationFailures,
-                        sta_data->dev_stats.cli_AuthenticationState,
-                        sta_data->dev_stats.cli_Active,
-                        sta_data->dev_stats.cli_InterferenceSources,
-                        sta_data->dev_stats.cli_DataFramesSentNoAck,
-                        sta_data->dev_stats.cli_RSSI,
-                        sta_data->dev_stats.cli_MinRSSI,
-                        sta_data->dev_stats.cli_MaxRSSI,
-                        sta_data->dev_stats.cli_Disassociations,
-                        sta_data->dev_stats.cli_Retransmissions);
 
+        if (pos >= buf_size || (buf_size - pos) <= json_trailer_len) {
+            wifi_util_error_print(WIFI_MON,
+                "%s %d Buffer limit reached for vap %d, pos=%u buf_size=%u sta_count=%u\n",
+                __func__, __LINE__, vap_index, pos, buf_size, sta_count);
+            break;
+        }
 
+        remaining = buf_size - pos;
+        sta_count++;
+
+        written = snprintf(&harvester_buf[vap_index][pos], remaining,
+            "{"
+            "\"MAC\":\"%02x%02x%02x%02x%02x%02x\","
+            "\"MLDMAC\":\"%02x%02x%02x%02x%02x%02x\","
+            "\"MLDEnable\":\"%d\","
+            "\"AssociationLink\":\"%d\","
+            "\"DownlinkDataRate\":\"%d\","
+            "\"UplinkDataRate\":\"%d\","
+            "\"BytesSent\":\"%lu\","
+            "\"BytesReceived\":\"%lu\","
+            "\"PacketsSent\":\"%lu\","
+            "\"PacketsRecieved\":\"%lu\","
+            "\"Errors\":\"%lu\","
+            "\"RetransCount\":\"%lu\","
+            "\"Acknowledgements\":\"%lu\","
+            "\"SignalStrength\":\"%d\","
+            "\"SNR\":\"%d\","
+            "\"OperatingStandard\":\"%s\","
+            "\"OperatingChannelBandwidth\":\"%s\","
+            "\"AuthenticationFailures\":\"%d\","
+            "\"AuthenticationState\":\"%d\","
+            "\"Active\":\"%d\","
+            "\"InterferenceSources\":\"%s\","
+            "\"DataFramesSentNoAck\":\"%lu\","
+            "\"RSSI\":\"%d\","
+            "\"MinRSSI\":\"%d\","
+            "\"MaxRSSI\":\"%d\","
+            "\"Disassociations\":\"%u\","
+            "\"Retransmissions\":\"%u\""
+            "},",
+            sta_data->dev_stats.cli_MACAddress[0], sta_data->dev_stats.cli_MACAddress[1],
+            sta_data->dev_stats.cli_MACAddress[2], sta_data->dev_stats.cli_MACAddress[3],
+            sta_data->dev_stats.cli_MACAddress[4], sta_data->dev_stats.cli_MACAddress[5],
+            sta_data->dev_stats.cli_MLDAddr[0], sta_data->dev_stats.cli_MLDAddr[1],
+            sta_data->dev_stats.cli_MLDAddr[2], sta_data->dev_stats.cli_MLDAddr[3],
+            sta_data->dev_stats.cli_MLDAddr[4], sta_data->dev_stats.cli_MLDAddr[5],
+            sta_data->dev_stats.cli_MLDEnable, sta_data->assoc_link,
+            sta_data->dev_stats.cli_MaxDownlinkRate, sta_data->dev_stats.cli_MaxUplinkRate,
+            sta_data->dev_stats.cli_BytesSent, sta_data->dev_stats.cli_BytesReceived,
+            sta_data->dev_stats.cli_PacketsSent, sta_data->dev_stats.cli_PacketsReceived,
+            sta_data->dev_stats.cli_ErrorsSent, sta_data->dev_stats.cli_RetransCount,
+            sta_data->dev_stats.cli_DataFramesSentAck, sta_data->dev_stats.cli_SignalStrength,
+            sta_data->dev_stats.cli_SNR, sta_data->dev_stats.cli_OperatingStandard,
+            sta_data->dev_stats.cli_OperatingChannelBandwidth,
+            sta_data->dev_stats.cli_AuthenticationFailures,
+            sta_data->dev_stats.cli_AuthenticationState, sta_data->dev_stats.cli_Active,
+            sta_data->dev_stats.cli_InterferenceSources,
+            sta_data->dev_stats.cli_DataFramesSentNoAck, sta_data->dev_stats.cli_RSSI,
+            sta_data->dev_stats.cli_MinRSSI, sta_data->dev_stats.cli_MaxRSSI,
+            sta_data->dev_stats.cli_Disassociations, sta_data->dev_stats.cli_Retransmissions);
+
+        if (written < 0) {
+            wifi_util_error_print(WIFI_MON, "%s %d snprintf failed for vap %d at sta_count=%u\n",
+                __func__, __LINE__, vap_index, sta_count);
+            break;
+        }
+
+        if ((unsigned int)written >= remaining) {
+            wifi_util_error_print(WIFI_MON,
+                "%s %d STA entry truncated for vap %d, stopping serialization pos=%u remaining=%u "
+                "sta_count=%u\n",
+                __func__, __LINE__, vap_index, pos, remaining, sta_count);
+            harvester_buf[vap_index][pos] = '\0';
+            break;
+        }
+        if ((buf_size - (pos + (unsigned int)written)) < json_trailer_len) {
+            wifi_util_error_print(WIFI_MON,
+                "%s %d Not enough space to append JSON trailer for vap %d, stopping serialization "
+                "pos=%u remaining=%u sta_count=%u\n",
+                __func__, __LINE__, vap_index, pos, remaining, sta_count);
+            harvester_buf[vap_index][pos] = '\0';
+            break;
+        }
+        pos += (unsigned int)written;
         sta_data = hash_map_get_next(g_monitor_module.bssid_data[vap_index].sta_map, sta_data);
-
     }
     pthread_mutex_unlock(&g_monitor_module.data_lock);
 
-    if (harvester_buf[vap_index][pos-1] == ',') {
+    if (pos > 0 && harvester_buf[vap_index][pos - 1] == ',') {
         pos--;
     }
 
-    snprintf(&harvester_buf[vap_index][pos], (
-             CLIENTDIAG_JSON_BUFFER_SIZE*(sizeof(char))*BSS_MAX_NUM_STATIONS)-pos,"]"
-             "}"
-             "]"
-             "}");
+    if (pos < buf_size) {
+        int trailer_written = snprintf(&harvester_buf[vap_index][pos], buf_size - pos,
+            "]"
+            "}"
+            "]"
+            "}");
+        if (trailer_written < 0) {
+            wifi_util_error_print(WIFI_MON, "%s %d Failed to append JSON trailer for vap %d\n",
+                __func__, __LINE__, vap_index);
+        }
+    } else {
+        wifi_util_error_print(WIFI_MON,
+            "%s %d No space left for JSON trailer for vap %d, pos=%u buf_size=%u\n", __func__,
+            __LINE__, vap_index, pos, buf_size);
+    }
 
     wifi_util_dbg_print(WIFI_MON, "%s %d pos : %u Buffer for vap %d updated as %s\n", __func__, __LINE__, pos, vap_index, harvester_buf[vap_index]);
     return RETURN_OK;


### PR DESCRIPTION
…2 on XB10 and XER10 gateways, which can cause brief WiFi interruptions for customers each time it restart

Reason for change:
harvester_get_associated_device_info() blindly iterates every entry in sta_map and appends JSON via pos += snprintf(...). There's no check whether pos has exceeded the buffer size (66,500 bytes). When it does, remaining size underflows to a large postive value and snprintf writes past the buffer size

Fix:
Harvester JSON building is made safe by:
--> Checking remaining buffer space before each client entry. 
--> Checking snprintf return for error and truncation. 
--> Stoping safely on truncation to avoid pointer jump and unsigned underflow.
 -->Keeping full per-client buffer budget, reserving only exact bytes needed for JSON closing trailer.
 
 Unit Testing:
 
 1. Connected around 57 clients on 5GHz private interface
 2. Checked if the Harvester report is generated after every reporting period to ensure that the fix did not break the functionality
 
 UT Logs: 
[harvester_report.txt](https://github.com/user-attachments/files/30976326/harvester_report.txt)


Priority : P1
Risk : Low