### PR TITLE
RDKB-65658 TunnelStatus Subscription to be done based on hotspot status

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1459,7 +1459,6 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
     bus_register_handlers(ctrl);
 
     ctrl->bus_events_subscribed = false;
-    ctrl->tunnel_events_subscribed = false;
     ctrl->device_tunnel_status_subscribed = false;
     ctrl->hotspot_status_subscribed = false;
     ctrl->hotspot_enabled = false;
@@ -2348,7 +2347,7 @@ static int bus_check_and_subscribe_events(void* arg)
 
     if ((ctrl->bus_events_subscribed == false) ||
         (ctrl->device_mode_subscribed == false) || (ctrl->active_gateway_check_subscribed == false) ||
-        (ctrl->hotspot_enabled && ctrl->device_tunnel_status_subscribed == false) ||
+        (ctrl->hotspot_status_subscribed && ctrl->device_tunnel_status_subscribed == false) ||
         (ctrl->device_wps_test_subscribed == false) ||
         (ctrl->test_device_mode_subscribed == false) || (ctrl->mesh_status_subscribed == false) ||
         (ctrl->marker_list_config_subscribed == false) || (ctrl->mesh_keep_out_chans_subscribed == false) ||

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1462,6 +1462,7 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
     ctrl->device_tunnel_status_subscribed = false;
     ctrl->hotspot_status_subscribed = false;
     ctrl->hotspot_enabled = false;
+    ctrl->tunnel_events_subscribed = false;
 
     // subscribe for BUS events
     bus_subscribe_events(ctrl);

--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -1458,6 +1458,12 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
     //Register to BUS for webconfig interactions
     bus_register_handlers(ctrl);
 
+    ctrl->bus_events_subscribed = false;
+    ctrl->tunnel_events_subscribed = false;
+    ctrl->device_tunnel_status_subscribed = false;
+    ctrl->hotspot_status_subscribed = false;
+    ctrl->hotspot_enabled = false;
+
     // subscribe for BUS events
     bus_subscribe_events(ctrl);
 
@@ -1474,9 +1480,6 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
     wifi_chan_event_register(channel_change_callback);
 
     wifi_wpsEvent_callback_register(wps_event_callback);
-
-    ctrl->bus_events_subscribed = false;
-    ctrl->tunnel_events_subscribed = false;
 
 #if defined (FEATURE_SUPPORT_WEBCONFIG)
     register_with_webconfig_framework();
@@ -2339,14 +2342,14 @@ static int bus_check_and_subscribe_events(void* arg)
 
 #if defined (ONEWIFI_FEATURE_SUBSCRIBE_FLAGS)
     ctrl->mesh_status_subscribed = true;
-    ctrl->device_tunnel_status_subscribed = true;
     ctrl->device_mode_subscribed = true;
     ctrl->mesh_keep_out_chans_subscribed = true;
 #endif
 
-    if ((ctrl->bus_events_subscribed == false) || (ctrl->tunnel_events_subscribed == false) ||
+    if ((ctrl->bus_events_subscribed == false) ||
         (ctrl->device_mode_subscribed == false) || (ctrl->active_gateway_check_subscribed == false) ||
-        (ctrl->device_tunnel_status_subscribed == false) || (ctrl->device_wps_test_subscribed == false) ||
+        (ctrl->hotspot_enabled && ctrl->device_tunnel_status_subscribed == false) ||
+        (ctrl->device_wps_test_subscribed == false) ||
         (ctrl->test_device_mode_subscribed == false) || (ctrl->mesh_status_subscribed == false) ||
         (ctrl->marker_list_config_subscribed == false) || (ctrl->mesh_keep_out_chans_subscribed == false) ||
         (ctrl->hotspot_client_dhcp_failure_subscribed == false)

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -64,7 +64,7 @@ extern "C" {
 #define WIFI_TxRx_RATE_LIST                "Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.TxRxRateList"
 #define WIFI_DEVICE_MODE                   "Device.X_RDKCENTRAL-COM_DeviceControl.DeviceNetworkingMode"
 #define WIFI_DEVICE_TUNNEL_STATUS          "Device.X_COMCAST-COM_GRE.Tunnel.1.TunnelStatus"
-#define WIFI_HOTSPOT_STATUS                "Device.X_COMCAST-COM_GRE.Tunnel.1.Status"
+#define WIFI_HOTSPOT_STATUS                "Device.X_COMCAST-COM_GRE.Tunnel.1.Enable"
 #define SPEEDTEST_STATUS                   "Device.IP.Diagnostics.X_RDKCENTRAL-COM_SpeedTest.Status"
 #define SPEEDTEST_SUBSCRIBE                "Device.IP.Diagnostics.X_RDK_SpeedTest.SubscriberUnPauseTimeOut"
 

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -64,6 +64,7 @@ extern "C" {
 #define WIFI_TxRx_RATE_LIST                "Device.DeviceInfo.X_RDKCENTRAL-COM_WIFI_TELEMETRY.TxRxRateList"
 #define WIFI_DEVICE_MODE                   "Device.X_RDKCENTRAL-COM_DeviceControl.DeviceNetworkingMode"
 #define WIFI_DEVICE_TUNNEL_STATUS          "Device.X_COMCAST-COM_GRE.Tunnel.1.TunnelStatus"
+#define WIFI_HOTSPOT_STATUS                "Device.X_COMCAST-COM_GRE.Tunnel.1.Status"
 #define SPEEDTEST_STATUS                   "Device.IP.Diagnostics.X_RDKCENTRAL-COM_SpeedTest.Status"
 #define SPEEDTEST_SUBSCRIBE                "Device.IP.Diagnostics.X_RDK_SpeedTest.SubscriberUnPauseTimeOut"
 
@@ -250,6 +251,8 @@ typedef struct wifi_ctrl {
     bool                device_mode_subscribed;
     bool                test_device_mode_subscribed;
     bool                device_tunnel_status_subscribed;
+    bool                hotspot_status_subscribed;
+    bool                hotspot_enabled;
     bool                device_wps_test_subscribed;
     bool                frame_802_11_injector_subscribed;
     bool                factory_reset;

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1418,6 +1418,39 @@ static void wan_failover_handler(char *event_name, bus_data_prop_t *p_data, void
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d: recv data:%d\r\n", __func__, __LINE__, data_value);
 }
+static void hotspotTunnelHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
+{
+    (void)userData;
+    char *pTmp;
+
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Recvd Event\n",  __func__, __LINE__);
+
+    if(strcmp(event_name, "TunnelStatus") != 0) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Not Tunnel event, %s\n", __func__, __LINE__, event_name);
+        return;
+    } else if (p_data->value.data_type != bus_data_type_string) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
+                __func__, __LINE__, event_name, p_data->value.data_type);
+        return;
+    }
+
+    pTmp = (char *)p_data->value.raw_data.bytes;
+
+    if (pTmp == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: wrong bus data recived for Event %s", __func__, __LINE__, event_name);
+        return;
+    }
+
+    bool tunnel_status = false;
+    if (strcmp(pTmp, "TUNNEL_UP") == 0) {
+        tunnel_status = true;
+    }
+
+    wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
+                                                 wifi_event_type_xfinity_tunnel_down;
+    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
+        NULL);
+}
 
 bus_error_t get_assoc_clients_data(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
@@ -2525,7 +2558,7 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
     }
 #endif
 
-	    if (consumer_app_file == 0 && ctrl->tunnel_events_subscribed == false) {
+    if (consumer_app_file == 0 && ctrl->tunnel_events_subscribed == false) {
         // TODO - what's the namespace for the event
         int rc = bus_desc->bus_event_subs_fn(&ctrl->handle, "TunnelStatus", hotspotTunnelHandler,
             NULL, 0);
@@ -2538,7 +2571,7 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
                 __FUNCTION__, __LINE__, rc);
         }
     }
-	
+
     if (ctrl->mesh_status_subscribed == false) {
         int rc = bus_desc->bus_event_subs_fn(&ctrl->handle, MESH_STATUS, meshStatusHandler, NULL,
             0);

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2535,6 +2535,20 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
     }
 #endif
 
+	    if (consumer_app_file == 0 && ctrl->tunnel_events_subscribed == false) {
+        // TODO - what's the namespace for the event
+        int rc = bus_desc->bus_event_subs_fn(&ctrl->handle, "TunnelStatus", hotspotTunnelHandler,
+            NULL, 0);
+        if (rc != bus_error_success) {
+            // wifi_util_dbg_print(WIFI_CTRL,"%s:%d TunnelStatus subscribe Failed, rc:
+            // %d\n",__FUNCTION__, __LINE__, rc);
+        } else {
+            ctrl->tunnel_events_subscribed = true;
+            wifi_util_info_print(WIFI_CTRL, "%s:%d TunnelStatus subscribe success, rc: %d\n",
+                __FUNCTION__, __LINE__, rc);
+        }
+    }
+	
     if (ctrl->mesh_status_subscribed == false) {
         int rc = bus_desc->bus_event_subs_fn(&ctrl->handle, MESH_STATUS, meshStatusHandler, NULL,
             0);

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -1418,39 +1418,6 @@ static void wan_failover_handler(char *event_name, bus_data_prop_t *p_data, void
 
     wifi_util_dbg_print(WIFI_CTRL, "%s:%d: recv data:%d\r\n", __func__, __LINE__, data_value);
 }
-static void hotspotTunnelHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
-{
-    (void)userData;
-    char *pTmp;
-
-    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Recvd Event\n",  __func__, __LINE__);
-
-    if(strcmp(event_name, "TunnelStatus") != 0) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d Not Tunnel event, %s\n", __func__, __LINE__, event_name);
-        return;
-    } else if (p_data->value.data_type != bus_data_type_string) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d: Invalid Received:%s data type:%x",
-                __func__, __LINE__, event_name, p_data->value.data_type);
-        return;
-    }
-
-    pTmp = (char *)p_data->value.raw_data.bytes;
-
-    if (pTmp == NULL) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d: wrong bus data recived for Event %s", __func__, __LINE__, event_name);
-        return;
-    }
-
-    bool tunnel_status = false;
-    if (strcmp(pTmp, "TUNNEL_UP") == 0) {
-        tunnel_status = true;
-    }
-
-    wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
-                                                 wifi_event_type_xfinity_tunnel_down;
-    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
-        NULL);
-}
 
 bus_error_t get_assoc_clients_data(char *event_name, raw_data_t *p_data, bus_user_data_t *user_data)
 {
@@ -2066,42 +2033,120 @@ static void meshStatusHandler(char *event_name, bus_data_prop_t *p_data, void *u
         wifi_event_type_command_mesh_status, NULL);
 }
 
