### PR TITLE
RDKB-66207:  [CI]  Cache hostap for both bpi and rpi builds

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -139,6 +139,9 @@ jobs:
           # hostap-patches repo IS the payload — any commit is a patch change.
           upstream="$(git ls-remote https://github.com/rdkcentral/hostap-patches.git HEAD | cut -f1)"
         fi
+        if [ -z "$upstream" ]; then
+          echo "::warning::Could not resolve upstream patch hash (API/network failure). Cache key falls back to 'unresolved' — a hit may serve a stale tree if patches changed during the outage. Purge with: gh cache delete --all"
+        fi
         echo "upstream=${upstream:-unresolved}" >> "$GITHUB_OUTPUT"
 
         # Hash the setup script + any supplementary patch-list file. rpi's
@@ -146,9 +149,9 @@ jobs:
         setup="easymesh_project/OneWifi/build/linux/${{ matrix.platform.id }}/setup.sh"
         patchlist="easymesh_project/OneWifi/build/openwrt/hostap_patch_list.txt"
         if [ "${{ matrix.platform.id }}" = "bpi" ]; then
-          hash="$(cat "$setup" "$patchlist" | sha256sum | cut -c1-32)"
+          hash="$(cat "$setup" "$patchlist" | sha256sum | cut -c1-16)"
         else
-          hash="$(sha256sum < "$setup" | cut -c1-32)"
+          hash="$(sha256sum < "$setup" | cut -c1-16)"
         fi
         echo "files_hash=$hash" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -146,9 +146,9 @@ jobs:
         setup="easymesh_project/OneWifi/build/linux/${{ matrix.platform.id }}/setup.sh"
         patchlist="easymesh_project/OneWifi/build/openwrt/hostap_patch_list.txt"
         if [ "${{ matrix.platform.id }}" = "bpi" ]; then
-          hash="$(cat "$setup" "$patchlist" | sha256sum | cut -c1-16)"
+          hash="$(cat "$setup" "$patchlist" | sha256sum | cut -c1-32)"
         else
-          hash="$(sha256sum < "$setup" | cut -c1-16)"
+          hash="$(sha256sum < "$setup" | cut -c1-32)"
         fi
         echo "files_hash=$hash" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -57,14 +57,6 @@ jobs:
         git clone https://github.com/rdkcentral/unified-wifi-mesh.git easymesh_project/unified-wifi-mesh
         mv OneWifi easymesh_project/OneWifi
 
-    - name: Cache dependencies
-      uses: actions/cache@v5
-      with:
-        path: /var/cache/apt
-        key: ${{ runner.os }}-apt-${{ hashFiles('**/apt-packages') }}
-        restore-keys: |
-          ${{ runner.os }}-apt-
-
     - name: Set up dependencies
       run: |
         sudo apt-get update
@@ -108,6 +100,64 @@ jobs:
         make -j"$(nproc)"
         sudo make install
         sudo ldconfig
