### PR TITLE
LTE-3045 : XLE loses STA mesh backhaul connectivity and requires self…

### DIFF
--- a/source/core/services/vap_svc_mesh_ext.c
+++ b/source/core/services/vap_svc_mesh_ext.c
@@ -1303,35 +1303,52 @@ int vap_svc_mesh_ext_disconnect(vap_svc_t *svc)
 int vap_svc_mesh_ext_start(vap_svc_t *svc, unsigned int radio_index, wifi_vap_info_map_t *map)
 {
     vap_svc_ext_t *ext = &svc->u.ext;
+    unsigned int i, num_of_radios;
 
     wifi_util_info_print(WIFI_CTRL, "%s:%d mesh service start\n", __func__, __LINE__);
 
-    if (radio_index >= MAX_NUM_RADIOS) {
+    if ((radio_index != WIFI_ALL_RADIO_INDICES) && (radio_index >= MAX_NUM_RADIOS)) {
         wifi_util_error_print(WIFI_CTRL,
             "%s:%d failed to start mesh service: wrong radio index %d\n", __func__, __LINE__,
             radio_index);
         return -1;
     }
 
+    if ((num_of_radios = getNumberRadios()) > MAX_NUM_RADIOS) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d number of radios %d exceeds supported %d\n", __func__, __LINE__,
+            num_of_radios, MAX_NUM_RADIOS);
+        return -1;
+    }
+
+    if (ext->is_started == false) {
+        // initialize all extender specific structures
+        if (ext->candidates_list.scan_list != NULL) {
+            free(ext->candidates_list.scan_list);
+            ext->candidates_list.scan_list = NULL;
+            ext->candidates_list.scan_count = 0;
+        }
+        memset(ext, 0, sizeof(vap_svc_ext_t));
+    }
+
     /* create STA vap's and install acl filters */
-    if (!ext->is_vap_started[radio_index]) {
-        vap_svc_start(svc, radio_index);
-        ext->is_vap_started[radio_index] = true;
+    for (i = 0; i < num_of_radios; i++) {
+        if ((radio_index != WIFI_ALL_RADIO_INDICES) && (i != radio_index)) {
+            continue;
+        }
+        if (!ext->is_vap_started[i]) {
+            vap_svc_start(svc, i);
+            ext->is_vap_started[i] = true;
+        }
     }
 
-    if (ext->is_started == true) {
+    if (ext->is_started == false) {
+        ext_set_conn_state(ext, connection_state_disconnected_scan_list_none, __func__, __LINE__);
+        schedule_connect_sm(svc);
+        ext->is_started = true;
+    } else {
         wifi_util_info_print(WIFI_CTRL, "%s:%d mesh service already started\n", __func__, __LINE__);
-        return 0;
     }
-
-    // initialize all extender specific structures
-    memset(ext, 0, sizeof(vap_svc_ext_t));
-
-    ext_set_conn_state(ext, connection_state_disconnected_scan_list_none, __func__, __LINE__);
-    schedule_connect_sm(svc);
-
-    ext->is_started = true;
-
     return 0;
 }
 
@@ -1361,6 +1378,7 @@ int vap_svc_mesh_ext_clear_variable(vap_svc_t *svc)
 int vap_svc_mesh_ext_stop(vap_svc_t *svc, unsigned int radio_index, wifi_vap_info_map_t *map)
 {
     vap_svc_ext_t *ext = &svc->u.ext;
+    unsigned int i, num_of_radios;
 
     wifi_util_info_print(WIFI_CTRL, "%s:%d mesh service stop\n", __func__, __LINE__);
 
@@ -1380,9 +1398,21 @@ int vap_svc_mesh_ext_stop(vap_svc_t *svc, unsigned int radio_index, wifi_vap_inf
         return -1;
     }
 
-    if (ext->is_vap_started[radio_index]) {
-        vap_svc_stop(svc, radio_index);
-        ext->is_vap_started[radio_index] = false;
+    if ((num_of_radios = getNumberRadios()) > MAX_NUM_RADIOS) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d number of radios %d exceeds supported %d\n", __func__, __LINE__,
+            num_of_radios, MAX_NUM_RADIOS);
+        return -1;
+    }
+
+    for (i = 0; i < num_of_radios; i++) {
+        if ((radio_index != WIFI_ALL_RADIO_INDICES) && (i != radio_index)) {
+            continue;
+        }
+        if (ext->is_vap_started[i]) {
+            vap_svc_stop(svc, i);
+            ext->is_vap_started[i] = false;
+        }
     }
 
     return 0;


### PR DESCRIPTION
…-heal reboot (sta-conn-failed) to recover

Reason for change:
vap_svc_mesh_ext_start()/stop() reject WIFI_ALL_RADIO_INDICES (the "all radios" sentinel) as an invalid index, since the bounds check has no exception for it. Callers passing this sentinel (e.g. device-mode-change handlers) fail immediately, so the extender never starts its mesh STA backhaul on that path.

Fix:
Exempt WIFI_ALL_RADIO_INDICES from the bounds check in both functions, and replace the single is_vap_started[radio_index] access with a loop over MAX_NUM_RADIOS, filtered by the same sentinel condition. A specific radio index still affects only that radio; WIFI_ALL_RADIO_INDICES now correctly starts/stops all radios instead of being rejected.

Risk: Low