### PR TITLE
RDKB-66207:  Fix CI tests: remove redundant WNM/RRM mock stubs causing link conflicts

### DIFF
--- a/source/test/platform_mocks.c
+++ b/source/test/platform_mocks.c
@@ -33,37 +33,6 @@
 #define MAX_SSID_LEN 33
 #define INVALID_KEY  "12345678"
 
-
-int wifi_rrm_send_beacon_req(struct wifi_interface_info_t *interface, const u8 *addr,
-    u16 num_of_repetitions, u8 measurement_request_mode, u8 oper_class, u8 channel,
-    u16 random_interval, u16 measurement_duration, u8 mode, const u8 *bssid,
-    struct wpa_ssid_value *ssid, u8 *rep_cond, u8 *rep_cond_threshold, u8 *rep_detail,
-    const u8 *ap_ch_rep, unsigned int ap_ch_rep_len, const u8 *req_elem, unsigned int req_elem_len,
-    u8 *ch_width, u8 *ch_center_freq0, u8 *ch_center_freq1, u8 last_indication)
-{
-    return 0;
-}
-
-/* called by BTM API */
-int wifi_wnm_send_bss_tm_req(struct wifi_interface_info_t *interface, struct sta_info *sta,
-    u8 dialog_token, u8 req_mode, int disassoc_timer, u8 valid_int, const u8 *bss_term_dur,
-    const char *url, const u8 *nei_rep, size_t nei_rep_len, const u8 *mbo_attrs, size_t mbo_len)
-{
-    return 0;
-}
-
-int handle_wnm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
-    struct ieee80211_mgmt *mgmt, size_t len)
-{
-    return 0;
-}
-
-int handle_rrm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
-    const struct ieee80211_mgmt *mgmt, size_t len, int ssi_signal)
-{
-    return 0;
-}
-
 #ifdef CONFIG_IEEE80211BE
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
     struct wpa_driver_ap_params *params)


### PR DESCRIPTION
wifi_rrm_send_beacon_req, wifi_wnm_send_bss_tm_req, handle_wnm_action_frame, and handle_rrm_action_frame are already defined in rdk-wifi-hal's wifi_hal_wnm_rrm.c and linked in via libwifihal.a. Referencing wifi_hal_parse_rm_beaon_report() (same object file) now pulls that .o into the gtest binary, causing "multiple definition" errors against the mock stubs here.

Dropping the stale mocks; the real implementations satisfy the link.