### PR TITLE
RDKB-65658 TunnelStatus Subscription to be done based on hotspot status

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1460,7 +1460,9 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
 
     ctrl->bus_events_subscribed = false;
     ctrl->tunnel_events_subscribed = false;
+    ctrl->device_tunnel_status_subscribed = false;
     ctrl->hotspot_status_subscribed = false;
+    ctrl->hotspot_enabled = false;
 
     // subscribe for BUS events
     bus_subscribe_events(ctrl);
@@ -2340,14 +2342,14 @@ static int bus_check_and_subscribe_events(void* arg)
 
 #if defined (ONEWIFI_FEATURE_SUBSCRIBE_FLAGS)
     ctrl->mesh_status_subscribed = true;
-    ctrl->device_tunnel_status_subscribed = true;
     ctrl->device_mode_subscribed = true;
     ctrl->mesh_keep_out_chans_subscribed = true;
 #endif
 
     if ((ctrl->bus_events_subscribed == false) || (ctrl->tunnel_events_subscribed == false) ||
         (ctrl->device_mode_subscribed == false) || (ctrl->active_gateway_check_subscribed == false) ||
-        (ctrl->device_tunnel_status_subscribed == false) || (ctrl->device_wps_test_subscribed == false) ||
+        (ctrl->hotspot_enabled && ctrl->device_tunnel_status_subscribed == false) ||
+        (ctrl->device_wps_test_subscribed == false) ||
         (ctrl->test_device_mode_subscribed == false) || (ctrl->mesh_status_subscribed == false) ||
         (ctrl->marker_list_config_subscribed == false) || (ctrl->mesh_keep_out_chans_subscribed == false) ||
         (ctrl->hotspot_client_dhcp_failure_subscribed == false)

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1459,7 +1459,6 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
     bus_register_handlers(ctrl);
 
     ctrl->bus_events_subscribed = false;
-    ctrl->tunnel_events_subscribed = false;
     ctrl->device_tunnel_status_subscribed = false;
     ctrl->hotspot_status_subscribed = false;
     ctrl->hotspot_enabled = false;

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1477,6 +1477,7 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
 
     ctrl->bus_events_subscribed = false;
     ctrl->tunnel_events_subscribed = false;
+  ctrl->hotspot_status_subscribed = false;
 
 #if defined (FEATURE_SUPPORT_WEBCONFIG)
     register_with_webconfig_framework();

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -2346,7 +2346,7 @@ static int bus_check_and_subscribe_events(void* arg)
     ctrl->mesh_keep_out_chans_subscribed = true;
 #endif
 
-    if ((ctrl->bus_events_subscribed == false) || (ctrl->tunnel_events_subscribed == false) ||
+    if ((ctrl->bus_events_subscribed == false) ||
         (ctrl->device_mode_subscribed == false) || (ctrl->active_gateway_check_subscribed == false) ||
         (ctrl->hotspot_enabled && ctrl->device_tunnel_status_subscribed == false) ||
         (ctrl->device_wps_test_subscribed == false) ||

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1458,6 +1458,10 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
     //Register to BUS for webconfig interactions
     bus_register_handlers(ctrl);
 
+    ctrl->bus_events_subscribed = false;
+    ctrl->tunnel_events_subscribed = false;
+    ctrl->hotspot_status_subscribed = false;
+
     // subscribe for BUS events
     bus_subscribe_events(ctrl);
 
@@ -1474,10 +1478,6 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
     wifi_chan_event_register(channel_change_callback);
 
     wifi_wpsEvent_callback_register(wps_event_callback);
-
-    ctrl->bus_events_subscribed = false;
-    ctrl->tunnel_events_subscribed = false;
-  ctrl->hotspot_status_subscribed = false;
 
 #if defined (FEATURE_SUPPORT_WEBCONFIG)
     register_with_webconfig_framework();

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -246,7 +246,6 @@ typedef struct wifi_ctrl {
     bus_handle_t        handle;
     bool                bus_events_subscribed;
     bool                active_gateway_check_subscribed;
-    bool                tunnel_events_subscribed;
     bool                mesh_status_subscribed;
     bool                device_mode_subscribed;
     bool                test_device_mode_subscribed;

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -252,6 +252,7 @@ typedef struct wifi_ctrl {
     bool                test_device_mode_subscribed;
     bool                device_tunnel_status_subscribed;
     bool                hotspot_status_subscribed;
+    bool                hotspot_enabled;
     bool                device_wps_test_subscribed;
     bool                frame_802_11_injector_subscribed;
     bool                factory_reset;

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -64,6 +64,7 @@ extern "C" {
 #define WIFI_TxRx_RATE_LIST                "Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.TxRxRateList"
 #define WIFI_DEVICE_MODE                   "Device.X_RDKCENTRAL-COM_DeviceControl.DeviceNetworkingMode"
 #define WIFI_DEVICE_TUNNEL_STATUS          "Device.X_COMCAST-COM_GRE.Tunnel.1.TunnelStatus"
+#define WIFI_HOTSPOT_STATUS                "Device.X_COMCAST-COM_GRE.Tunnel.1.Status"
 #define SPEEDTEST_STATUS                   "Device.IP.Diagnostics.X_RDKCENTRAL-COM_SpeedTest.Status"
 #define SPEEDTEST_SUBSCRIBE                "Device.IP.Diagnostics.X_RDK_SpeedTest.SubscriberUnPauseTimeOut"
 

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -251,6 +251,7 @@ typedef struct wifi_ctrl {
     bool                device_mode_subscribed;
     bool                test_device_mode_subscribed;
     bool                device_tunnel_status_subscribed;
+    bool                hotspot_status_subscribed;
     bool                device_wps_test_subscribed;
     bool                frame_802_11_injector_subscribed;
     bool                factory_reset;

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2111,6 +2111,29 @@ static void sync_device_tunnel_status(wifi_ctrl_t *ctrl)
     get_bus_descriptor()->bus_data_free_fn(&data);
 }
 
+static void subscribe_device_tunnel_status(wifi_ctrl_t *ctrl)
+{
+    wifi_bus_desc_t *bus_desc = get_bus_descriptor();
+    bus_error_t rc;
+
+    if (ctrl == NULL || bus_desc == NULL || ctrl->hotspot_enabled == false ||
+        ctrl->device_tunnel_status_subscribed) {
+        return;
+    }
+
+    rc = bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS,
+        eventReceiveHandler, NULL, 0);
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Tunnel status subscribe rc=%d\n", __func__, __LINE__,
+        rc);
+    if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
+        ctrl->device_tunnel_status_subscribed = true;
+        sync_device_tunnel_status(ctrl);
+    } else {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to subscribe to %s, rc:%d\n", __func__,
+            __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
+    }
+}
+
 static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
@@ -2136,22 +2159,10 @@ static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void
     }
 
     if (strcmp(status, "Enabled") == 0) {
-        if (ctrl->device_tunnel_status_subscribed == false) {
-            wifi_util_dbg_print(WIFI_CTRL, "%s:%d Subscribing tunnel status path=%s\n", __func__,
-                __LINE__, WIFI_DEVICE_TUNNEL_STATUS);
-            rc = bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS,
-                eventReceiveHandler, NULL, 0);
-            wifi_util_dbg_print(WIFI_CTRL, "%s:%d Tunnel status subscribe rc=%d\n", __func__,
-                __LINE__, rc);
-            if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
-                ctrl->device_tunnel_status_subscribed = true;
-                sync_device_tunnel_status(ctrl);
-            } else {
-                wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to subscribe to %s, rc:%d\n",
-                    __func__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
-            }
-        }
+        ctrl->hotspot_enabled = true;
+    subscribe_device_tunnel_status(ctrl);
     } else if (strcmp(status, "Disabled") == 0) {
+        ctrl->hotspot_enabled = false;
         if (ctrl->device_tunnel_status_subscribed == true) {
             rc = bus_desc->bus_event_unsubs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS);
             if (rc == bus_error_success) {
@@ -2590,6 +2601,8 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
                 __LINE__, WIFI_HOTSPOT_STATUS, rc);
         }
     }
