### PR TITLE
RDKBDEV-3492: Fix resource leak in WiFi_SetGasConfig

### DIFF
--- a/source/core/wifi_passpoint.c
+++ b/source/core/wifi_passpoint.c
@@ -719,6 +719,7 @@ INT WiFi_SetGasConfig(char *JSON_STR)
         return RETURN_OK;
       }
       wifi_util_dbg_print(WIFI_PASSPOINT,"Failed to update HAL with GAS Config. Adv-ID:%d\n",gasConfig_struct.AdvertisementID);
+      cJSON_Delete(passPointCfg);
       return RETURN_ERR;
 #else
     UNREFERENCED_PARAMETER(JSON_STR);

--- a/source/webconfig/wifi_webconfig_em_sta_link_metrics.c
+++ b/source/webconfig/wifi_webconfig_em_sta_link_metrics.c
@@ -152,12 +152,14 @@ webconfig_error_t decode_em_sta_link_subdoc(webconfig_t *config, webconfig_subdo
         sta_link_metrics->vap_index = vap_index_item->valueint;
     } else {
         wifi_util_error_print(WIFI_WEBCONFIG, "%s:%d: Vap Index is invalid\n", __func__, __LINE__);
+        cJSON_Delete(json);
         return webconfig_error_decode;
     }
 
     rsp_obj = cJSON_GetObjectItem(json, "Associated STA Link Metrics Report");
     if (rsp_obj == NULL) {
         wifi_util_error_print(WIFI_WEBCONFIG,"%s:%d: cjson object is NULL\n", __func__, __LINE__);
+        cJSON_Delete(json);
         return webconfig_error_decode;
     }
 
@@ -175,3 +177,4 @@ webconfig_error_t decode_em_sta_link_subdoc(webconfig_t *config, webconfig_subdo
     return webconfig_error_none;
 }
 #endif
+


### PR DESCRIPTION
A resource leak was identified in the WiFi_SetGasConfig() error handling path.

The passPointCfg JSON object is created using cJSON_Parse() and is properly deleted on the successful configuration path. However, when wifi_setGasConfiguration() fails, the function returns RETURN_ERR without deleting the passPointCfg JSON object.

Added cJSON_Delete(passPointCfg) before returning from the failure path to ensure the allocated JSON object is properly released and prevent a potential resource leak.

**Expected behavior:**
The passPointCfg JSON object should be properly cleaned up before returning an error.

**Acceptance Criteria:**
1. The passPointCfg JSON object is deleted when wifi_setGasConfiguration() fails.
2. cJSON_Delete(passPointCfg) is called before returning RETURN_ERR from the HAL update failure path.
3. No resource leak should occur on this error path.
4. Existing successful configuration behavior remains unchanged.
5. Existing error handling and return values remain unchanged.