+
+    # Perf: each device leg (bpi, rpi) clones + patches hostap from upstream
+    # (git.w1.fi for rpi, git.w1.fi + GitHub layers for bpi). The patched tree
+    # is a pure function of the pins in setup.sh plus the patch inputs, so
+    # cache it keyed on those files. On a hit, setup.sh's .hostap_patched flag
+    # skips the clone AND patching entirely. A miss falls back to the normal
+    # clone, so this can never be slower than today.
+    #
+    # Exact-key-only (NO restore-keys): a pin bump edits setup.sh -> key
+    # changes -> miss -> full re-clone at new pins. restore-keys would
+    # resurrect a stale patched tree and silently build the wrong hostap.
+    #
+    # Each leg has one UNPINNED patch source whose changes must invalidate
+    # the cache:
+    #   bpi: meta-cmf-bananapi — only the kernel_6_6 patch subdir matters;
+    #        the repo gets daily unrelated commits, so we key on the GitHub
+    #        API tree SHA of that directory (changes only when a patch file
+    #        changes), NOT the whole-repo tip.
+    #   rpi: hostap-patches — the entire repo IS patches, so ls-remote tip
+    #        is appropriate.
+    # mock never clones hostap -> no cache needed.
+    - name: Resolve hostap cache key inputs
+      if: matrix.platform.id != 'mock'
+      id: hostap_key
+      run: |
+        if [ "${{ matrix.platform.id }}" = "bpi" ]; then
+          # meta-cmf-bananapi is a large Yocto layer repo that gets daily
+          # commits unrelated to hostap patches. Only one subdirectory
+          # matters: the kernel_6_6 patch dir. Query its git tree SHA via
+          # the GitHub API — it changes only when an actual patch file is
+          # added, removed, renamed, or modified.
+          api_url="https://api.github.com/repos/rdkcentral/meta-cmf-bananapi/contents"
+          api_url="$api_url/meta-rdk-mtk-bpir4/recipes-ccsp/rdk-wifi-libhostap/files/2.11"
+          upstream="$(curl -sfL -H "Authorization: Bearer ${{ github.token }}" "$api_url" \
+            | python3 -c "import sys,json; entries=json.load(sys.stdin); print(next(e['sha'] for e in entries if e['name']=='kernel_6_6'))" 2>/dev/null || true)"
+        else
+          # hostap-patches repo IS the payload — any commit is a patch change.
+          upstream="$(git ls-remote https://github.com/rdkcentral/hostap-patches.git HEAD | cut -f1)"
+        fi
+        echo "upstream=${upstream:-unresolved}" >> "$GITHUB_OUTPUT"
+
+        # Hash the setup script + any supplementary patch-list file. rpi's
+        # patches are inline in setup.sh; bpi's are in hostap_patch_list.txt.
+        setup="easymesh_project/OneWifi/build/linux/${{ matrix.platform.id }}/setup.sh"
+        patchlist="easymesh_project/OneWifi/build/openwrt/hostap_patch_list.txt"
+        if [ "${{ matrix.platform.id }}" = "bpi" ]; then
+          hash="$(cat "$setup" "$patchlist" | sha256sum | cut -c1-16)"
+        else
+          hash="$(sha256sum < "$setup" | cut -c1-16)"
+        fi
+        echo "files_hash=$hash" >> "$GITHUB_OUTPUT"
+
+    - name: Cache patched hostap
+      if: matrix.platform.id != 'mock'
+      uses: actions/cache@v5
+      with:
+        path: easymesh_project/rdk-wifi-libhostap
+        key: hostap-${{ matrix.platform.id }}-${{ steps.hostap_key.outputs.files_hash }}-${{ steps.hostap_key.outputs.upstream }}
 
     - name: Setup OneWiFi for ${{ matrix.platform.name }}
       working-directory: easymesh_project/OneWifi

--- a/build/linux/bpi/setup.sh
+++ b/build/linux/bpi/setup.sh
@@ -55,7 +55,7 @@ else
     cd $HOSTAP_DIR
 fi
 
-if [ -f "$HOSTAP_PATCH_FLAG" ]; then
+if [ -f "$HOSTAP_PATCH_FLAG" ] && [ -d "$HOSTAP_SRC_DIR/hostap-2.11" ]; then
     echo "Hostap patches are already applied. Retry after deleting $HOSTAP_DIR"
 else
     #Clone meta-cmf-bananapi, meta-filogic and  apply hostap patches

--- a/build/linux/bpi/setup.sh
+++ b/build/linux/bpi/setup.sh
@@ -49,9 +49,9 @@ else
     #and move to the relevant commit
     cd $HOSTAP_SRC_DIR
     echo "Cloning hostap in $HOSTAP_SRC_DIR"
-    git clone $UPSTREAM_HOSTAP_URL hostap-2.11
+    git clone $UPSTREAM_HOSTAP_URL hostap-2.11 || exit 1
     cd hostap-2.11
-    git reset --hard $SRCREV_2_11
+    git reset --hard $SRCREV_2_11 || exit 1
     cd $HOSTAP_DIR
 fi
 
@@ -67,8 +67,8 @@ else
         git remote add origin "$META_FILOGIC_URL"
         #Increased HTTP post buffer to 1GB to prevent "RPC failed" or "Broken pipe" errors.
         git config http.postBuffer 1048576000
-        git fetch --depth 1 origin "$SRCREV_META_FILOGIC"
-        git reset --hard FETCH_HEAD
+        git fetch --depth 1 origin "$SRCREV_META_FILOGIC" || exit 1
+        git reset --hard FETCH_HEAD || exit 1
         cd "$HOSTAP_DIR"
     fi
 

--- a/build/linux/bpi/setup.sh
+++ b/build/linux/bpi/setup.sh
@@ -25,9 +25,9 @@ export GIT_HTTP_LOW_SPEED_TIME=999999
 
 #git clone other wifi related components
 cd ..