+
+        subscribe_device_tunnel_status(ctrl);
 
     if (consumer_app_file == 0 && ctrl->device_wps_test_subscribed == false) {
         if (bus_desc->bus_event_subs_fn(&ctrl->handle, BUS_WIFI_WPS_PIN_START,

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2160,14 +2160,13 @@ static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void
 
     if (strcmp(status, "Enabled") == 0) {
         ctrl->hotspot_enabled = true;
-    subscribe_device_tunnel_status(ctrl);
+        subscribe_device_tunnel_status(ctrl);
     } else if (strcmp(status, "Disabled") == 0) {
         ctrl->hotspot_enabled = false;
         if (ctrl->device_tunnel_status_subscribed == true) {
             rc = bus_desc->bus_event_unsubs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS);
-            if (rc == bus_error_success) {
-                ctrl->device_tunnel_status_subscribed = false;
-            } else {
+            ctrl->device_tunnel_status_subscribed = false;
+            if (rc != bus_error_success) {
                 wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to unsubscribe from %s, rc:%d\n",
                     __func__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
             }
@@ -2596,13 +2595,26 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
             hotspotStatusHandler, NULL, 0);
         if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
             ctrl->hotspot_status_subscribed = true;
+            // GET current hotspot state in case Enabled was published before subscription
+            raw_data_t hs_data;
+            memset(&hs_data, 0, sizeof(raw_data_t));
+            rc = bus_desc->bus_data_get_fn(&ctrl->handle, WIFI_HOTSPOT_STATUS, &hs_data);
+            if (rc == bus_error_success && hs_data.data_type == bus_data_type_string) {
+                char *hs_val = (char *)hs_data.raw_data.bytes;
+                if (hs_val != NULL && strcmp(hs_val, "Enabled") == 0) {
+                    ctrl->hotspot_enabled = true;
+                    wifi_util_info_print(WIFI_CTRL, "%s:%d Hotspot already Enabled at startup\n",
+                        __func__, __LINE__);
+                }
+            }
+            bus_desc->bus_data_free_fn(&hs_data);
         } else {
             wifi_util_error_print(WIFI_CTRL, "%s:%d %s subscription failed, rc:%d\n", __func__,
                 __LINE__, WIFI_HOTSPOT_STATUS, rc);
         }
     }
 
-        subscribe_device_tunnel_status(ctrl);
+    subscribe_device_tunnel_status(ctrl);
 
     if (consumer_app_file == 0 && ctrl->device_wps_test_subscribed == false) {
         if (bus_desc->bus_event_subs_fn(&ctrl->handle, BUS_WIFI_WPS_PIN_START,
@@ -2695,7 +2707,7 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
         }
     }
 #endif
-    if(!ctrl->hotspot_client_dhcp_failure_subscribed) {
+    if(!ctrl->hotspot_client_dhcp_failure_subscribed && ctrl->hotspot_enabled) {
         if (bus_desc->bus_event_subs_fn(&ctrl->handle, HOTSPOT_CLIENT_DHCP_FAILURE_DISCONNECTED, hotspot_client_dhcp_failure_disconnect, NULL, 
             0) != bus_error_success) {
             // wifi_util_dbg_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe fail\n",

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1419,40 +1419,6 @@ static void wan_failover_handler(char *event_name, bus_data_prop_t *p_data, void
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d: recv data:%d\r\n", __func__, __LINE__, data_value);
 }
 
-static void hotspotTunnelHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
-{
-    (void)userData;
-    char *pTmp;
-
-    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Recvd Event\n",  __func__, __LINE__);
-
-    if(strcmp(event_name, "TunnelStatus") != 0) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d Not Tunnel event, %s\n", __func__, __LINE__, event_name);
-        return;
-    } else if (p_data->value.data_type != bus_data_type_string) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
-                __func__, __LINE__, event_name, p_data->value.data_type);
-        return;
-    }
-
-    pTmp = (char *)p_data->value.raw_data.bytes;
-
-    if (pTmp == NULL) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d: wrong bus data recived for Event %s", __func__, __LINE__, event_name);
-        return;
-    }
-
-    bool tunnel_status = false;
-    if (strcmp(pTmp, "TUNNEL_UP") == 0) {
-        tunnel_status = true;
-    }
-
-    wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
-                                                 wifi_event_type_xfinity_tunnel_down;
-    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
-        NULL);
-}
-
 bus_error_t get_assoc_clients_data(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     (void)user_data;
@@ -2586,20 +2552,6 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
         }
     }
 #endif
