### PR TITLE
[ccsp-one-wifi] Add 11BN TR-181 variant support

### DIFF
--- a/config/rdkb-wifi.ovsschema
+++ b/config/rdkb-wifi.ovsschema
@@ -1,6 +1,6 @@
 {
   "name": "Wifi_Rdk_Database",
-  "version": "1.00.052",
+  "version": "1.00.053",
   "cksum": "2353365742 523",
   "tables": {
     "Wifi_Device_Config": {

--- a/source/apps/blaster/wifi_blaster.c
+++ b/source/apps/blaster/wifi_blaster.c
@@ -1164,6 +1164,9 @@ static void convert_variant_to_str(wifi_ieee80211Variant_t variant, char *str, s
 #ifdef CONFIG_IEEE80211BE
         "be",
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+        "bn",
+#endif /* CONFIG_IEEE80211BN */
     };
     static const wifi_ieee80211Variant_t arr_enum[] =
     {
@@ -1176,6 +1179,9 @@ static void convert_variant_to_str(wifi_ieee80211Variant_t variant, char *str, s
 #ifdef CONFIG_IEEE80211BE
         WIFI_80211_VARIANT_BE,
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+        WIFI_80211_VARIANT_BN,
+#endif /* CONFIG_IEEE80211BN */
     };
 
     for (size_t i = 0; i < ARRAY_SIZE(arr_enum); i++) {

--- a/source/core/wifi_ctrl_wifiapi_handlers.c
+++ b/source/core/wifi_ctrl_wifiapi_handlers.c
@@ -134,6 +134,11 @@ void wifiapi_printradioconfig(char *buff, unsigned int buff_size, wifi_radio_ope
         idx += snprintf(&buff[idx], buff_size-idx, " be");
     }
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+    else if (radio_config->variant & WIFI_80211_VARIANT_BN) {
+        idx += snprintf(&buff[idx], buff_size-idx, " bn");
+    }
+#endif /* CONFIG_IEEE80211BN */
 
     if (idx >= buff_size) return;
     idx += snprintf(&buff[idx], buff_size-idx, "\ncsa_beacon_count: %d\n", radio_config->csa_beacon_count);

--- a/source/db/wifi_db.c
+++ b/source/db/wifi_db.c
@@ -104,6 +104,9 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
             cfg.variant |= WIFI_80211_VARIANT_BE;
             cfg.channelWidth = WIFI_CHANNELBANDWIDTH_40MHZ;
 #endif /* defined(CONFIG_IEEE80211BE) && defined(_PLATFORM_BANANAPI_R4_) */
+#if defined(CONFIG_IEEE80211BN)
+            cfg.variant |= WIFI_80211_VARIANT_BN;
+#endif /* defined(CONFIG_IEEE80211BN) */
             break;
         case WIFI_FREQUENCY_5_BAND:
         case WIFI_FREQUENCY_5L_BAND:
@@ -119,6 +122,9 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
 #ifdef CONFIG_IEEE80211BE
             cfg.variant |= WIFI_80211_VARIANT_BE;
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+            cfg.variant |= WIFI_80211_VARIANT_BN;
+#endif /* CONFIG_IEEE80211BN */
             break;
         case WIFI_FREQUENCY_5H_BAND:
             cfg.operatingClass = 128;
@@ -129,6 +135,9 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
 #ifdef CONFIG_IEEE80211BE
             cfg.variant |= WIFI_80211_VARIANT_BE;
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+            cfg.variant |= WIFI_80211_VARIANT_BN;
+#endif /* CONFIG_IEEE80211BN */
             break;
         case WIFI_FREQUENCY_6_BAND:
             cfg.operatingClass = 134;
@@ -147,6 +156,9 @@ static int init_radio_config_default(int radio_index, wifi_radio_operationParam_
 //            cfg.channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
 #endif /* _PLATFORM_BANANAPI_R4_ */
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+            cfg.variant |= WIFI_80211_VARIANT_BN;
+#endif /* CONFIG_IEEE80211BN */
             break;
         default:
             wifi_util_error_print(WIFI_DB,"%s:%d radio index %d, invalid band %d\n", __func__,

--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -95,6 +95,7 @@
 #define ONEWIFI_DB_VERSION_TCM_PER_VAP_FLAG 100050
 #define ONEWIFI_DB_VERSION_HOSTAP_MGMT_FRAME_CTRL_NEW_FLAG 100051
 #define ONEWIFI_DB_VERSION_MLD_LINK_ID_FLAG 100052
+#define ONEWIFI_DB_VERSION_IEEE80211BN_FLAG 100053
 
 #define IGNITE_MIN_CHUTIL_THRESHOLD  50
 #define IGNITE_MAX_CHUTIL_THRESHOLD 100
@@ -5069,6 +5070,19 @@ static void wifidb_radio_config_upgrade(unsigned int index, wifi_radio_operation
         }
     }
 #endif /* CONFIG_IEEE80211BE */
+
+#ifdef CONFIG_IEEE80211BN
+    if (g_wifidb->db_version < ONEWIFI_DB_VERSION_IEEE80211BN_FLAG) {
+        wifi_util_info_print(WIFI_DB, "%s:%d upgrade radio=%d config for 11bn, old db version: %d total radios: %u\n",
+            __func__, __LINE__, index, g_wifidb->db_version, total_radios);
+        if (config->band != WIFI_FREQUENCY_2_4_BAND)
+            config->variant |= WIFI_80211_VARIANT_BN;
+        if(wifidb_update_wifi_radio_config(index, config, rdk_config) != RETURN_OK) {
+            wifi_util_error_print(WIFI_DB,"%s:%d error in updating radio config\n", __func__,__LINE__);
+            return;
+        }
+    }
+#endif /* CONFIG_IEEE80211BN */
 }
 
 int wifidb_get_default_mld_link_id(int band)
@@ -7356,7 +7370,9 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
             cfg->channelWidth = WIFI_CHANNELBANDWIDTH_40MHZ;
 #endif  /* defined(_PLATFORM_BANANAPI_R4_) */
 #endif /* defined(CONFIG_IEEE80211BE) */
-
+#if defined(CONFIG_IEEE80211BN)
+            cfg->variant |= WIFI_80211_VARIANT_BN;
+#endif /* defined(CONFIG_IEEE80211BN) */
 
 #if defined (_PP203X_PRODUCT_REQ_) || defined (_GREXT02ACTS_PRODUCT_REQ_)
             cfg->beaconInterval = 100;
@@ -7387,6 +7403,9 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
 #ifdef CONFIG_IEEE80211BE
             cfg->variant |= WIFI_80211_VARIANT_BE;
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+            cfg->variant |= WIFI_80211_VARIANT_BN;
+#endif /* CONFIG_IEEE80211BN */
             break;
         case WIFI_FREQUENCY_5H_BAND:
             cfg->operatingClass = 128;
@@ -7403,6 +7422,9 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
 #ifdef CONFIG_IEEE80211BE
             cfg->variant |= WIFI_80211_VARIANT_BE;
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+            cfg->variant |= WIFI_80211_VARIANT_BN;
+#endif /* CONFIG_IEEE80211BN */
             break;
         case WIFI_FREQUENCY_6_BAND:
             cfg->operatingClass = 134;
@@ -7421,6 +7443,9 @@ int wifidb_init_radio_config_default(int radio_index,wifi_radio_operationParam_t
             cfg->channelWidth = WIFI_CHANNELBANDWIDTH_320MHZ;
 #endif /* _PLATFORM_BANANAPI_R4_ */
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+            cfg->variant |= WIFI_80211_VARIANT_BN;
+#endif /* CONFIG_IEEE80211BN */
             break;
         default:
             wifi_util_error_print(WIFI_DB,"%s:%d radio index %d, invalid band %d\n", __func__,

--- a/source/dml/dml_webconfig/dml_onewifi_api.c
+++ b/source/dml/dml_webconfig/dml_onewifi_api.c
@@ -1943,6 +1943,14 @@ wifi_channelBandwidth_t sync_bandwidth_and_hw_variant(uint32_t variant, wifi_cha
         }
     }
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+    if ( variant & WIFI_80211_VARIANT_BN ) {
+        if (supported_bw < WIFI_CHANNELBANDWIDTH_320MHZ) {
+            supported_bw = WIFI_CHANNELBANDWIDTH_320MHZ;
+        }
+    }
+#endif /* CONFIG_IEEE80211BN */
+
     wifi_util_dbg_print(WIFI_DMCLI,"%s:%d variant:%d supported bandwidth:%d current_bw:%d \r\n", __func__, __LINE__, variant, supported_bw, current_bw);
     if (supported_bw < current_bw) {
         return supported_bw;

--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -2834,6 +2834,21 @@ Radio_GetParamStringValue
                 }
         }
 #endif /* CONFIG_IEEE80211BE */
+
+#ifdef CONFIG_IEEE80211BN
+        if ( pcfg->variant & WIFI_80211_VARIANT_BN )
+        {
+                if (AnscSizeOfString(buf) != 0)
+                {
+                    strcat(buf, ",bn");
+                }
+                else
+                {
+                    strcat(buf, "bn");
+                }
+        }
+#endif /* CONFIG_IEEE80211BN */
+
         if ( AnscSizeOfString(buf) < *pUlSize)
         {
             AnscCopyString(pValue, buf);
@@ -4301,6 +4316,9 @@ Radio_SetParamStringValue
 #ifdef CONFIG_IEEE80211BE
             "WIFI_80211_VARIANT_BE",
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+            "WIFI_80211_VARIANT_BN",
+#endif /* CONFIG_IEEE80211BN */
         };
 
         for (size_t i = 0; i < (sizeof(wifi_mode_strings) / sizeof(wifi_mode_strings[0])); i++) {

--- a/source/dml/tr_181/sbapi/cosa_wifi_apis.c
+++ b/source/dml/tr_181/sbapi/cosa_wifi_apis.c
@@ -230,8 +230,11 @@ struct  wifiStdCosaHalMap wifiStdDmlMap[] =
     {WIFI_80211_VARIANT_AD, COSA_DML_WIFI_STD_ad, "ad"},
     {WIFI_80211_VARIANT_AX, COSA_DML_WIFI_STD_ax, "ax"},
 #ifdef CONFIG_IEEE80211BE
-    {WIFI_80211_VARIANT_BE, COSA_DML_WIFI_STD_be, "be"}
+    {WIFI_80211_VARIANT_BE, COSA_DML_WIFI_STD_be, "be"},
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+    {WIFI_80211_VARIANT_BN, COSA_DML_WIFI_STD_bn, "bn"},
+#endif /* CONFIG_IEEE80211BN */
 };
 
 /**************************************************************************

--- a/source/dml/tr_181/sbapi/cosa_wifi_apis.h
+++ b/source/dml/tr_181/sbapi/cosa_wifi_apis.h
@@ -170,7 +170,8 @@ _COSA_DML_WIFI_STD
     COSA_DML_WIFI_STD_ax            = 32,
     COSA_DML_WIFI_STD_h             = 64,
     COSA_DML_WIFI_STD_ad            = 128,
-    COSA_DML_WIFI_STD_be            = 256
+    COSA_DML_WIFI_STD_be            = 256,
+    COSA_DML_WIFI_STD_bn           = 512
 }
 COSA_DML_WIFI_STD, *PCOSA_DML_WIFI_STD;
 

--- a/source/platform/common/data_model/wifi_dml_api.c
+++ b/source/platform/common/data_model/wifi_dml_api.c
@@ -611,8 +611,11 @@ int get_radio_variant_string_from_int(wifi_ieee80211Variant_t l_radio_variant,
         { WIFI_80211_VARIANT_AD, "ad" },
         { WIFI_80211_VARIANT_AX, "ax" },
 #ifdef CONFIG_IEEE80211BE
-        { WIFI_80211_VARIANT_BE, "be" }
+        { WIFI_80211_VARIANT_BE, "be" },
 #endif  /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+        { WIFI_80211_VARIANT_BN, "bn" }
+#endif /* CONFIG_IEEE80211BN */
     };
 
     for (index = 0; index < (uint32_t)ARRAY_SZ(wifi_variant_map); index++) {
@@ -654,8 +657,11 @@ int get_radio_variant_int_from_string(const char *p_radio_variant_name,
         { WIFI_80211_VARIANT_AD, "ad" },
         { WIFI_80211_VARIANT_AX, "ax" },
 #ifdef CONFIG_IEEE80211BE
-        { WIFI_80211_VARIANT_BE, "be" }
+        { WIFI_80211_VARIANT_BE, "be" },
 #endif  /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+        { WIFI_80211_VARIANT_BN, "bn" }
+#endif /* CONFIG_IEEE80211BN */
     };
 
     uint32_t index = 0;

--- a/source/utils/wifi_util.c
+++ b/source/utils/wifi_util.c
@@ -1605,6 +1605,9 @@ int hw_mode_conversion(wifi_ieee80211Variant_t *hw_mode_enum, char *hw_mode, int
 #ifdef CONFIG_IEEE80211BE
         "11be",
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+        "11bn",
+#endif /* CONFIG_IEEE80211BN */
     };
 
     static const wifi_ieee80211Variant_t arr_enum[] =
@@ -1618,6 +1621,10 @@ int hw_mode_conversion(wifi_ieee80211Variant_t *hw_mode_enum, char *hw_mode, int
 #ifdef CONFIG_IEEE80211BE
         WIFI_80211_VARIANT_BE,
 #endif /* CONFIG_IEEE80211BE */
+
+#ifdef CONFIG_IEEE80211BN
+        WIFI_80211_VARIANT_BN,
+#endif /* CONFIG_IEEE80211BN */
     };
     bool is_mode_valid = false;
 
@@ -3068,8 +3075,11 @@ struct  wifiStdHalMap wifiStdMap[] =
     {WIFI_80211_VARIANT_AD, "ad"},
     {WIFI_80211_VARIANT_AX, "ax"},
 #ifdef CONFIG_IEEE80211BE
-    {WIFI_80211_VARIANT_BE, "be"}
+    {WIFI_80211_VARIANT_BE, "be"},
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+    {WIFI_80211_VARIANT_BN, "bn"}
+#endif /* CONFIG_IEEE80211BN */
 };
 
 bool wifiStandardStrToEnum(char *pWifiStdStr, wifi_ieee80211Variant_t *p80211VarEnum, ULONG instance_number, bool twoG80211axEnable)
@@ -3653,6 +3663,13 @@ bool is_bandwidth_and_hw_variant_compatible(uint32_t variant, wifi_channelBandwi
         }
     }
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+    if ( variant & WIFI_80211_VARIANT_BN ) {
+        if (supported_bw < WIFI_CHANNELBANDWIDTH_320MHZ) {
+            supported_bw = WIFI_CHANNELBANDWIDTH_320MHZ;
+        }
+    }
+#endif /* CONFIG_IEEE80211BN */
     if (supported_bw < current_bw) {
         wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d variant:%d supported bandwidth:%d current_bw:%d \r\n", __func__, __LINE__, variant, supported_bw, current_bw);
         return false;

--- a/source/webconfig/wifi_decoder.c
+++ b/source/webconfig/wifi_decoder.c
@@ -2749,6 +2749,9 @@ int validate_wifi_hw_variant(wifi_freq_bands_t radio_band, wifi_ieee80211Variant
 #ifdef CONFIG_IEEE80211BE
         MASK_BITSET(wifi_hw_mode, WIFI_80211_VARIANT_BE);
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+       MASK_BITSET(wifi_hw_mode, WIFI_80211_VARIANT_BN);
+#endif /* CONFIG_IEEE80211BN */
         if(wifi_hw_mode != 0) {
             wifi_util_error_print(WIFI_WEBCONFIG, "%s() %d Error wifi_hw_mode %d\n", __FUNCTION__, __LINE__, wifi_hw_mode);
             return RETURN_ERR;
@@ -2765,6 +2768,9 @@ int validate_wifi_hw_variant(wifi_freq_bands_t radio_band, wifi_ieee80211Variant
 #ifdef CONFIG_IEEE80211BE
         MASK_BITSET(wifi_hw_mode, WIFI_80211_VARIANT_BE);
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+         MASK_BITSET(wifi_hw_mode, WIFI_80211_VARIANT_BN);
+#endif /* CONFIG_IEEE80211BN */
         if (wifi_hw_mode != 0) {
             wifi_util_error_print(WIFI_WEBCONFIG, "%s() %d Error wifi_hw_mode %d\n", __FUNCTION__, __LINE__, wifi_hw_mode);
             return RETURN_ERR;
@@ -2775,6 +2781,9 @@ int validate_wifi_hw_variant(wifi_freq_bands_t radio_band, wifi_ieee80211Variant
 #ifdef CONFIG_IEEE80211BE
         MASK_BITSET(wifi_hw_mode, WIFI_80211_VARIANT_BE);
 #endif /* CONFIG_IEEE80211BE */
+#ifdef CONFIG_IEEE80211BN
+        MASK_BITSET(wifi_hw_mode, WIFI_80211_VARIANT_BN);
+#endif /* CONFIG_IEEE80211BN */
         if (wifi_hw_mode != 0) {
             wifi_util_error_print(WIFI_WEBCONFIG, "%s() %d Error wifi_hw_mode %d\n", __FUNCTION__, __LINE__, wifi_hw_mode);
             return RETURN_ERR;


### PR DESCRIPTION
Reason for change: [rdk-wifi-hal] Add 802.11bn variant support for TR-181

- Add 802.11bn variant string mapping for TR-181 standard reporting
- Include BN in radio variant conversion for supported and operating standards

This change provides baseline 11BN/802.11bn variant handling required for TR-181 reporting and platform variant support.