+static void process_device_tunnel_status(const char *status)
+{
+    bool tunnel_status = false;
+    wifi_event_subtype_t ces_t;
+
+    if (strcmp(status, "Up") == 0) {
+        tunnel_status = true;
+    } else if (strcmp(status, "Down") != 0) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d: Received Unsupported value:%s\n", __func__,
+            __LINE__, status);
+        return;
+    }
+
+    ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
+                            wifi_event_type_xfinity_tunnel_down;
+    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
+        NULL);
+}
+
 static void eventReceiveHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
-    bool tunnel_status = false;
     char *pTmp = NULL;
 
-    wifi_util_dbg_print(WIFI_CTRL, " %s:%d Recvd Event\n", __func__, __LINE__);
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d TunnelStatus callback event=%s data=%p\n", __func__,
+        __LINE__, event_name != NULL ? event_name : "NULL", (void *)p_data);
 
-    if ((strcmp(event_name, WIFI_DEVICE_TUNNEL_STATUS) == 0) && p_data->value.data_type == bus_data_type_string) {
-
+    if (event_name != NULL && p_data != NULL &&
+        (strcmp(event_name, WIFI_DEVICE_TUNNEL_STATUS) == 0) &&
+        p_data->value.data_type == bus_data_type_string) {
         pTmp = (char *)p_data->value.raw_data.bytes;
-        if(pTmp == NULL) {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d: Unable to get  value in event:%s\n", __func__, __LINE__, event_name);
+        if (pTmp == NULL) {
+            wifi_util_error_print(WIFI_CTRL, "%s:%d: Unable to get value in event:%s\n", __func__,
+                __LINE__, event_name);
             return;
         }
-
-        if (strcmp(pTmp, "Up") == 0) {
-            tunnel_status = true;
-        } else if (strcmp(pTmp, "Down") == 0) {
-            tunnel_status = false;
-        } else {
-            wifi_util_error_print(WIFI_CTRL, "%s:%d: Received Unsupported value\n", __func__,
-                __LINE__);
-            return;
-        }
-        wifi_util_dbg_print(WIFI_CTRL, "%s:%d: event:%s: value:%d\n", __func__, __LINE__,
-            event_name, tunnel_status);
     } else {
         wifi_util_error_print(WIFI_CTRL, "%s:%d: Unsupported event:%s:%x\n", __func__, __LINE__,
-            event_name, p_data->value.data_type);
+            event_name != NULL ? event_name : "NULL",
+            p_data != NULL ? p_data->value.data_type : 0);
         return;
     }
-    wifi_event_subtype_t ces_t = tunnel_status ? wifi_event_type_xfinity_tunnel_up :
-                                                 wifi_event_type_xfinity_tunnel_down;
-    push_event_to_ctrl_queue(&tunnel_status, sizeof(tunnel_status), wifi_event_type_command, ces_t,
-        NULL);
+
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d TunnelStatus callback value=%s\n", __func__, __LINE__,
+        pTmp);
+    process_device_tunnel_status(pTmp);
+}
+
+static void subscribe_device_tunnel_status(wifi_ctrl_t *ctrl)
+{
+    wifi_bus_desc_t *bus_desc = get_bus_descriptor();
+    bus_error_t rc;
+
+    if (ctrl == NULL || bus_desc == NULL || ctrl->hotspot_enabled == false ||
+        ctrl->device_tunnel_status_subscribed) {
+        return;
+    }
+
+    rc = bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS,
+        eventReceiveHandler, NULL, 0);
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Tunnel status subscribe rc=%d\n", __func__, __LINE__,
+        rc);
+    if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
+        ctrl->device_tunnel_status_subscribed = true;
+    } else {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Failed to subscribe to %s, rc:%d\n", __func__,
+            __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
+    }
+}
+
+static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
+{
+    (void)userData;
+    char *status = NULL;
+    wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
+    wifi_bus_desc_t *bus_desc = get_bus_descriptor();
+    bus_error_t rc;
+
+    if (ctrl == NULL || bus_desc == NULL || event_name == NULL || p_data == NULL ||
+        strcmp(event_name, WIFI_HOTSPOT_STATUS) != 0 ||
+        p_data->value.data_type != bus_data_type_string) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid hotspot status event\n", __func__,
+            __LINE__);
+        return;
+    }
+
+    status = (char *)p_data->value.raw_data.bytes;
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Hotspot status event value=%s tunnel_subscribed=%d\n",
+        __func__, __LINE__, status != NULL ? status : "NULL",
+        ctrl->device_tunnel_status_subscribed);
+    if (status == NULL) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d NULL hotspot status\n", __func__, __LINE__);
+        return;
+    }
+
+    if (strcmp(status, "Enabled") == 0) {
+        ctrl->hotspot_enabled = true;
+        subscribe_device_tunnel_status(ctrl);
+    } else if (strcmp(status, "Disabled") == 0) {
+        ctrl->hotspot_enabled = false;
+        if (ctrl->device_tunnel_status_subscribed) {
+            rc = bus_desc->bus_event_unsubs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS);
+            if (rc == bus_error_success) {
+                ctrl->device_tunnel_status_subscribed = false;
+            } else {
+                wifi_util_error_print(WIFI_CTRL,
+                    "%s:%d Failed to unsubscribe from %s, rc:%d\n",
+                    __func__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
+            }
+        }
+    } else {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Unsupported hotspot status:%s\n", __func__,
+            __LINE__, status);
+    }
 }
 
 static void frame_802_11_injector_Handler(char *event_name, bus_data_prop_t *p_data, void *userData)
