### PR TITLE
RDKB-66816 --- Move eapol key message header and call back to halinterface

### DIFF
--- a/source/apps/linkquality/wifi_linkquality_libs.c
+++ b/source/apps/linkquality/wifi_linkquality_libs.c
@@ -209,7 +209,7 @@ wifi_lq_descriptor_t* get_lq_descriptor()
     static wifi_lq_descriptor_t desc;
 
     if (!initialized) {
-#ifdef ONEWIFI_RDKB_APP_SUPPORT
+#if defined (ONEWIFI_RDKB_APP_SUPPORT) || defined (_GREXT02ACTS_PRODUCT_REQ_)
         desc.periodic_caffinity_stats_update_fn = periodic_caffinity_stats_update_impl;
         desc.register_station_mac_fn            = register_station_mac_impl;
         desc.unregister_station_mac_fn          = unregister_station_mac_impl;


### PR DESCRIPTION
RDKB-66816 --- Move eapol key message header and call back to halinterface

Reason for change: Add eapol key message header to halinterface.
Test Procedure: Connect multiple clients and verify the Scoring and Measurement bundles

Risks: Moderate

Signed-off-by:[pramod.7456@gmail.com](mailto:pramod.7456@gmail.com)