-git clone https://github.com/rdkcentral/rdk-wifi-hal.git rdk-wifi-hal
-git clone https://github.com/rdkcentral/rdkb-halif-wifi.git halinterface
-git clone https://github.com/xmidt-org/trower-base64.git trower-base64
+[ ! -d rdk-wifi-hal ] && git clone https://github.com/rdkcentral/rdk-wifi-hal.git rdk-wifi-hal
+[ ! -d halinterface ] && git clone https://github.com/rdkcentral/rdkb-halif-wifi.git halinterface
+[ ! -d trower-base64 ] && git clone https://github.com/xmidt-org/trower-base64.git trower-base64
 cd $ONEWIFI_DIR
 mkdir -p install/bin
 mkdir -p install/lib

--- a/build/linux/rpi/setup.sh
+++ b/build/linux/rpi/setup.sh
@@ -24,7 +24,7 @@ else
         mkdir -p $HOSTAP_DIR
 fi
 
-if [ -f "$HOSTAP_PATCH_FLAG" ]; then
+if [ -f "$HOSTAP_PATCH_FLAG" ] && [ -d "$HOSTAP_DIR/hostap-2.10" ]; then
     echo "Hostap patches are already applied. Retry after deleting $(dirname "$HOSTAP_PATCH_FLAG")"
 else
     #clone the upstream hostap in HOSTAP_DIR as hostap-x.xx

--- a/build/linux/rpi/setup.sh
+++ b/build/linux/rpi/setup.sh
@@ -31,12 +31,12 @@ else
     #and move to the relevant commit
     cd $HOSTAP_DIR
     echo "Cloning hostap in $HOSTAP_DIR"
-    git clone $UPSTREAM_HOSTAP_URL hostap-2.10
+    git clone $UPSTREAM_HOSTAP_URL hostap-2.10 || exit 1
     cd hostap-2.10
-    git reset --hard $SRCREV_2_10
+    git reset --hard $SRCREV_2_10 || exit 1
 
     #clone the hostap-patches and apply
-    git clone https://github.com/rdkcentral/hostap-patches.git hostap-patches
+    git clone https://github.com/rdkcentral/hostap-patches.git hostap-patches || exit 1
 
     #Apply the patch
     patch_filenames="hostap-patches/0001-OneWifi-related-hostap-patch-for-2.10-based-hostap.patch \
@@ -47,10 +47,10 @@ else
         hostap-patches/0006-RDKB-59523-connectivity-via-supplicant.patch \
 	hostap-patches/mdu_radius_psk_auth_2_10.patch"
     echo "Applying patches ..."
-    git am $patch_filenames
+    git am $patch_filenames || exit 1
 
     #Apply additional patches
-    patch -p3 --no-backup-if-mismatch < hostap-patches/xfi-tel-complete_2_10.patch
+    patch -p3 --no-backup-if-mismatch < hostap-patches/xfi-tel-complete_2_10.patch || exit 1
 
     #Delete the hostap-patches directory after applying
     rm -rf hostap-patches

--- a/build/linux/rpi/setup.sh
+++ b/build/linux/rpi/setup.sh
@@ -2,14 +2,15 @@
 
 ONEWIFI_DIR=$(pwd)
 HOSTAP_DIR="$(pwd)/../rdk-wifi-libhostap/source"
+HOSTAP_PATCH_FLAG="$(pwd)/../rdk-wifi-libhostap/.hostap_patched"
 UPSTREAM_HOSTAP_URL="https://git.w1.fi/hostap.git"
 SRCREV_2_10="9d07b9447e76059a2ddef2a879c57d0934634188"
 
 #git clone other wifi related components
 cd ..
-git clone https://github.com/rdkcentral/rdk-wifi-hal.git rdk-wifi-hal
-git clone https://github.com/rdkcentral/rdkb-halif-wifi.git halinterface
-git clone https://github.com/xmidt-org/trower-base64.git trower-base64
+[ ! -d rdk-wifi-hal ] && git clone https://github.com/rdkcentral/rdk-wifi-hal.git rdk-wifi-hal
+[ ! -d halinterface ] && git clone https://github.com/rdkcentral/rdkb-halif-wifi.git halinterface
+[ ! -d trower-base64 ] && git clone https://github.com/xmidt-org/trower-base64.git trower-base64
 
 cd $ONEWIFI_DIR
 mkdir -p install/bin