-
-    if (consumer_app_file == 0 && ctrl->tunnel_events_subscribed == false) {
-        // TODO - what's the namespace for the event
-        int rc = bus_desc->bus_event_subs_fn(&ctrl->handle, "TunnelStatus", hotspotTunnelHandler,
-            NULL, 0);
-        if (rc != bus_error_success) {
-            // wifi_util_dbg_print(WIFI_CTRL,"%s:%d TunnelStatus subscribe Failed, rc:
-            // %d\n",__FUNCTION__, __LINE__, rc);
-        } else {
-            ctrl->tunnel_events_subscribed = true;
-            wifi_util_info_print(WIFI_CTRL, "%s:%d TunnelStatus subscribe success, rc: %d\n",
-                __FUNCTION__, __LINE__, rc);
-        }
-    }
 
     if (ctrl->mesh_status_subscribed == false) {
         int rc = bus_desc->bus_event_subs_fn(&ctrl->handle, MESH_STATUS, meshStatusHandler, NULL,

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2066,42 +2066,118 @@ static void meshStatusHandler(char *event_name, bus_data_prop_t *p_data, void *u
         wifi_event_type_command_mesh_status, NULL);
 }
 
+static void process_device_tunnel_status(const char *status)
+{
+    bool tunnel_status = false;
+    wifi_event_subtype_t ces_t;
+
+    if (strcmp(status, "Up") == 0) {
+        tunnel_status = true;
+    } else if (strcmp(status, "Down") != 0) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Received Unsupported value:%s\n", __func__,
+            __LINE__, status);
+        return;
+    }
+
+    ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up : wifi_event_type_xfinity_tunnel_down;
+    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
+        NULL);
+}
+
 static void eventReceiveHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
