### PR TITLE
RDKB-65811: Move MLO defines to rdk-wifi-halif (#1348)

### DIFF
--- a/include/wifi_base.h
+++ b/include/wifi_base.h
@@ -93,18 +93,6 @@ extern "C" {
 #define WIFI_LINK_QUALITY_FLAGS     "Device.WiFi.LinkQualityFlags"
 #define WIFI_IGNITE_STATUS "Device.WiFi.EndPoint.1.LinkQualityStatus"
 
-#ifndef MAX_NUM_MLD_LINKS
-#define MAX_NUM_MLD_LINKS 15
-#endif /*MAX_NUM_MLD_LINKS*/
-
-#ifndef UNDEFINED_MLD_LINK_ID
-#define UNDEFINED_MLD_LINK_ID 255
-#endif
-
-#define UNDEFINED_MLD_ID 255
-#define MLD_UNIT_COUNT 8
-#define MIN_MLO_GROUP_SIZE 2
-
 #define PLAN_ID_LENGTH     38
 #define MAX_STEP_COUNT  32 /*Active Measurement Step Count */
 #define  MAC_ADDRESS_LENGTH  13


### PR DESCRIPTION
Reason for change: These are common values that should be used between OneWifi and its libraries, they should be reachable from one place. Test Procedure: Verify build, verify if MLO works on related platforms Risks: None
Priority: P2