### PR TITLE
RDKB-66207: [CI] Make gcc-gate and clang-tidy line scoping

### DIFF
--- a/.github/scripts/diff_to_suggestions.py
+++ b/.github/scripts/diff_to_suggestions.py
@@ -63,7 +63,10 @@ import re
 import sys
 
 HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
-CHANGED_LINE = re.compile(r"^([^:]+):(\d+)-(\d+)$")
+# Split on the LAST ':' — the range is always the final field, and a path may
+# itself contain ':' (legal on POSIX). A greedy '.+' with the anchored numeric
+# tail backtracks to the right delimiter; '[^:]+' would drop colon-in-path files.
+CHANGED_LINE = re.compile(r"^(.+):(\d+)-(\d+)$")
 
 
 def load_changed_lines(path):

--- a/.github/scripts/diff_to_suggestions.py
+++ b/.github/scripts/diff_to_suggestions.py
@@ -18,16 +18,37 @@
 # limitations under the License.
 #
 """Convert a git-clang-format unified diff (read from stdin) into GitHub PR review
-suggestions.
+suggestions, scoped to lines the PR actually changed.
 
 Writes two files consumed by the pr-comments.yml `format` job:
   /tmp/comments.json  - the (capped) list of review comments
   /tmp/review.json    - the full review payload for POST .../pulls/{n}/reviews
 
 Environment:
-  HEAD_SHA       required - commit the review is posted against.
-  MAX_COMMENTS   optional - cap on comments per review (default 25). Large
-                 reviews trigger GitHub rate limiting and fail as a misleading 404 error.
+  HEAD_SHA            required - commit the review is posted against.
+  MAX_COMMENTS        optional - cap on comments per review (default 25). Large
+                      reviews trigger GitHub rate limiting and fail as a misleading
+                      404 error.
+  CHANGED_LINES_FILE  optional - path to a file listing the PR's changed lines
+                      (format: "path:start-end" per line, new-side line numbers).
+                      When present, suggestions that target only lines the PR did
+                      NOT change are dropped. When absent or unparseable, all
+                      suggestions are kept (fail-open, same as before this filter).
+
+Line scoping rationale: git-clang-format can reformat lines adjacent to the
+actual change. The primary mechanism (verified in git_clang_format 18.1.8,
+extract_lines_from_patch): when a hunk is a pure deletion (+C,0 — zero
+new-side lines), the script forces line_count to 1 and formats the line at
+the deletion site. ColumnLimit / SortIncludes can also cascade beyond changed
+lines. Without this filter, the PR review would contain suggestions on lines
+the author never touched — confusing and noisy. A suggestion is kept if ANY
+of its target lines overlaps a PR-changed line (so a multi-line reformat
+triggered by one changed line still posts).
+
+Note: a deletions-only PR produces an empty changed-lines file (no new-side
+lines) → filter active with zero lines → all suggestions dropped. This is
+correct (no surviving line was changed), distinct from a missing file which
+is fail-open.
 
 A "Commit suggestion" button is just a review comment whose body is a
 ```suggestion block. In the diff the 'old' side (-) is the text currently in the
@@ -42,6 +63,35 @@ import re
 import sys
 
 HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+CHANGED_LINE = re.compile(r"^([^:]+):(\d+)-(\d+)$")
+
+
+def load_changed_lines(path):
+    """Load {file: set_of_changed_line_numbers} from a changed-lines file.
+
+    Each line is "path:start-end" (inclusive, new-side line numbers from
+    git diff -U0). Returns None on any I/O or parse error (fail-open).
+    """
+    try:
+        changed = {}
+        with open(path) as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue                      # blank line: an empty file (deletions-only PR) is valid
+                m = CHANGED_LINE.match(line)
+                if not m:
+                    # A malformed record must not silently shrink the map (that would
+                    # drop the affected file's suggestions). Fail open instead: raise
+                    # so the handler below returns None and all suggestions are kept.
+                    raise ValueError(f"unparseable changed-lines record: {line!r}")
+                f, s, e = m.group(1), int(m.group(2)), int(m.group(3))
+                changed.setdefault(f, set()).update(range(s, e + 1))
+        return changed
+    except (OSError, ValueError) as exc:
+        print(f"::warning::Could not load changed-lines file {path}: {exc} "
+              "(posting unfiltered)", file=sys.stderr)
+        return None
 
 
 def parse(diff_text):
@@ -106,6 +156,24 @@ def parse(diff_text):
 
 def main():
     comments = parse(sys.stdin.read())
+    raw_total = len(comments)
+
+    # Line-scope: drop suggestions that target only lines the PR didn't change.
+    cl_path = os.environ.get("CHANGED_LINES_FILE", "")
+    changed = load_changed_lines(cl_path) if cl_path else None
+    if changed is not None:
+        def overlaps(c):
+            lines = changed.get(c["path"])
+            if lines is None:
+                return False
+            start = c.get("start_line", c["line"])
+            return any(ln in lines for ln in range(start, c["line"] + 1))
+        before = len(comments)
+        comments = [c for c in comments if overlaps(c)]
+        dropped = before - len(comments)
+        if dropped:
+            print(f"Line-scoping: dropped {dropped} suggestion(s) on untouched lines")
+
     total = len(comments)
     cap = int(os.environ.get("MAX_COMMENTS", "25"))
     if total > cap:
@@ -131,7 +199,8 @@ def main():
     }
     with open("/tmp/review.json", "w") as fh:
         json.dump(review, fh)
-    print(f"{total} suggestion(s) parsed; prepared {len(comments)} to post")
+    print(f"{raw_total} suggestion(s) parsed, {total} after line-scoping; "
+          f"prepared {len(comments)} to post")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/diff_to_suggestions.py
+++ b/.github/scripts/diff_to_suggestions.py
@@ -41,9 +41,15 @@ extract_lines_from_patch): when a hunk is a pure deletion (+C,0 — zero
 new-side lines), the script forces line_count to 1 and formats the line at
 the deletion site. ColumnLimit / SortIncludes can also cascade beyond changed
 lines. Without this filter, the PR review would contain suggestions on lines
-the author never touched — confusing and noisy. A suggestion is kept if ANY
-of its target lines overlaps a PR-changed line (so a multi-line reformat
-triggered by one changed line still posts).
+the author never touched — confusing and noisy. A suggestion is kept only if it
+is BOTH (a) *relevant* — it overlaps at least one line the PR actually changed —
+and (b) *postable* — its whole line range lies inside the region GitHub will accept
+a comment on: the changed lines PLUS the diff context rendered around them. Neither
+half suffices alone: mere overlap risks a 422 (GitHub anchors a multi-line review
+comment on both endpoints and rejects the ENTIRE review if either is outside the
+rendered diff, so one out-of-range suggestion drops them all); containment in the
+changed lines alone was the opposite error, dropping a reformat that cascades a line
+or two into commentable context. See relevant_and_postable() below.
 
 Note: a deletions-only PR produces an empty changed-lines file (no new-side
 lines) → filter active with zero lines → all suggestions dropped. This is
@@ -80,6 +86,24 @@ CHANGED_LINE = re.compile(r"^(.+):(\d+)-(\d+)$")
 # beyond it we fail open (post unfiltered, still capped by MAX_COMMENTS).
 MAX_CHANGED_RECORDS = 1_000_000
 
+# Total-byte guard on the same attacker-influenced file. The record cap above counts
+# newline-delimited records, but `for raw in fh` materializes one physical line at a time,
+# so a single newline-free multi-GB line would OOM-kill this job before any record is seen
+# (and MemoryError escapes the OSError/ValueError handler below). An fstat on the open
+# handle bounds total bytes up front -- no line can exceed the file -- closing both the
+# single-huge-line case and a flood of blank lines (which `continue` before the counter).
+# 64 MiB is generous next to the ~20 B/record minimum implied by the 1M-record cap.
+MAX_FILE_BYTES = 64 * 1024 * 1024
+
+# GitHub renders a PR diff with a few lines of CONTEXT around each change, and those context
+# lines are commentable too — so the region a review comment may anchor in is the changed
+# lines GROWN by this margin (then merged where two hunks sit close enough to render as one).
+# 3 is GitHub's default rendered context. This is the one value here NOT backed by a documented
+# API contract: too small over-drops valid suggestions (safe); too large risks a residual 422,
+# which the pr-comments.yml handler absorbs as an advisory. Set to 0 to recover strict
+# containment-in-changed-lines.
+DIFF_CONTEXT = 3
+
 
 def load_changed_lines(path):
     """Load {file: [(start, end), ...]} changed-line intervals from a changed-lines file.