-    bool tunnel_status = false;
     char *pTmp = NULL;
 
     wifi_util_dbg_print(WIFI_CTRL, " %s:%d Recvd Event\n", __func__, __LINE__);
 
     if ((strcmp(event_name, WIFI_DEVICE_TUNNEL_STATUS) == 0) && p_data->value.data_type == bus_data_type_string) {
-
         pTmp = (char *)p_data->value.raw_data.bytes;
-        if(pTmp == NULL) {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d: Unable to get  value in event:%s\n", __func__, __LINE__, event_name);
+        if (pTmp == NULL) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d: Unable to get value in event:%s\n", __func__,
+                __LINE__, event_name);
             return;
         }
-
-        if (strcmp(pTmp, "Up") == 0) {
-            tunnel_status = true;
-        } else if (strcmp(pTmp, "Down") == 0) {
-            tunnel_status = false;
-        } else {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d: Received Unsupported value\n", __func__,
-                __LINE__);
-            return;
-        }
-        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: event:%s: value:%d\n", __func__, __LINE__,
-            event_name, tunnel_status);
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Unsupported event:%s:%x\n", __func__, __LINE__,
             event_name, p_data->value.data_type);
         return;
     }
-    wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
-                                                 wifi_event_type_xfinity_tunnel_down;
-    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
-        NULL);
+
+    process_device_tunnel_status(pTmp);
+}
+
+static void sync_device_tunnel_status(wifi_ctrl_t *ctrl)
+{
+    bus_error_t rc;
+    raw_data_t data;
+    char *status = NULL;
+
+    memset(&data, 0, sizeof(raw_data_t));
+    rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS, &data);
+    if (rc != bus_error_success || data.data_type != bus_data_type_string) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d '%s' bus_data_get_fn failed with data_type:0x%x, rc:%d\n", __func__, __LINE__,
+            WIFI_DEVICE_TUNNEL_STATUS, data.data_type, rc);
+        get_bus_descriptor()->bus_data_free_fn(&data);
+        return;
+    }
+
+    status = (char *)data.raw_data.bytes;
+    if (status != NULL) {
+        process_device_tunnel_status(status);
+    } else {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d NULL tunnel status value\n", __func__, __LINE__);
+    }
+    get_bus_descriptor()->bus_data_free_fn(&data);
+}
+
+static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
+{
+    (void)userData;
+    char *status = NULL;
+    wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
+    wifi_bus_desc_t *bus_desc = get_bus_descriptor();
+    bus_error_t rc;
+
+    if (ctrl == NULL || bus_desc == NULL || strcmp(event_name, WIFI_HOTSPOT_STATUS) != 0 ||
+        p_data->value.data_type != bus_data_type_string) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid hotspot status event\n", __func__, __LINE__);
+        return;
+    }
+
+    status = (char *)p_data->value.raw_data.bytes;
+    if (status == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d NULL hotspot status\n", __func__, __LINE__);
+        return;
+    }
+
+    if (strcmp(status, "Enabled") == 0) {
+        if (ctrl->device_tunnel_status_subscribed == false) {
+            rc = bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS,
+                eventReceiveHandler, NULL, 0);
+            if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
+                ctrl->device_tunnel_status_subscribed = true;
+                sync_device_tunnel_status(ctrl);
+            } else {
+                wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to subscribe to %s, rc:%d\n",
+                    __func__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
+            }
+        }
+    } else if (strcmp(status, "Disabled") == 0) {
+        if (ctrl->device_tunnel_status_subscribed == true) {
+            rc = bus_desc->bus_event_unsubs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS);
+            if (rc == bus_error_success) {
+                ctrl->device_tunnel_status_subscribed = false;
+            } else {
+                wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to unsubscribe from %s, rc:%d\n",
+                    __func__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
+            }
+        }
+    } else {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Unsupported hotspot status:%s\n", __func__,
+            __LINE__, status);
+    }
 }
 
 static void frame_802_11_injector_Handler(char *event_name, bus_data_prop_t *p_data, void *userData)
