### PR TITLE
RDKB-66207: Mediatek repo migration fix

### DIFF
--- a/build/linux/bpi/setup.sh
+++ b/build/linux/bpi/setup.sh
@@ -13,7 +13,10 @@ KERNEL_PATCH_DIR="$RDK_WIFI_HAL_DIR/platform/banana-pi/kernel-patches_6.6/openwr
 UPSTREAM_HOSTAP_URL="https://git.w1.fi/hostap.git"
 SRCREV_2_11="4b8ac10cb77c3d4dbf7ccefbe697dc0578da374c"
 META_CMF_BPI_URL="https://github.com/rdkcentral/meta-cmf-bananapi.git"
-META_FILOGIC_URL="https://git01.mediatek.com/filogic/rdk-b/meta-filogic"
+# MediaTek disabled git01.mediatek.com (2026-08); their public layers moved to GitHub.
+# github.com/mediatek/meta-filogic mirrors the same history, so the pinned SRCREV below
+# is fetchable there and the patch tree is byte-identical (same commit SHA => same tree).
+META_FILOGIC_URL="https://github.com/mediatek/meta-filogic"
 SRCREV_META_FILOGIC="c67a32a7c8876b328a8d1eeaca213e860d85b3ce"
 
 # Apply network optimizations for reliable git clone


### PR DESCRIPTION
MediaTek disabled git01.mediatek.com (2026-08-20) and moved their public Yocto layers to GitHub, which broke the bpi setup. The setup.sh clones 'meta-filogic'  for 'kernel6-6-patches' set of  hostap patches, then rm -rf's it. With git01 gone the clone fails and the whole bpi build (both OneWifi CI and rdk-wifi-hal CI, which runs this makefile) dies.

Point META_FILOGIC_URL at github.com/mediatek/meta-filogic. The mirror preserved the history. The pinned SRCREV c67a32a7 is fetchable there and, being the same commit SHA, yields a byte-identical patch tree (all 236 kernel6-6-patches). Thus no patch-list change and the build reproduces exactly. rpi does not use meta-filogic; bpi/setup.sh is the only file.

Verified end-to-end on a clean tree.