### PR TITLE
RDKB-62791 CAC parameter <PreAssocDeny.RssiUpThreshold> supported values range is set incorrectly

### DIFF
--- a/source/dml/tr_181/ml/cosa_wifi_dml.c
+++ b/source/dml/tr_181/ml/cosa_wifi_dml.c
@@ -10489,7 +10489,7 @@ PreAssocDeny_GetParamStringValue
     /* check the parameter name and return the corresponding value */
     if( AnscEqualString(ParamName, "RssiUpThresholdSupported", TRUE))
     {
-        snprintf(pValue,*pUlSize,"disabled, 10 to 100");
+        snprintf(pValue, *pUlSize, "disabled, -50 to -95");
         return 0;
     }
 

--- a/source/platform/common/data_model/wifi_dml_cb.c
+++ b/source/platform/common/data_model/wifi_dml_cb.c
@@ -5238,7 +5238,7 @@ bool pre_conn_ctrl_get_param_string_value(void *obj_ins_context, char *param_nam
     wifi_preassoc_control_t *p_pre_assoc = &vap_pcfg->u.bss_info.preassoc;
 
     if (STR_CMP(param_name, "RssiUpThresholdSupported")) {
-        set_output_string(output_value, "disabled, 10 to 100");
+        set_output_string(output_value, "disabled, -50 to -95");
     } else if (STR_CMP(param_name, "SnrThresholdSupported")) {
         set_output_string(output_value, "disabled, 1 to 100");
     } else if (STR_CMP(param_name, "RssiUpThreshold")) {


### PR DESCRIPTION
RDKB-62791 CAC parameter <PreAssocDeny.RssiUpThreshold> supported values range is set incorrectly

Reason to chnage : It's observed the CAC parameter <PreAssocDeny.RssiUpThreshold> supported values range is set incorrectly <10 and 100> . The correct range is -*50 to -95 *

Test Procedure:
1. load the custom build
2. Configure the Xfinity Hotspot VAPs 
3. Check the CAC parameters for the Xfinity Hotspots for any VAP e.g Xfinity_2gOpen, Xfiniy_5gOpen, etc
4. you should see the required value -50 to -95

Priority: P1
Risks: Low
Signed-off-by: Sneha Kannansneha_kannan@comcast.com