@@ -2531,15 +2607,14 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
     }
 #endif
 
-    if (ctrl->device_tunnel_status_subscribed == false) {
-        if (bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS,
-                eventReceiveHandler, NULL, 0) != bus_error_success) {
-            // wifi_util_dbg_print(WIFI_CTRL,"%s:%d bus: bus event:%s subscribe
-            // failed\n",__FUNCTION__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS);
+    if (ctrl->hotspot_status_subscribed == false) {
+        bus_error_t rc = bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_HOTSPOT_STATUS,
+            hotspotStatusHandler, NULL, 0);
+        if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
+            ctrl->hotspot_status_subscribed = true;
         } else {
-            ctrl->device_tunnel_status_subscribed = true;
-            wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe success\n",
-                __FUNCTION__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS);
+            wifi_util_error_print(WIFI_CTRL, "%s:%d %s subscription failed, rc:%d\n", __func__,
+                __LINE__, WIFI_HOTSPOT_STATUS, rc);
         }
     }
 

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1418,40 +1418,6 @@ static void wan_failover_handler(char *event_name, bus_data_prop_t *p_data, void
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d: recv data:%d\r\n", __func__, __LINE__, data_value);
 }
-static void hotspotTunnelHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
-{
-    (void)userData;
-    char *pTmp;
-
-    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Recvd Event\n",  __func__, __LINE__);
-
-    if(strcmp(event_name, "TunnelStatus") != 0) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d Not Tunnel event, %s\n", __func__, __LINE__, event_name);
-        return;
-    } else if (p_data->value.data_type != bus_data_type_string) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
-                __func__, __LINE__, event_name, p_data->value.data_type);
-        return;
-    }
-
-    pTmp = (char *)p_data->value.raw_data.bytes;
-
-    if (pTmp == NULL) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d: wrong bus data recived for Event %s", __func__, __LINE__, event_name);
-        return;
-    }
-
-    bool tunnel_status = false;
-    if (strcmp(pTmp, "TUNNEL_UP") == 0) {
-        tunnel_status = true;
-    }
-
-    wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
-                                                 wifi_event_type_xfinity_tunnel_down;
-    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
-        NULL);
-}
-
 bus_error_t get_assoc_clients_data(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     (void)user_data;
@@ -2089,9 +2055,12 @@ static void eventReceiveHandler(char *event_name, bus_data_prop_t *p_data, void 
     (void)userData;
     char *pTmp = NULL;
 
-    wifi_util_dbg_print(WIFI_CTRL, " %s:%d Recvd Event\n", __func__, __LINE__);
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d TunnelStatus callback event=%s data=%p\n", __func__,
+        __LINE__, event_name != NULL ? event_name : "NULL", (void *)p_data);
 
-    if ((strcmp(event_name, WIFI_DEVICE_TUNNEL_STATUS) == 0) && p_data->value.data_type == bus_data_type_string) {
+    if (event_name != NULL && p_data != NULL &&
+        (strcmp(event_name, WIFI_DEVICE_TUNNEL_STATUS) == 0) &&
+        p_data->value.data_type == bus_data_type_string) {
         pTmp = (char *)p_data->value.raw_data.bytes;
         if (pTmp == NULL) {
             wifi_util_error_print(WIFI_CTRL, "%s:%d: Unable to get value in event:%s\n", __func__,
@@ -2100,10 +2069,13 @@ static void eventReceiveHandler(char *event_name, bus_data_prop_t *p_data, void 
         }
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Unsupported event:%s:%x\n", __func__, __LINE__,
-            event_name, p_data->value.data_type);
+            event_name != NULL ? event_name : "NULL",
+            p_data != NULL ? p_data->value.data_type : 0);
         return;
     }
 
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d TunnelStatus callback value=%s\n", __func__, __LINE__,
+        pTmp);
     process_device_tunnel_status(pTmp);
 }
 