@@ -23,33 +24,40 @@ else
         mkdir -p $HOSTAP_DIR
 fi
 
-#clone the upstream hostap in HOSTAP_DIR as hostap-x.xx
-#and move to the relevant commit
-cd $HOSTAP_DIR
-echo "Cloning hostap in $HOSTAP_DIR"
-git clone $UPSTREAM_HOSTAP_URL hostap-2.10
-cd hostap-2.10
-git reset --hard $SRCREV_2_10
+if [ -f "$HOSTAP_PATCH_FLAG" ]; then
+    echo "Hostap patches are already applied. Retry after deleting $(dirname "$HOSTAP_PATCH_FLAG")"
+else
+    #clone the upstream hostap in HOSTAP_DIR as hostap-x.xx
+    #and move to the relevant commit
+    cd $HOSTAP_DIR
+    echo "Cloning hostap in $HOSTAP_DIR"
+    git clone $UPSTREAM_HOSTAP_URL hostap-2.10
+    cd hostap-2.10
+    git reset --hard $SRCREV_2_10
 
-#clone the hostap-patches and apply
-git clone https://github.com/rdkcentral/hostap-patches.git hostap-patches
+    #clone the hostap-patches and apply
+    git clone https://github.com/rdkcentral/hostap-patches.git hostap-patches
 
-#Apply the patch
-patch_filenames="hostap-patches/0001-OneWifi-related-hostap-patch-for-2.10-based-hostap.patch \
+    #Apply the patch
+    patch_filenames="hostap-patches/0001-OneWifi-related-hostap-patch-for-2.10-based-hostap.patch \
 	hostap-patches/0002-radius_failover_2.10.patch \
 	hostap-patches/0003-mbssid_support_2.10.patch \
         hostap-patches/wpa3_compatibility_hostap_2_10.patch \
         hostap-patches/0005-RDKB-58414-Dynamically-update-NAS_2_10.patch \
         hostap-patches/0006-RDKB-59523-connectivity-via-supplicant.patch \
 	hostap-patches/mdu_radius_psk_auth_2_10.patch"
-echo "Applying patches ..."
-git am $patch_filenames
+    echo "Applying patches ..."
+    git am $patch_filenames
 
-#Apply additional patches
-patch -p3 --no-backup-if-mismatch < hostap-patches/xfi-tel-complete_2_10.patch
+    #Apply additional patches
+    patch -p3 --no-backup-if-mismatch < hostap-patches/xfi-tel-complete_2_10.patch
 
-#Delete the hostap-patches directory after applying
-rm -rf hostap-patches
+    #Delete the hostap-patches directory after applying
+    rm -rf hostap-patches
+
+    touch "$HOSTAP_PATCH_FLAG"
+    echo "All patches applied successfully."
+fi
 
 #return back to initial directory
 cd $ONEWIFI_DIR


### PR DESCRIPTION
Each devices workflow clones and patches hostap from upstream (git.w1.fi, plus GH-hosted patch layers for bpi). The patched tree is a function of the pinned revisions (in setup.sh) plus the patch inputs, so it can be cached between builds. This saves the w1.fi clone + patch apply time and insures against w1.fi access issues.

Cache easymesh_project/rdk-wifi-libhostap keyed on:
  1. sha256(setup.sh +hostap_patch_list.txt on bpi) - this captures SRCREVs, patch filenames, and directory paths.
  2. An upstream content hash for the one unpinned patch source per leg: bpi: git tree SHA of the meta-cmf-bananapi kernel_6_6 patch subdir (via GH API - tracks only actual patch dir, not all repo commits) rpi: ls-remote tip of rdkcentral/hostap-patches (the entire repo IS patches, so any commit is a patch change).

On a hit, setup.sh's .hostap_patched flag skips both the clone and the patching. On a miss, falls back to today's full clone.

Also:
- Delete the dead apt cache step (constant key-always empty, only cached .deb downloads, produced noisy tar warning on every post-job save).
- Add .hostap_patched flag + sibling clone guards to rpi/setup.sh (bpi already had these; rpi needed them for cache restore to work).
- Add sibling clone guards to bpi/setup.sh (unguarded on develop).

Match cache on exact-key-only, no restore-keys: a revision bump edits setup.sh -> key changes -> miss -> clean re-clone. restore-keys would resurrect a stale patched tree.