### PR TITLE
RDKB-66207: [CI] Add workflow_dispatch to enable stage2 testing

### DIFF
--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -28,6 +28,17 @@ on:
   workflow_run:
     workflows: ["Build Check", "clang-format"]
     types: [completed]
+  # Manual trigger so stage 2 can be dispatched from a feature branch pre-merge
+  # to test changes before they land (a dispatch runs the branch's copy of this
+  # file, unlike workflow_run which always uses the default-branch copy). Harmless
+  # on 'develop': every job's if: name-gate below is false for a dispatch event,
+  # so all jobs skip until the companion PR adds a resolve job to wire it up.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Stage-1 run id to post from'
+        required: true
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
Stage 2 (pr-comments.yml) is driven by workflow_run, which always executes the default-branch copy of the workflow. That makes it impossible to test any change to this file on a feature branch before merge.

GitHub only accepts `gh workflow run --ref <branch>` when the trigger exists in the default-branch copy of the workflow (otherwise it 422s).  This adds only the workflow_dispatch trigger (with a run_id input) so that, once merged, maintainers can start  stage 2 job from any feature branch and GitHub will run that branch's copy.

No behavior change on develop: this PR adds no resolve job, so on a dispatch the existing job `if:` name-gates (workflow_run.name == 'Build Check'/'clang-format') all evaluate false and every job skips. The following PR will add the resolve job that uses 'run_id' to finish the dispatch path and use artifacts from stage1 automatically.