@@ -2490,20 +2535,6 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
     }
 #endif
 
-    if (consumer_app_file == 0 && ctrl->tunnel_events_subscribed == false) {
-        // TODO - what's the namespace for the event
-        int rc = bus_desc->bus_event_subs_fn(&ctrl->handle, "TunnelStatus", hotspotTunnelHandler,
-            NULL, 0);
-        if (rc != bus_error_success) {
-            // wifi_util_dbg_print(WIFI_CTRL,"%s:%d TunnelStatus subscribe Failed, rc:
-            // %d\n",__FUNCTION__, __LINE__, rc);
-        } else {
-            ctrl->tunnel_events_subscribed = true;
-            wifi_util_info_print(WIFI_CTRL, "%s:%d TunnelStatus subscribe success, rc: %d\n",
-                __FUNCTION__, __LINE__, rc);
-        }
-    }
-
     if (ctrl->mesh_status_subscribed == false) {
         int rc = bus_desc->bus_event_subs_fn(&ctrl->handle, MESH_STATUS, meshStatusHandler, NULL,
             0);
@@ -2531,17 +2562,30 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
     }
 #endif
 
-    if (ctrl->device_tunnel_status_subscribed == false) {
-        if (bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS,
-                eventReceiveHandler, NULL, 0) != bus_error_success) {
-            // wifi_util_dbg_print(WIFI_CTRL,"%s:%d bus: bus event:%s subscribe
-            // failed\n",__FUNCTION__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS);
+    if (ctrl->hotspot_status_subscribed == false) {
+        bus_error_t rc = bus_desc->bus_event_subs_fn(&ctrl->handle, WIFI_HOTSPOT_STATUS,
+            hotspotStatusHandler, NULL, 0);
+        if (rc == bus_error_success || rc == bus_error_subscription_already_exist) {
+            ctrl->hotspot_status_subscribed = true;
+            raw_data_t hs_data;
+            memset(&hs_data, 0, sizeof(raw_data_t));
+            rc = bus_desc->bus_data_get_fn(&ctrl->handle, WIFI_HOTSPOT_STATUS, &hs_data);
+            if (rc == bus_error_success && hs_data.data_type == bus_data_type_string) {
+                char *hs_val = (char *)hs_data.raw_data.bytes;
+                if (hs_val != NULL && strcmp(hs_val, "Enabled") == 0) {
+                    ctrl->hotspot_enabled = true;
+                    wifi_util_info_print(WIFI_CTRL, "%s:%d Hotspot already Enabled at startup\n",
+                        __func__, __LINE__);
+                }
+            }
+            bus_desc->bus_data_free_fn(&hs_data);
         } else {
-            ctrl->device_tunnel_status_subscribed = true;
-            wifi_util_info_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe success\n",
-                __FUNCTION__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS);
+            wifi_util_error_print(WIFI_CTRL, "%s:%d %s subscription failed, rc:%d\n", __func__,
+                __LINE__, WIFI_HOTSPOT_STATUS, rc);
         }
     }