@@ -93,6 +117,10 @@ def load_changed_lines(path):
         changed = {}
         records = 0
         with open(path) as fh:
+            if os.fstat(fh.fileno()).st_size > MAX_FILE_BYTES:
+                # Reject before reading: bounds memory regardless of how the bytes are
+                # split into lines. Raise so the handler below fails open (post unfiltered).
+                raise ValueError(f"changed-lines file exceeds {MAX_FILE_BYTES} bytes")
             for raw in fh:
                 line = raw.strip()
                 if not line:
@@ -120,6 +148,21 @@ def load_changed_lines(path):
         print(f"::warning::Could not load changed-lines file {path}: {exc} "
               "(posting unfiltered)", file=sys.stderr)
         return None
+
+
+def _commentable_intervals(intervals, ctx):
+    """Changed intervals grown by `ctx` and merged — the line ranges GitHub will accept a
+    review comment on (a hunk's changed lines plus the context lines rendered around them).
+    Two grown intervals that touch/overlap (i.e. the original change gap is <= 2*ctx, which
+    is exactly when git renders one contiguous hunk) merge into one region."""
+    grown = sorted((max(1, s - ctx), e + ctx) for (s, e) in intervals)
+    merged = []
+    for s, e in grown:
+        if merged and s <= merged[-1][1] + 1:     # overlaps or adjoins the previous region
+            merged[-1][1] = max(merged[-1][1], e)
+        else:
+            merged.append([s, e])
+    return merged
 
 
 def parse(diff_text):
@@ -196,23 +239,31 @@ def main():
     cl_path = os.environ.get("CHANGED_LINES_FILE", "")
     changed = load_changed_lines(cl_path) if cl_path else None
     if changed is not None:
-        def overlaps(c):
-            intervals = changed.get(c["path"])
-            if not intervals:                     # None (file untouched) or empty
+        # Precompute the commentable region (changed lines grown by DIFF_CONTEXT, merged)
+        # once per file; the raw changed intervals stay for the relevance test below.
+        commentable = {f: _commentable_intervals(ivs, DIFF_CONTEXT)
+                       for f, ivs in changed.items()}
+
+        def relevant_and_postable(c):
+            raw = changed.get(c["path"])
+            if not raw:                           # file untouched by the PR
                 return False
             cstart = c.get("start_line", c["line"])
             cend = c["line"]
-            # The comment spans the contiguous range [cstart, cend]; keep it if
-            # that interval intersects any changed interval for this file. Because
-            # every changed interval [s, e] is itself contiguous, an intersection
-            # guarantees a shared line — exactly equivalent to the old per-line set
-            # membership test, without materializing (and bounding) the lines.
-            return any(s <= cend and cstart <= e for (s, e) in intervals)
+            # (a) relevant: the comment range overlaps >=1 line the PR actually changed.
+            #     Drops a reformat sitting wholly on context lines the author never touched.
+            touches = any(s <= cend and cstart <= e for (s, e) in raw)
+            # (b) postable: its whole range lies inside the commentable region, so GitHub
+            #     accepts the anchor and does not 422 the review. Overlap alone risked that
+            #     422; containment-in-changed alone over-dropped a reformat cascading a line
+            #     or two into commentable context. Keep only what is both.
+            postable = any(s <= cstart and cend <= e for (s, e) in commentable[c["path"]])
+            return touches and postable
         before = len(comments)
-        comments = [c for c in comments if overlaps(c)]
+        comments = [c for c in comments if relevant_and_postable(c)]
         dropped = before - len(comments)
         if dropped:
-            print(f"Line-scoping: dropped {dropped} suggestion(s) on untouched lines")
+            print(f"Line-scoping: dropped {dropped} suggestion(s) off the PR's changed/commentable lines")
 
     total = len(comments)
     cap = int(os.environ.get("MAX_COMMENTS", "25"))

--- a/.github/scripts/diff_to_suggestions.py
+++ b/.github/scripts/diff_to_suggestions.py
@@ -68,15 +68,30 @@ HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 # tail backtracks to the right delimiter; '[^:]+' would drop colon-in-path files.
 CHANGED_LINE = re.compile(r"^(.+):(\d+)-(\d+)$")
 
