### PR TITLE
RDKB-66071 MLO client connection log message update (#1271) (#1273)

### DIFF
--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -2520,8 +2520,8 @@ void process_assoc_device_event(void *data)
             wifi_util_error_print(WIFI_CTRL, "%s:%d No valid associated link found for MLD STA " MAC_FMT "\n",
                 __func__, __LINE__, MAC_ARG(assoc_data->dev_stats.cli_MACAddress));
         }
-        wifi_util_info_print(WIFI_CTRL, "%s:%d MLO client connected " MAC_FMT " with %d links\n",
-            __func__, __LINE__, MAC_ARG(assoc_data->dev_stats.cli_MACAddress), num_links);
+        wifi_util_info_print(WIFI_CTRL, "%s:%d MLO client connected with %d links " MAC_FMT "\n",
+            __func__, __LINE__, num_links, MAC_ARG(assoc_data->dev_stats.cli_MACAddress));
     } else {
         assoc_dev_event(assoc_data);
     }


### PR DESCRIPTION
Reason for change: Update MLO client connection log message to required format

Test Procedure: Connect the Wifi7 client in MLO mode and verify that the connection log message meets the required format.

Risks: Low
Priority: P1