+
+    subscribe_device_tunnel_status(ctrl);
 
     if (consumer_app_file == 0 && ctrl->device_wps_test_subscribed == false) {
         if (bus_desc->bus_event_subs_fn(&ctrl->handle, BUS_WIFI_WPS_PIN_START,
@@ -2634,7 +2678,7 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
         }
     }
 #endif
-    if(!ctrl->hotspot_client_dhcp_failure_subscribed) {
+    if (!ctrl->hotspot_client_dhcp_failure_subscribed && ctrl->hotspot_enabled) {
         if (bus_desc->bus_event_subs_fn(&ctrl->handle, HOTSPOT_CLIENT_DHCP_FAILURE_DISCONNECTED, hotspot_client_dhcp_failure_disconnect, NULL, 
             0) != bus_error_success) {
             // wifi_util_dbg_print(WIFI_CTRL, "%s:%d bus: bus event:%s subscribe fail\n",

--- a/source/core/wifi_ctrl_rbus_handlers.c
+++ b/source/core/wifi_ctrl_rbus_handlers.c
@@ -2106,33 +2106,26 @@ static void subscribe_device_tunnel_status(wifi_ctrl_t *ctrl)
 static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void *userData)
 {
     (void)userData;
-    char *status = NULL;
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     wifi_bus_desc_t *bus_desc = get_bus_descriptor();
     bus_error_t rc;
 
     if (ctrl == NULL || bus_desc == NULL || event_name == NULL || p_data == NULL ||
         strcmp(event_name, WIFI_HOTSPOT_STATUS) != 0 ||
-        p_data->value.data_type != bus_data_type_string) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid hotspot status event\n", __func__,
+        p_data->value.data_type != bus_data_type_boolean) {
+        wifi_util_error_print(WIFI_CTRL, "%s:%d Invalid hotspot enable event\n", __func__,
             __LINE__);
         return;
     }
 
-    status = (char *)p_data->value.raw_data.bytes;
-    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Hotspot status event value=%s tunnel_subscribed=%d\n",
-        __func__, __LINE__, status != NULL ? status : "NULL",
+    ctrl->hotspot_enabled = p_data->value.raw_data.b;
+    wifi_util_dbg_print(WIFI_CTRL, "%s:%d Hotspot enable event value=%d tunnel_subscribed=%d\n",
+        __func__, __LINE__, ctrl->hotspot_enabled,
         ctrl->device_tunnel_status_subscribed);
-    if (status == NULL) {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d NULL hotspot status\n", __func__, __LINE__);
-        return;
-    }
 
-    if (strcmp(status, "Enabled") == 0) {
-        ctrl->hotspot_enabled = true;
+    if (ctrl->hotspot_enabled) {
         subscribe_device_tunnel_status(ctrl);
-    } else if (strcmp(status, "Disabled") == 0) {
-        ctrl->hotspot_enabled = false;
+    } else {
         if (ctrl->device_tunnel_status_subscribed) {
             rc = bus_desc->bus_event_unsubs_fn(&ctrl->handle, WIFI_DEVICE_TUNNEL_STATUS);
             if (rc == bus_error_success) {
@@ -2143,9 +2136,6 @@ static void hotspotStatusHandler(char *event_name, bus_data_prop_t *p_data, void
                     __func__, __LINE__, WIFI_DEVICE_TUNNEL_STATUS, rc);
             }
         }
-    } else {
-        wifi_util_error_print(WIFI_CTRL, "%s:%d Unsupported hotspot status:%s\n", __func__,
-            __LINE__, status);
     }
 }
 
@@ -2584,10 +2574,9 @@ void bus_subscribe_events(wifi_ctrl_t *ctrl)
             raw_data_t hs_data;
             memset(&hs_data, 0, sizeof(raw_data_t));
             rc = bus_desc->bus_data_get_fn(&ctrl->handle, WIFI_HOTSPOT_STATUS, &hs_data);
-            if (rc == bus_error_success && hs_data.data_type == bus_data_type_string) {
-                char *hs_val = (char *)hs_data.raw_data.bytes;
-                if (hs_val != NULL && strcmp(hs_val, "Enabled") == 0) {
-                    ctrl->hotspot_enabled = true;
+            if (rc == bus_error_success && hs_data.data_type == bus_data_type_boolean) {
+                ctrl->hotspot_enabled = hs_data.raw_data.b;
+                if (ctrl->hotspot_enabled) {
                     wifi_util_info_print(WIFI_CTRL, "%s:%d Hotspot already Enabled at startup\n",
                         __func__, __LINE__);
                 }


### PR DESCRIPTION
RDKB-65658 TunnelStatus Subscription to be done based on hotspot status
Reason for change: TunnelStatus Subscription on OneWifi, has to be done based on hotspot status. the tunnel status event has been moved from PAM to hotspot component.

Test Procedure :

Load custom image
check Hotspot status
if hotspot is up , check for logs from /tmp/WifiCtrl showing TunnelStatus Subscription success
Priority: P0
Risks: medium
Signed-off-by: Sneha Kannan [sneha_kannan@comcast.com](mailto:sneha_kannan@comcast.com)