+# Upper bound on records loaded from CHANGED_LINES_FILE. That file is a stage-1
+# artifact built over untrusted fork PR code (clang-format.yml runs on
+# `pull_request`, whose workflow the PR author can modify), yet it is consumed
+# here in the trusted `pull-requests: write` comment job — so it is
+# attacker-influenced input. Ranges are kept as (start, end) intervals and NEVER
+# expanded into per-line sets, so a compact hostile record like "x.c:1-1000000000"
+# costs one tuple, not a billion-element set that would OOM-kill this job (and
+# MemoryError is not an OSError/ValueError — it would escape the handler below and
+# crash the step). This cap additionally bounds a pathological many-record file;
+# beyond it we fail open (post unfiltered, still capped by MAX_COMMENTS).
+MAX_CHANGED_RECORDS = 1_000_000
+
 
 def load_changed_lines(path):
-    """Load {file: set_of_changed_line_numbers} from a changed-lines file.
+    """Load {file: [(start, end), ...]} changed-line intervals from a changed-lines file.
 
     Each line is "path:start-end" (inclusive, new-side line numbers from
-    git diff -U0). Returns None on any I/O or parse error (fail-open).
+    git diff -U0). Ranges are stored as intervals, NOT expanded into sets, so a
+    hostile range cannot exhaust memory (see MAX_CHANGED_RECORDS). Returns None on
+    any I/O or parse error, or if the record cap is exceeded (fail-open).
     """
     try:
         changed = {}
+        records = 0
         with open(path) as fh:
             for raw in fh:
                 line = raw.strip()
@@ -89,7 +104,17 @@ def load_changed_lines(path):
                     # so the handler below returns None and all suggestions are kept.
                     raise ValueError(f"unparseable changed-lines record: {line!r}")
                 f, s, e = m.group(1), int(m.group(2)), int(m.group(3))
-                changed.setdefault(f, set()).update(range(s, e + 1))
+                if s > e:
+                    # Reversed range. With sets, range(5,3) was silently empty; with
+                    # intervals a (5,2) tuple would spuriously overlap-match, so treat
+                    # it as malformed and fail open rather than change matching
+                    # behavior. Well-formed git-diff -U0 records always have s <= e.
+                    raise ValueError(f"reversed changed-lines record: {line!r}")
+                records += 1
+                if records > MAX_CHANGED_RECORDS:
+                    raise ValueError(
+                        f"changed-lines file exceeds {MAX_CHANGED_RECORDS} records")
+                changed.setdefault(f, []).append((s, e))
         return changed
     except (OSError, ValueError) as exc:
         print(f"::warning::Could not load changed-lines file {path}: {exc} "
@@ -172,11 +197,17 @@ def main():
     changed = load_changed_lines(cl_path) if cl_path else None
     if changed is not None:
         def overlaps(c):
-            lines = changed.get(c["path"])
-            if lines is None:
+            intervals = changed.get(c["path"])
+            if not intervals:                     # None (file untouched) or empty
                 return False
-            start = c.get("start_line", c["line"])
-            return any(ln in lines for ln in range(start, c["line"] + 1))
+            cstart = c.get("start_line", c["line"])
+            cend = c["line"]
+            # The comment spans the contiguous range [cstart, cend]; keep it if
+            # that interval intersects any changed interval for this file. Because
+            # every changed interval [s, e] is itself contiguous, an intersection
+            # guarantees a shared line — exactly equivalent to the old per-line set
+            # membership test, without materializing (and bounding) the lines.
+            return any(s <= cend and cstart <= e for (s, e) in intervals)
         before = len(comments)
         comments = [c for c in comments if overlaps(c)]
         dropped = before - len(comments)

--- a/.github/scripts/diff_to_suggestions.py
+++ b/.github/scripts/diff_to_suggestions.py
@@ -98,6 +98,12 @@ def load_changed_lines(path):
 
 
 def parse(diff_text):
+    # diff_text is the git-clang-format diff (HEAD vs its reformatted copy), NOT the
+    # PR diff. So the '-' side is the current PR HEAD file: old_ln (the '-' line
+    # number) is already in HEAD coordinates — exactly what a GitHub side:RIGHT
+    # suggestion anchors on, and the same coordinate system as CHANGED_LINES_FILE
+    # (git diff -U0 BASE HEAD, new-side). Do NOT "fix" this to the '+' range: those
+    # are the reformatted-file line numbers, which match neither GitHub nor the filter.
     comments, path, old_ln = [], None, 0
     removed, added, start = [], [], None
 

--- a/.github/scripts/gcc_diff_gate.py
+++ b/.github/scripts/gcc_diff_gate.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2026 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Diff-scoped gcc warning gate (PROPOSAL — branch ci/diff-scoped-warning-gate).
+
+Gate not-yet-promoted gcc warning classes on the PR's changed lines *only*, without
+promoting them tree-wide. The OneWifi tree still carries backlogs for these classes
+(e.g. -Wvla: 18 sites, -Wreturn-type: 11), so a whole-file/tree -Werror would red every
+PR. Instead lets recompile each changed .c/.cpp from compile_commands.json with the candidate
+warnings enabled, then keep only findings whose line the PR actually changed.
+A PR can then fail on a class it newly introduced on a line it touched.
+The silent baseline (and the build-summary that relies on it) remains unaffected.
+
+This is the gcc analogue of the clang-tidy changed-lines gate already in makefile.yml.
+Because each file is recompiled on its own, every warning in that compile belongs to that
+file, so filtering on the line number alone is sufficient (same reasoning as clang-tidy).
+No need to filter on file:line pairs as analyzing full build.log would require
+
+Env:
+  BASE               PR base sha (already fetched by the caller)
+  GATE_WARNINGS      space-separated -W flags that FAIL the job when introduced on a changed line
+  ADVISORY_WARNINGS  space-separated -W flags that are only reported
+  ENFORCE            'false' -> advisory (render ❌ but exit 0). default enforce
+  REPO_DIR           dir the changed files + git history live in (default '.'; the HAL sets
+                     this to '../rdk-wifi-hal' since its DB lives in the cloned OneWifi cwd)
+Exit: 1 iff a GATE class fired on a changed line (and ENFORCE); else 0. Always writes a
+markdown summary to stdout. Identical file ships in OneWifi and the HAL.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+BASE = os.environ.get("BASE", "").strip()
+GATE = os.environ.get("GATE_WARNINGS", "").split()
+ADVISORY = os.environ.get("ADVISORY_WARNINGS", "").split()
+# Rollout toggle: when false, a GATE-class finding still renders (❌ "would fail")
+# but the job is NOT failed (exit 0). Lets the mechanism run on real PRs as an
+# advisory before it can red anyone. Default 'true' so a missing env stays strict
+# (the gate's identity). The workflow sets it to 'false' during the advisory window.
+ENFORCE = os.environ.get("ENFORCE", "true").strip().lower() not in ("false", "0", "no", "off", "")
+# Where the changed files + git history live. '.' for OneWifi (DB is in its own cwd);
+# '../rdk-wifi-hal' for the HAL (its DB is built in the cloned OneWifi cwd, cross-dir).
+REPO_DIR = os.environ.get("REPO_DIR", ".").strip() or "."
+DB = "compile_commands.json"
+
+# Map each candidate -Wflag to its [-Wflag] diagnostic tag; classify a warning line by tag.
+GATE_TAGS = {f"[{w}]" for w in GATE}
+ADVISORY_TAGS = {f"[{w}]" for w in ADVISORY}
+ALL_FLAGS = GATE + ADVISORY
+# Demote every candidate to a warning so the recompile never errors out mid-file.
+NO_ERROR = [f"-Wno-error={w[2:]}" for w in ALL_FLAGS]
+LINE_RE = re.compile(r"\.(?:c|cpp):(\d+):")
+TAG_RE = re.compile(r"\[-W[a-z0-9-]+\]")
+
+
+def changed_files():
+    out = subprocess.run(
+        ["git", "-C", REPO_DIR, "diff", "--name-only", "--diff-filter=ACM", BASE, "HEAD", "--", "*.c", "*.cpp"],
+        capture_output=True, text=True,
+    ).stdout.splitlines()
+    return [f for f in out if not f.startswith("build/") and "hostap" not in f]
+
+
+def changed_lines(f):
+    """New-side line numbers this PR changed in f (zero-context hunks)."""
+    diff = subprocess.run(
+        ["git", "-C", REPO_DIR, "diff", "-U0", "--diff-filter=ACM", BASE, "HEAD", "--", f],
+        capture_output=True, text=True,
+    ).stdout
+    lines = set()
+    for m in re.finditer(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", diff, re.M):
+        start = int(m.group(1))
+        count = int(m.group(2)) if m.group(2) else 1
+        lines.update(range(start, start + count))
+    return lines
+
+
+def db_args(db, f):
+    """arguments for the DB entry whose file ends with /f, minus -c and -o <out>."""
+    entry = next((e for e in db if e["file"].endswith("/" + f) or e["file"].endswith(f)), None)
+    if not entry:
+        return None
+    out, skip = [], False
+    for a in entry.get("arguments", []):
+        if skip:
+            skip = False
+            continue
+        if a == "-o":
+            skip = True
+            continue
+        if a == "-c":
+            continue
+        out.append(a)
+    return entry["directory"], out
+
+
+def main():
+    if not BASE or not os.path.exists(DB):
+        print("### 🚦 gcc diff-gate: no compile DB or PR base — skipped")
+        return 0
+    db = json.load(open(DB))
+    gated, advis = [], []
+    for f in changed_files():
+        info = db_args(db, f)
+        if not info:
+            continue  # not built (not in DB) -> can't judge, skip (same as clang-tidy)
+        cwd, args = info
+        want = changed_lines(f)
+        if not want:
+            continue
+        cmd = args + ["-c", "-o", os.devnull] + ALL_FLAGS + NO_ERROR
+        r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+        for line in r.stderr.splitlines():
+            if ": warning:" not in line and ": error:" not in line:
+                continue
+            m = LINE_RE.search(line)
+            t = TAG_RE.search(line)
+            if not m or not t:
+                continue
+            if int(m.group(1)) not in want:
+                continue
+            tag = t.group(0)
+            disp = re.sub(r"^.*?/(?:OneWifi|rdk-wifi-hal)/+", "", line)
+            if tag in GATE_TAGS:
+                gated.append(disp)
+            elif tag in ADVISORY_TAGS:
+                advis.append(disp)
+    gated = sorted(set(gated))
+    advis = sorted(set(advis))
+
+    # GitHub annotations (top-of-check box).
+    for l in gated[:10]:
+        print(f"::error::{l}".replace("%", "%25").replace("\r", "%0D"), file=sys.stderr)
+    for l in advis[:10]:
+        print(f"::warning::{l}".replace("%", "%25").replace("\r", "%0D"), file=sys.stderr)
+
+    if not gated and not advis:
+        print("### 🚦 gcc diff-gate: clean on changed lines")
+        return 0
+    if gated:
+        verb = "newly-introduced on changed lines" if ENFORCE else "would fail the job (advisory: ENFORCE=false)"
+        print(f"### ❌ gcc diff-gate — {len(gated)} {verb}")
+        print("```")
+        print("\n".join(gated[:100]))
+        print("```")
+        print("_Fix the finding, or waive it inline with a `// NOLINT`-style guard / refactor._")
+    if advis:
+        print(f"### 🚦 gcc diff-gate advisory — {len(advis)} findings")
+        print("```")
+        print("\n".join(advis[:100]))
+        print("```")
+    # In advisory mode the ❌ block above still renders, but we never red the job.
+    return 1 if (gated and ENFORCE) else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        # A malformed DB entry / KeyError / json error must not masquerade as a
+        # gated finding (bare `exit 1` with an empty summary). Print a summary
+        # line so the comment isn't blank, warn, dump the trace to stderr for
+        # debugging, and exit 0. Same approach as the clang-tidy gate.
+        import traceback
+        print("### 🚦 gcc diff-gate: skipped (mechanism error) — failing open")
+        print(f"::warning::gcc diff-gate mechanism error: {exc}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(0)

--- a/.github/scripts/gcc_diff_gate.py
+++ b/.github/scripts/gcc_diff_gate.py
@@ -145,8 +145,11 @@ def changed_lines(base, f):
 
 
 def db_args(db, f):
-    """arguments for the DB entry whose file ends with /f, minus -c and -o <out>."""
-    entry = next((e for e in db if e["file"].endswith("/" + f) or e["file"].endswith(f)), None)
+    """arguments for the DB entry whose file is f (exact) or ends with /f, minus -c and -o <out>."""
+    # Match on a path boundary: exact relative path, or a suffix that begins at a '/'. A bare
+    # endswith(f) would let a root-level 'foo.c' match an unrelated '/src/notfoo.c' (or 'x/foo.c'
+    # match 'x/notfoo.c') -> next() recompiles the wrong TU and misattributes the gate result.
+    entry = next((e for e in db if e["file"] == f or e["file"].endswith("/" + f)), None)
     if not entry:
         return None
     out, skip = [], False

--- a/.github/scripts/gcc_diff_gate.py
+++ b/.github/scripts/gcc_diff_gate.py
@@ -74,23 +74,66 @@ LINE_RE = re.compile(r"\.(?:c|cpp):(\d+):")
 TAG_RE = re.compile(r"\[-W[a-z0-9-]+\]")
 
 
-def changed_files():
-    # check=True: 'git diff' returns non-zero only on error (a bad/unfetched BASE),
-    # never merely because a diff exists. Without it an unresolvable BASE yields
+def effective_base():
+    """Diff base for line attribution — HEAD^1 when it is the trustworthy base.
+
+    On a `pull_request` event checked out with no explicit `ref:` (as makefile.yml
+    does), HEAD is the merge ref refs/pull/N/merge: HEAD^1 is the CURRENT base tip,
+    HEAD^2 the PR head. The frozen event-payload BASE
+    (github.event.pull_request.base.sha) can drift from that fresh base parent —
+    most visibly on a re-run of an OLD workflow run, where the merge ref
+    re-resolves to today's base but BASE stays pinned. A two-dot
+    `git diff BASE HEAD` then attributes post-fork base-branch changes to the PR
+    and can fire the gate on lines the author never touched (poisoning exactly the
+    'zero false positives on GATE classes' evidence the ENFORCE rollout waits on).
+
+    Prefer HEAD^1 when (a) HEAD is a merge commit (HEAD^2 exists) AND (b) the
+    payload BASE is an ancestor of HEAD^1 (a fast-forward base advance — the normal
+    case). Probe (b) makes the merge-ref parent-order assumption self-verifying: if
+    HEAD is not a merge commit, or the base was rewritten so BASE no longer leads
+    into HEAD^1, fall back to BASE (today's exact two-dot behavior). Never raises;
+    worst case it returns BASE. The HAL leg runs this same file against
+    REPO_DIR=../rdk-wifi-hal, which is likewise checked out with no `ref:` (the
+    default merge ref) — so HEAD^1 is its current base too and the same path
+    applies; the is-ancestor probe still guards the fork / base-rewrite cases.
+    """
+    def git_rc(*args):
+        return subprocess.run(
+            ["git", "-C", REPO_DIR, *args],
+            capture_output=True, text=True,
+        ).returncode
+    if git_rc("rev-parse", "--verify", "--quiet", "HEAD^2") != 0:
+        return BASE                               # not a merge ref -> can't trust HEAD^1
+    if git_rc("merge-base", "--is-ancestor", BASE, "HEAD^1") != 0:
+        return BASE                               # base rewritten / BASE unfetched -> stay with BASE
+    return "HEAD^1"
+
+
+def changed_files(base):
+    # --diff-filter=ACM intentionally omits renames (R): line-scoping a renamed
+    # path via `git diff -U0 -- <newpath>` (changed_lines below) can't pair the old
+    # path (pathspec-limited), so git reports the file as wholly ADDED -> every
+    # line counts as "changed" -> the gate would fire on moved-but-unedited code.
+    # For an advisory line gate, skipping renamed files is a safe false-negative;
+    # catching their real edits would need full rename-aware line mapping. (Kept
+    # deliberately — a naive ACMR would make attribution worse, not better.)
+    #
+    # check=True: 'git diff' returns non-zero only on error (a bad/unfetched base),
+    # never merely because a diff exists. Without it an unresolvable base yields
     # empty stdout and we'd report the PR "clean" instead of surfacing the
     # mechanism error. On failure the raise propagates to main()'s top-level
     # except, which prints the skip summary and fails open.
     out = subprocess.run(
-        ["git", "-C", REPO_DIR, "diff", "--name-only", "--diff-filter=ACM", BASE, "HEAD", "--", "*.c", "*.cpp"],
+        ["git", "-C", REPO_DIR, "diff", "--name-only", "--diff-filter=ACM", base, "HEAD", "--", "*.c", "*.cpp"],
         capture_output=True, text=True, check=True,
     ).stdout.splitlines()
     return [f for f in out if not f.startswith("build/") and "hostap" not in f]
 
 
-def changed_lines(f):
+def changed_lines(base, f):
     """New-side line numbers this PR changed in f (zero-context hunks)."""
     diff = subprocess.run(
-        ["git", "-C", REPO_DIR, "diff", "-U0", "--diff-filter=ACM", BASE, "HEAD", "--", f],
+        ["git", "-C", REPO_DIR, "diff", "-U0", "--diff-filter=ACM", base, "HEAD", "--", f],
         capture_output=True, text=True, check=True,
     ).stdout
     lines = set()
@@ -124,14 +167,15 @@ def main():
     if not BASE or not os.path.exists(DB):
         print("### 🚦 gcc diff-gate: no compile DB or PR base — skipped")
         return 0
+    base = effective_base()
     db = json.load(open(DB))
-    gated, advis = [], []
-    for f in changed_files():
+    gated, advis, failed = [], [], []
+    for f in changed_files(base):
         info = db_args(db, f)
         if not info:
             continue  # not built (not in DB) -> can't judge, skip (same as clang-tidy)
         cwd, args = info
-        want = changed_lines(f)
+        want = changed_lines(base, f)
         if not want:
             continue
         cmd = args + ["-c", "-o", os.devnull] + ALL_FLAGS + NO_ERROR
@@ -157,16 +201,35 @@ def main():
                 gated.append(disp)
             elif tag in ADVISORY_TAGS:
                 advis.append(disp)
+        if r.returncode != 0:
+            # Every candidate class is demoted with -Wno-error=, so a well-formed
+            # recompile of an already-built file exits 0. A nonzero code is a
+            # MECHANISM failure, not a clean file: gcc aborts with "unrecognized
+            # command-line option" for a clang-only/mistyped GATE/ADVISORY entry
+            # (which would otherwise silently disable the gate for EVERY file), or
+            # the file hit a missing generated header / a killed-or-OOM compiler.
+            # Verified on gcc 13.3.0: these aborts print no source-line [-Wflag]
+            # tag, so the loop above finds nothing and the file would otherwise be
+            # reported "clean". Record it so the summary shows incomplete coverage
+            # instead. Any findings parsed above this point still count.
+            reason = next((ln.strip() for ln in r.stderr.splitlines()
+                           if ": error:" in ln), f"compiler exit {r.returncode}")
+            reason = re.sub(r"^[^ ]*/(?:OneWifi|rdk-wifi-hal)/+", "", reason)  # same path-strip as disp
+            failed.append(f"{f}: {reason}")
     gated = sorted(set(gated))
     advis = sorted(set(advis))
+    failed = sorted(set(failed))
 
     # GitHub annotations (top-of-check box).
     for l in gated[:10]:
         print(f"::error::{l}".replace("%", "%25").replace("\r", "%0D"), file=sys.stderr)
     for l in advis[:10]:
         print(f"::warning::{l}".replace("%", "%25").replace("\r", "%0D"), file=sys.stderr)
+    for l in failed[:10]:
+        print(f"::warning::gcc diff-gate could not recompile — {l}"
+              .replace("%", "%25").replace("\r", "%0D"), file=sys.stderr)
 
-    if not gated and not advis:
+    if not gated and not advis and not failed:
         print("### 🚦 gcc diff-gate: clean on changed lines")
         return 0
     if gated:
@@ -181,7 +244,16 @@ def main():
         print("```")
         print("\n".join(advis[:100]))
         print("```")
+    if failed:
+        print(f"### ⚠️ gcc diff-gate: {len(failed)} file(s) failed to recompile — coverage incomplete")
+        print("```")
+        print("\n".join(failed[:100]))
+        print("```")
+        print("_A nonzero compiler exit means these files were NOT analyzed (an unrecognized -W flag, "
+              "a missing generated header, or a killed compiler) — the result above is partial. This is "
+              "a mechanism warning, not a code finding, so it never reds the job on its own._")
     # In advisory mode the ❌ block above still renders, but we never red the job.
+    # `failed` alone never fails the gate (fail-open) — only a GATE finding under ENFORCE does.
     return 1 if (gated and ENFORCE) else 0
 
 

--- a/.github/scripts/gcc_diff_gate.py
+++ b/.github/scripts/gcc_diff_gate.py
@@ -136,8 +136,10 @@ def changed_files(base):
     # first-party sources (the HAL's wifi_hal_hostapd.c, OneWifi's wifi_hostapd_glue.c)
     # while its intended target -- the vendored hostap tree -- lives in the sibling
     # rdk-wifi-libhostap/ clone a diff can't surface. Exclude only that vendored tree,
-    # by its path marker (documented intent; a diff never reaches it in practice).
-    return [f for f in out if "rdk-wifi-libhostap/" not in f]
+    # by its path prefix (anchored startswith: git diff paths are repo-relative and the
+    # vendored tree sits at the repo root, so a first-party path merely *containing* the
+    # name is never dropped; documented intent -- a diff never reaches it in practice).
+    return [f for f in out if not f.startswith("rdk-wifi-libhostap/")]
 
 
 def changed_lines(base, f):

--- a/.github/scripts/gcc_diff_gate.py
+++ b/.github/scripts/gcc_diff_gate.py
@@ -24,10 +24,13 @@ promoting them tree-wide. The OneWifi tree still carries backlogs for these clas
 (e.g. -Wvla: 18 sites, -Wreturn-type: 11), so a whole-file/tree -Werror would red every
 PR. Instead lets recompile each changed .c/.cpp from compile_commands.json with the candidate
 warnings enabled, then keep only findings whose line the PR actually changed.
-A PR can then fail on a class it newly introduced on a line it touched.
+A PR can then fail on a class that fires on a line it changed. NB this is
+line-scoped, not base-compared: a warning already present on a line the PR
+edits for an unrelated reason also counts (accepted trade-off, not literally
+"newly introduced").
 The silent baseline (and the build-summary that relies on it) remains unaffected.
 
-This is the gcc analogue of the clang-tidy changed-lines gate already in makefile.yml.
+This is the gcc analogue of the clang-tidy changed-files gate already in makefile.yml.
 Because each file is recompiled on its own, every warning in that compile belongs to that
 file, so filtering on the line number alone is sufficient (same reasoning as clang-tidy).
 No need to filter on file:line pairs as analyzing full build.log would require
@@ -72,9 +75,14 @@ TAG_RE = re.compile(r"\[-W[a-z0-9-]+\]")
 
 
 def changed_files():
+    # check=True: 'git diff' returns non-zero only on error (a bad/unfetched BASE),
+    # never merely because a diff exists. Without it an unresolvable BASE yields
+    # empty stdout and we'd report the PR "clean" instead of surfacing the
+    # mechanism error. On failure the raise propagates to main()'s top-level
+    # except, which prints the skip summary and fails open.
     out = subprocess.run(
         ["git", "-C", REPO_DIR, "diff", "--name-only", "--diff-filter=ACM", BASE, "HEAD", "--", "*.c", "*.cpp"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, check=True,
     ).stdout.splitlines()
     return [f for f in out if not f.startswith("build/") and "hostap" not in f]
 
@@ -83,7 +91,7 @@ def changed_lines(f):
     """New-side line numbers this PR changed in f (zero-context hunks)."""
     diff = subprocess.run(
         ["git", "-C", REPO_DIR, "diff", "-U0", "--diff-filter=ACM", BASE, "HEAD", "--", f],
-        capture_output=True, text=True,
+        capture_output=True, text=True, check=True,
     ).stdout
     lines = set()
     for m in re.finditer(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", diff, re.M):
@@ -138,7 +146,13 @@ def main():
             if int(m.group(1)) not in want:
                 continue
             tag = t.group(0)
-            disp = re.sub(r"^.*?/(?:OneWifi|rdk-wifi-hal)/+", "", line)
+            # Strip to the LAST repo dir in the path token: the runner checks out to
+            # .../work/OneWifi/OneWifi/easymesh_project/OneWifi/source/..., so a
+            # non-greedy '.*?' would stop at the first 'OneWifi/' and leave a broken,
+            # non-repo-relative path. '[^ ]*' stays within the path token (can't eat
+            # into the message text) yet backtracks to the last match. Mirrors the
+            # sed idiom in makefile.yml's build/tidy summaries.
+            disp = re.sub(r"^[^ ]*/(?:OneWifi|rdk-wifi-hal)/+", "", line)
             if tag in GATE_TAGS:
                 gated.append(disp)
             elif tag in ADVISORY_TAGS:
@@ -156,7 +170,7 @@ def main():
         print("### 🚦 gcc diff-gate: clean on changed lines")
         return 0
     if gated:
-        verb = "newly-introduced on changed lines" if ENFORCE else "would fail the job (advisory: ENFORCE=false)"
+        verb = "on lines this PR changed" if ENFORCE else "would fail the job (advisory: ENFORCE=false)"
         print(f"### ❌ gcc diff-gate — {len(gated)} {verb}")
         print("```")
         print("\n".join(gated[:100]))

--- a/.github/scripts/gcc_diff_gate.py
+++ b/.github/scripts/gcc_diff_gate.py
@@ -127,7 +127,17 @@ def changed_files(base):
         ["git", "-C", REPO_DIR, "diff", "--name-only", "--diff-filter=ACM", base, "HEAD", "--", "*.c", "*.cpp"],
         capture_output=True, text=True, check=True,
     ).stdout.splitlines()
-    return [f for f in out if not f.startswith("build/") and "hostap" not in f]
+    # Keep every changed tracked source; db_args() in main() already skips anything the
+    # compile DB didn't build. `git diff` only ever returns TRACKED files, so generated
+    # build outputs (.o, libs) never appear here -- the old `not startswith("build/")`
+    # dropped nothing but the one tracked source under build/:
+    # build/linux/compat/coverage_stubs.c, a first-party file the bpi makefile compiles
+    # (makefile:478, real DB entry). Likewise the old bare `"hostap" not in f` dropped
+    # first-party sources (the HAL's wifi_hal_hostapd.c, OneWifi's wifi_hostapd_glue.c)
+    # while its intended target -- the vendored hostap tree -- lives in the sibling
+    # rdk-wifi-libhostap/ clone a diff can't surface. Exclude only that vendored tree,
+    # by its path marker (documented intent; a diff never reaches it in practice).
+    return [f for f in out if "rdk-wifi-libhostap/" not in f]
 
 
 def changed_lines(base, f):

--- a/.github/scripts/gcc_diff_gate.py
+++ b/.github/scripts/gcc_diff_gate.py
@@ -175,7 +175,7 @@ def main():
         print("```")
         print("\n".join(gated[:100]))
         print("```")
-        print("_Fix the finding, or waive it inline with a `// NOLINT`-style guard / refactor._")
+        print("_Fix the finding, or suppress it with a GCC diagnostic pragma where intentional / refactor._")
     if advis:
         print(f"### 🚦 gcc diff-gate advisory — {len(advis)} findings")
         print("```")

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -50,6 +50,18 @@ jobs:
             exit 1
           }
           echo "Diffing against merge base: $BASE_SHA"
+
+          # Record which lines the PR actually changed (new-side, commit-to-commit
+          # so unaffected by the formatter's worktree edits). Stage 2 uses this to
+          # drop suggestions that git-clang-format expanded onto untouched lines.
+          git diff -U0 "$BASE_SHA" HEAD -- . \
+            | awk '/^\+\+\+ b\// { file = substr($0, 7) }
+                   /^@@ / { c=$3; sub(/^\+/,"",c); n=1
+                             if (c~/,/) { split(c,a,","); c=a[1]; n=a[2] }
+                             if (n>0) print file ":" c "-" c+n-1 }' \
+            > changed-lines.txt
+          echo "PR changed-line ranges: $(wc -l < changed-lines.txt)"
+
           # ================== EXCLUDED PATHS (edit me) ======================
           # Files/dirs here are never reformatted (e.g. vendor ports, imported
           # headers/utils). Uses git pathspec syntax: ':!<pattern>'.
@@ -104,6 +116,7 @@ jobs:
           name: clang-format-suggestions
           path: |
             clang-format.diff
+            changed-lines.txt
             pr-meta.env
           if-no-files-found: ignore
           retention-days: 1

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -303,7 +303,7 @@ jobs:
       # PR's changed LINES only, without promoting them tree-wide (the tree still carries a
       # backlog: -Wvla 18, -Wreturn-type 11, dead-code family). The script recompiles each changed
       # .c/.cpp from compile_commands.json with the candidate warnings enabled (non-fatal) and keeps
-      # only findings on lines the PR touched -> a PR can only fail on a class it newly introduced.
+      # only findings on lines the PR touched -> a PR can only fail on a class that fires on a changed line.
       # The silent baseline (and the build-summary that relies on it) is unaffected. bpi leg only
       # (it owns the compile DB). Runs AFTER clang-tidy so both gate independently.
       if: always() && matrix.platform.clang_tidy && github.event_name == 'pull_request'
@@ -340,6 +340,12 @@ jobs:
         git fetch --no-tags --depth=1 origin "$BASE" >/dev/null 2>&1 || true
         # The script prints a markdown summary to stdout and ::error::/::warning:: to stderr;
         # it exits 1 iff a GATE class fired on a changed line.
+        # A missing script (partial cherry-pick / not yet on this branch) must skip,
+        # not red the job: python3 on an absent file exits 2 and would fail the matrix.
+        if [ ! -f .github/scripts/gcc_diff_gate.py ]; then
+          echo "### 🚦 gcc diff-gate: script not present — skipped" | tee -a ci-out/gcc-gate-summary.md >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
         set +e
         python3 .github/scripts/gcc_diff_gate.py > gcc-gate.md
         rc=$?

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -298,6 +298,55 @@ jobs:
           exit 1
         fi
 
+    - name: gcc diff-scoped warning gate for ${{ matrix.platform.name }}
+      # PROPOSAL (branch ci/gcc-diff-gate). Gate not-yet-promoted gcc classes on the
+      # PR's changed LINES only, without promoting them tree-wide (the tree still carries a
+      # backlog: -Wvla 18, -Wreturn-type 11, dead-code family). The script recompiles each changed
+      # .c/.cpp from compile_commands.json with the candidate warnings enabled (non-fatal) and keeps
+      # only findings on lines the PR touched -> a PR can only fail on a class it newly introduced.
+      # The silent baseline (and the build-summary that relies on it) is unaffected. bpi leg only
+      # (it owns the compile DB). Runs AFTER clang-tidy so both gate independently.
+      if: always() && matrix.platform.clang_tidy && github.event_name == 'pull_request'
+      working-directory: easymesh_project/OneWifi
+      env:
+        BASE: ${{ github.event.pull_request.base.sha }}
+        # ROLLOUT: start in advisory mode. ENFORCE=false renders the ❌ "would fail"
+        # block but never reds the job, so the mechanism runs on real PRs first.
+        # FLIP to 'true' (one-word change) once ALL of these hold on the live runner:
+        #   1. >= a handful of real PRs touching .c/.cpp have processed end-to-end
+        #      with NO "mechanism error" summary line (the try/except fail-open);
+        #   2. >= 1 advisory finding (the -Wunused-* classes fire on ordinary
+        #      refactors) hand-checked against the diff -> line attribution correct;
+        #   3. zero false positives on the GATE classes.
+        # Gate on that evidence, not the calendar. Silence of the GATE classes alone
+        # proves nothing (they're rarely introduced) -- the advisory classes are what
+        # exercise the recompile + line-scoping machinery.
+        ENFORCE: 'false'
+        # GATE = fail the job (when ENFORCE=true) if introduced on a changed line.
+        # ADVISORY = report only. -Wvla (stack-overflow) + -Wreturn-type (UB) are
+        # high-impact + reliable -> first to gate. The dead-code family is
+        # diff-scope-reliable but kept ADVISORY (promote a class into GATE_WARNINGS
+        # once quiet on real PRs). (-Wunreachable-code-* are clang-only; the "moved
+        # code left set-but-unused vars" case is -Wunused-but-set-variable.)
+        GATE_WARNINGS: "-Wvla -Wreturn-type"
+        ADVISORY_WARNINGS: "-Wunused-but-set-variable -Wunused-value -Wunused-label"
+      run: |
+        set -uo pipefail
+        mkdir -p ci-out
+        if [ ! -f compile_commands.json ] || [ -z "$BASE" ]; then
+          echo "### 🚦 gcc diff-gate: no compile DB or PR base — skipped" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+        git fetch --no-tags --depth=1 origin "$BASE" >/dev/null 2>&1 || true
+        # The script prints a markdown summary to stdout and ::error::/::warning:: to stderr;
+        # it exits 1 iff a GATE class fired on a changed line.
+        set +e
+        python3 .github/scripts/gcc_diff_gate.py > gcc-gate.md
+        rc=$?
+        set -e
+        tee -a ci-out/gcc-gate-summary.md < gcc-gate.md >> "$GITHUB_STEP_SUMMARY"
+        exit "$rc"
+
     # ---- Hand-off to the trusted PR-comment stage (pr-comments.yml) ----------
     # Record the PR identity as passive data for the workflow_run poster to
     # validate. Only meaningful on PRs; push builds skip it.

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -95,6 +95,10 @@ jobs:
         # Steps for ucode installation required for hostapd compilation
         git clone https://github.com/jow-/ucode.git ucode
         cd ucode
+        # Pin ucode: PR#398 (LibFFI module) merged to master 2026-08-27 and broke the bpi
+        # build (ucode's `unused` macro collides with OpenSSL's ossl_unused in HAL TUs).
+        # 19ffa8a = last master before that merge = last known-good; bump deliberately.
+        git checkout 19ffa8a
         mkdir build && cd build
         cmake -DUBUS_SUPPORT=OFF -DUCI_SUPPORT=OFF -DULOOP_SUPPORT=OFF ..
         make -j"$(nproc)"

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -256,8 +256,13 @@ jobs:
           # flags. A real source then can't resolve its includes -> a fatal clang-diagnostic
           # aborts file parsing before any check run on it -> that output is dropped by the
           # clang-diagnostic filter below -> file can't fail. Thus, only built files are judged.
+          # Exclude only the vendored hostap tree (sibling clone rdk-wifi-libhostap/), never
+          # first-party sources: '^build/' wrongly dropped build/linux/compat/coverage_stubs.c
+          # (compiled by the makefile, real DB entry) and bare 'hostap' dropped e.g.
+          # wifi_hostapd_glue.c. A changed file not in the DB self-skips (default-flags fallback
+          # -> fatal clang-diagnostic -> filtered below), so DB membership is the real gate.
           CHANGED=$(git diff --name-only --diff-filter=ACM "$BASE" HEAD -- '*.c' '*.cpp' 2>/dev/null \
-                    | grep -vE '^build/|hostap' || true)
+                    | grep -vE 'rdk-wifi-libhostap/' || true)
         fi
         : > tidy.log
         for f in $CHANGED; do

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -261,8 +261,11 @@ jobs:
           # (compiled by the makefile, real DB entry) and bare 'hostap' dropped e.g.
           # wifi_hostapd_glue.c. A changed file not in the DB self-skips (default-flags fallback
           # -> fatal clang-diagnostic -> filtered below), so DB membership is the real gate.
+          # Anchored '^': git diff paths are repo-relative and the vendored tree, if ever
+          # surfaced, sits at the repo root -- so a first-party path that merely *contains*
+          # the name (e.g. source/.../rdk-wifi-libhostap-notes.c) is never dropped.
           CHANGED=$(git diff --name-only --diff-filter=ACM "$BASE" HEAD -- '*.c' '*.cpp' 2>/dev/null \
-                    | grep -vE 'rdk-wifi-libhostap/' || true)
+                    | grep -vE '^rdk-wifi-libhostap/' || true)
         fi
         : > tidy.log
         for f in $CHANGED; do

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -97,8 +97,12 @@ jobs:
         cd ucode
         # Pin ucode: PR#398 (LibFFI module) merged to master 2026-08-27 and broke the bpi
         # build (ucode's `unused` macro collides with OpenSSL's ossl_unused in HAL TUs).
-        # 19ffa8a = last master before that merge = last known-good; bump deliberately.
-        git checkout 19ffa8a
+        # 655ca6d = a0ca7b1^1 = last master BEFORE the FFI merge = last known-good state
+        # (it is literally what the last green build cloned). The colliding `unused` macro
+        # was added by abb80c6 ON the PR#398 branch, so any commit on that branch -- incl.
+        # 19ffa8a, the earlier (wrong) pin -- still ships the poisoned util.h. Use first-
+        # parent (a0ca7b1^1), NOT plain `git log`, when moving this pin; bump deliberately.
+        git checkout 655ca6d
         mkdir build && cd build
         cmake -DUBUS_SUPPORT=OFF -DUCI_SUPPORT=OFF -DULOOP_SUPPORT=OFF ..
         make -j"$(nproc)"

--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -90,6 +90,7 @@ jobs:
         env:
           HEAD_SHA: ${{ steps.ctx.outputs.head_sha }}
           # MAX_COMMENTS comes from the workflow-level env.
+          CHANGED_LINES_FILE: clang-format-suggestions/changed-lines.txt
         run: |
           # The converter lives in a checked-out script (trusted base branch). When the
           # changed lines are already clang-format clean there is no diff file - feed /dev/null


### PR DESCRIPTION
This ports recent advancement in CI checks from the rdk-wifi-hal repository:
1) clang-tidy (And future gcc-gate-warnings) are now properly scoped to  changed LINES only (previously changed files),   increasing its value. 
2) [add] gcc-gate. Add a facility to check changed-files with stricter warning set, then permissible tree-wide (example: to catch attempts at adding dead code or variable-length arrays. Both issues present with many occurences). This warnings are changed line-scoped only, as clang's.
3) [add] pr-comments.yml: merge  gcc diff-gate summary into the clang-tidy sticky
  comment, making  one "Diff-scoped checks (changed lines only)" comment. Degrades
  gracefully if  gcc-diff script is missing. This reduces CI build check output to two comments :
    a) build compilation summary
    b) static analysis and most important (but not fixed tree-wide) warnings/errors summary