@@ -2114,7 +2086,11 @@ static void sync_device_tunnel_status(wifi_ctrl_t *ctrl)
     char *status = NULL;
 
     memset(&data, 0, sizeof(raw_data_t));
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Getting tunnel status path=%s\n", __func__, __LINE__,
+        WIFI_DEVICE_TUNNEL_STATUS);
     rc = get_bus_descriptor()->bus_data_get_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS, &data);
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Tunnel status GET rc=%d data_type=0x%x data=%p len=%u\n",
+        __func__, __LINE__, rc, data.data_type, (void *)data.raw_data.bytes, data.raw_data_len);
     if (rc != bus_error_success || data.data_type != bus_data_type_string) {
         wifi_util_error_print(WIFI_CTRL,
             "%s:%d '%s' bus_data_get_fn failed with data_type:0x%x, rc:%d\n", __func__, __LINE__,
@@ -2125,6 +2101,8 @@ static void sync_device_tunnel_status(wifi_ctrl_t *ctrl)
 
     status = (char *)data.raw_data.bytes;
     if (status != NULL) {
+        wifi_util_dbg_print(WIFI_CTRL, "%s:%d Tunnel status GET value=%s\n", __func__, __LINE__,
+            status);
         process_device_tunnel_status(status);
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d NULL tunnel status value\n", __func__, __LINE__);
@@ -2140,13 +2118,17 @@ static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void
     wifi_bus_desc_t *bus_desc = get_bus_descriptor();
     bus_error_t rc;
 
-    if (ctrl == NULL || bus_desc == NULL || strcmp(event_name, WIFI_HOTSPOT_STATUS) != 0 ||
+    if (ctrl == NULL || bus_desc == NULL || event_name == NULL || p_data == NULL ||
+        strcmp(event_name, WIFI_HOTSPOT_STATUS) != 0 ||
         p_data->value.data_type != bus_data_type_string) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid hotspot status event\n", __func__, __LINE__);
         return;
     }
 
     status = (char *)p_data->value.raw_data.bytes;
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Hotspot status event value=%s tunnel_subscribed=%d\n",
+        __func__, __LINE__, status != NULL ? status : "NULL",
+        ctrl->device_tunnel_status_subscribed);
     if (status == NULL) {
         wifi_util_error_print(WIFI_CTRL, "%s:%d NULL hotspot status\n", __func__, __LINE__);
         return;
@@ -2154,8 +2136,12 @@ static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void
 
     if (strcmp(status, "Enabled") == 0) {
         if (ctrl->device_tunnel_status_subscribed == false) {
+            wifi_util_dbg_print(WIFI_CTRL, "%s:%d Subscribing tunnel status path=%s\n", __func__,
+                __LINE__, WIFI_DEVICE_TUNNEL_STATUS);
             rc = bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS,
                 eventReceiveHandler, NULL, 0);
+            wifi_util_dbg_print(WIFI_CTRL, "%s:%d Tunnel status subscribe rc=%d\n", __func__,
+                __LINE__, rc);
             if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
                 ctrl->device_tunnel_status_subscribed = true;
                 sync_device_tunnel_status(ctrl);

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2125,10 +2125,12 @@ static void subscribe_device_tunnel_status(wifi_ctrl_t *ctrl)
         eventReceiveHandler, NULL, 0);
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d Tunnel status subscribe rc=%d\n", __func__, __LINE__,
         rc);
-    if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
-        ctrl->device_tunnel_status_subscribed = true;
+    if (rc == bus_error_success ||rc == bus_error_subscription_already_exist) {
+		ctrl->device_tunnel_status_subscribed = true;
+		if (rc == bus_error_success) {
         sync_device_tunnel_status(ctrl);
-    } else {
+		}
+	} else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to subscribe to %s, rc:%d\n", __func__,
             __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
     }

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1418,6 +1418,41 @@ static void wan_failover_handler(char *event_name, bus_data_prop_t *p_data, void
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d: recv data:%d\r\n", __func__, __LINE__, data_value);
 }
+
+static void hotspotTunnelHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
+{
+    (void)userData;
+    char *pTmp;
+
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Recvd Event\n",  __func__, __LINE__);
+
+    if(strcmp(event_name, "TunnelStatus") != 0) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Not Tunnel event, %s\n", __func__, __LINE__, event_name);
+        return;
+    } else if (p_data->value.data_type != bus_data_type_string) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
+                __func__, __LINE__, event_name, p_data->value.data_type);
+        return;
+    }
+
+    pTmp = (char *)p_data->value.raw_data.bytes;
+
+    if (pTmp == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: wrong bus data recived for Event %s", __func__, __LINE__, event_name);
+        return;
+    }
+
+    bool tunnel_status = false;
+    if (strcmp(pTmp, "TUNNEL_UP") == 0) {
+        tunnel_status = true;
+    }
+
+    wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
+                                                 wifi_event_type_xfinity_tunnel_down;
+    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
+        NULL);
+}
+
 bus_error_t get_assoc_clients_data(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
     (void)user_data;


### PR DESCRIPTION
RDKB-65658 TunnelStatus Subscription to be done based on hotspot status
Reason for change: TunnelStatus Subscription on OneWifi, has to be done based on hotspot status. the tunnel status event has been moved from PAM to hotspot component.

Test Procedure :

Load custom image
check Hotspot status
if hotspot is up , check for logs from /tmp/WifiCtrl showing TunnelStatus Subscription success
Priority: P0
Risks: medium
Signed-off-by: Sneha Kannan [sneha_kannan@comcast.com](mailto:sneha_kannan@comcast.com)
