### PR TITLE
RDKB-66681 TCXB7-7237: Fix for OneWifi Crash (rdkcentral#1369)

### DIFF
--- a/source/apps/csi/wifi_csi.c
+++ b/source/apps/csi/wifi_csi.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <sys/time.h>
 #include <errno.h>
+#include <pthread.h>
 #include "stdlib.h"
 #include "wifi_hal.h"
 #include "wifi_ctrl.h"
@@ -28,6 +29,8 @@
 #include "wifi_csi.h"
 #include "wifi_util.h"
 #include "wifi_analytics.h"
+
+static pthread_mutex_t g_csi_map_lock = PTHREAD_MUTEX_INITIALIZER;
 
 INT process_csi(mac_address_t mac_addr, wifi_csi_data_t  *csi_data)
 {
@@ -56,8 +59,10 @@ INT process_csi(mac_address_t mac_addr, wifi_csi_data_t  *csi_data)
 
     to_mac_str((unsigned char *)mac_addr, mac_str);
 
+    pthread_mutex_lock(&g_csi_map_lock);
     csi_map_entry = hash_map_get(wifi_app->data.u.csi.csi_sounding_mac_map, mac_str);
     if (csi_map_entry == NULL) {
+        pthread_mutex_unlock(&g_csi_map_lock);
         wifi_util_error_print(WIFI_APPS, "%s:%d No entry in CSI map for MAC %s\n", __func__,
             __LINE__, mac_str);
         return -1;
@@ -69,6 +74,7 @@ INT process_csi(mac_address_t mac_addr, wifi_csi_data_t  *csi_data)
             memcpy(result_mac, mac_addr, mac_size);
         }
     }
+    pthread_mutex_unlock(&g_csi_map_lock);
 
     event = create_wifi_event(sizeof(wifi_csi_dev_t), wifi_event_type_csi, wifi_event_type_csi_data); 
     if (event == NULL) {
@@ -94,6 +100,9 @@ void update_pinger_config(int ap_index, mac_addr_t mac_addr, bool pause_pinger)
     }
     memset(data, 0, sizeof(wifi_monitor_data_t));
 
+    wifi_util_dbg_print(WIFI_APPS,
+        "%s:%d pinger request ap:%d pause:%d\n",
+        __func__, __LINE__, ap_index, pause_pinger);
     memcpy(data->u.csi_mon.mac_addr, mac_addr, sizeof(mac_addr_t));
     data->u.csi_mon.ap_index = ap_index;
     data->u.csi_mon.pause_pinger = pause_pinger;
@@ -106,6 +115,7 @@ void update_pinger_config(int ap_index, mac_addr_t mac_addr, bool pause_pinger)
 int csi_start_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int sounding_app)
 {
     mac_addr_str_t mac_str = { 0 };
+    mac_addr_str_t evicted_mac_str = { 0 };
     csi_mac_data_t *to_hash_map = NULL;
     bool enable_sounding = false;
     assoc_dev_data_t *assoc_dev_data = NULL;
@@ -124,6 +134,9 @@ int csi_start_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int 
         wifi_util_error_print(WIFI_APPS, "%s:%d NULL Pointer\n", __func__, __LINE__);
         return -1;
     }
+    wifi_util_dbg_print(WIFI_APPS,
+        "%s:%d start ap:%u app:%d mac:%02x..%02x\n",
+        __func__, __LINE__, ap_index, sounding_app, mac_addr[0], mac_addr[5]);
 
     if (app->data.u.csi.csi_sounding_mac_map ==  NULL){
         wifi_util_error_print(WIFI_APPS, "%s:%d NULL Hash Map\n", __func__, __LINE__);
@@ -147,10 +160,12 @@ int csi_start_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int 
     }
     pthread_mutex_unlock(rdk_vap_info->associated_devices_lock);
 
+    pthread_mutex_lock(&g_csi_map_lock);
     to_hash_map = hash_map_get(app->data.u.csi.csi_sounding_mac_map, mac_str);
     if (to_hash_map != NULL) {
         if (to_hash_map->subscribed_apps & sounding_app) {
             wifi_util_info_print(WIFI_APPS, "%s:%d Request from same APP not sounding\n", __func__, __LINE__);
+            pthread_mutex_unlock(&g_csi_map_lock);
             return 0;
         } else {
             to_hash_map->subscribed_apps |= sounding_app;
@@ -164,13 +179,24 @@ int csi_start_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int 
                 while(to_hash_map != NULL) {
                     if ((to_hash_map->subscribed_apps & ~wifi_app_inst_motion)){
                         wifi_util_info_print(WIFI_APPS, "%s:%d Disabling CSI for mac %02x..%02x\n", __func__, __LINE__, to_hash_map->mac_addr[0], to_hash_map->mac_addr[5]);
+                        if (to_hash_map->is_mlo) {
+                            to_mac_str((unsigned char *)to_hash_map->link_addr, evicted_mac_str);
+                        } else {
+                            to_mac_str((unsigned char *)to_hash_map->mac_addr, evicted_mac_str);
+                        }
                         wifi_enableCSIEngine(to_hash_map->ap_index, to_hash_map->mac_addr, FALSE);
                         update_pinger_config(to_hash_map->ap_index, to_hash_map->mac_addr, true);
-                        to_hash_map = (csi_mac_data_t *)hash_map_remove(app->data.u.csi.csi_sounding_mac_map, mac_str);
+                        to_hash_map = (csi_mac_data_t *)hash_map_remove(app->data.u.csi.csi_sounding_mac_map, evicted_mac_str);
                         if (to_hash_map != NULL) {
                             free(to_hash_map);
+                            if (app->data.u.csi.num_current_sounding > 0) {
+                                app->data.u.csi.num_current_sounding--;
+                            }
+                            enable_sounding = true;
+                        } else {
+                            wifi_util_error_print(WIFI_APPS, "%s:%d CSI eviction remove failed for mac %s\n",
+                                __func__, __LINE__, evicted_mac_str);
                         }
-                        enable_sounding = true;
                         break;
                     }
                     to_hash_map = hash_map_get_next(app->data.u.csi.csi_sounding_mac_map, to_hash_map);
@@ -178,6 +204,7 @@ int csi_start_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int 
             } else {
                 //Ignore request for Low priority apps.
                 wifi_util_info_print(WIFI_APPS, "%s:%d Not Enabling for Low priority Apps", __func__, __LINE__);
+                pthread_mutex_unlock(&g_csi_map_lock);
                 return -1;
             }
         } else {
@@ -185,13 +212,13 @@ int csi_start_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int 
         }
 
         if (enable_sounding) {
-            wifi_util_info_print(WIFI_APPS, "%s:%d Enabling CSI\n", __func__, __LINE__);
             to_hash_map = (csi_mac_data_t *)malloc(sizeof(csi_mac_data_t));
             if (to_hash_map == NULL) {
                 wifi_util_info_print(WIFI_APPS, "%s:%d NULL Pointer\n", __func__, __LINE__);
+                pthread_mutex_unlock(&g_csi_map_lock);
                 return -1;
             }
-
+            wifi_util_info_print(WIFI_APPS, "%s:%d Enabling CSI\n", __func__, __LINE__);
             memset(to_hash_map, 0, sizeof(csi_mac_data_t));
             to_hash_map->ap_index = ap_index;
             memcpy(to_hash_map->mac_addr, mac_addr, mac_size);
@@ -200,14 +227,23 @@ int csi_start_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int 
             to_hash_map->subscribed_apps |= sounding_app;
             wifi_util_info_print(WIFI_APPS, "%s:%d Enabling CSI for mac %02x..%02x\n", __func__, __LINE__, to_hash_map->mac_addr[0], to_hash_map->mac_addr[5]);
             wifi_enableCSIEngine(ap_index, (unsigned char *)mac_addr, TRUE);
-            hash_map_put(app->data.u.csi.csi_sounding_mac_map, strdup(mac_str), to_hash_map);
+            if (hash_map_put(app->data.u.csi.csi_sounding_mac_map, strdup(mac_str), to_hash_map) != 0) {
+                wifi_util_error_print(WIFI_APPS, "%s:%d CSI map insert failed for mac %s\n",
+                    __func__, __LINE__, mac_str);
+                wifi_enableCSIEngine(ap_index, (unsigned char *)mac_addr, FALSE);
+                pthread_mutex_unlock(&g_csi_map_lock);
+                update_pinger_config(ap_index, mac_addr, true);
+                return -1;
+            }
             app->data.u.csi.num_current_sounding++;
+            pthread_mutex_unlock(&g_csi_map_lock);
             update_pinger_config(ap_index, mac_addr, false);
             return 0;
         } else {
             wifi_util_info_print(WIFI_APPS, "%s:%d Slots are FULL Not sounding\n", __func__, __LINE__);
         }
     }
+    pthread_mutex_unlock(&g_csi_map_lock);
     return 0;
 }
 
@@ -221,6 +257,10 @@ int csi_stop_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int s
         return -1;
     }
 
+    wifi_util_dbg_print(WIFI_APPS,
+        "%s:%d stop ap:%u app:%d mac:%02x..%02x\n",
+        __func__, __LINE__, ap_index, sounding_app, mac_addr[0], mac_addr[5]);
+
     to_mac_str((unsigned char *)mac_addr, mac_str);
     //Check if the MAC is there in the hash_map.
     if (app->data.u.csi.csi_sounding_mac_map == NULL) {
@@ -228,6 +268,7 @@ int csi_stop_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int s
         return -1;
     }
 
+    pthread_mutex_lock(&g_csi_map_lock);
     csi_mac_data_t *mac_data = (csi_mac_data_t *)hash_map_get(app->data.u.csi.csi_sounding_mac_map, mac_str);
     if (mac_data == NULL) {
         // We hash in MLO case by link address, so we need to
@@ -243,6 +284,7 @@ int csi_stop_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int s
 
         if (mac_data == NULL) {
             wifi_util_info_print(WIFI_APPS, "%s:%d Rogue Disable Request from app %d\n", __func__, __LINE__, sounding_app);
+            pthread_mutex_unlock(&g_csi_map_lock);
             return 0;
         }
     }
@@ -251,14 +293,23 @@ int csi_stop_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int s
     if (mac_data->subscribed_apps & ~sounding_app) {
         wifi_util_info_print(WIFI_APPS, "%s:%d MAC is being sounded by more than one apps not disabling sounding\n", __func__, __LINE__);
         mac_data->subscribed_apps &= ~sounding_app;
+        pthread_mutex_unlock(&g_csi_map_lock);
     } else {
         //Disable Sounding.
         wifi_util_info_print(WIFI_APPS, "%s:%d Disabling CSI for mac %02x..%02x\n", __func__, __LINE__, mac_data->mac_addr[0], mac_data->mac_addr[5]);
         wifi_enableCSIEngine(mac_data->ap_index, mac_data->mac_addr, FALSE);
         mac_data = (csi_mac_data_t *)hash_map_remove(app->data.u.csi.csi_sounding_mac_map, mac_str);
+        if (mac_data == NULL) {
+            wifi_util_error_print(WIFI_APPS, "%s:%d hash_map_remove returned NULL for mac_str %s\n", __func__, __LINE__, mac_str);
+            pthread_mutex_unlock(&g_csi_map_lock);
+            return -1;
+        }
+        if (app->data.u.csi.num_current_sounding > 0) {
+            app->data.u.csi.num_current_sounding--;
+        }
+        pthread_mutex_unlock(&g_csi_map_lock);
         update_pinger_config(mac_data->ap_index, mac_data->mac_addr, true);
         free(mac_data);
-        app->data.u.csi.num_current_sounding--;
     }
     return 0;
 }
@@ -266,6 +317,7 @@ int csi_stop_fn(void* csi_app, unsigned int ap_index, mac_addr_t mac_addr, int s
 #ifdef ONEWIFI_CSI_APP_SUPPORT
 int csi_init(wifi_app_t *app, unsigned int create_flag)
 {
+    wifi_util_info_print(WIFI_APPS, "%s:%d init\n", __func__, __LINE__);
     app->data.u.csi.csi_fns.csi_start_fn = csi_start_fn;
     app->data.u.csi.csi_fns.csi_stop_fn = csi_stop_fn;
     app->data.u.csi.csi_sounding_mac_map = hash_map_create();

--- a/source/apps/levl/wifi_levl.c
+++ b/source/apps/levl/wifi_levl.c
@@ -55,9 +55,12 @@ typedef struct {
 #define MIN_LEVL_PUBLISH_INTERVAL_MS 100
 #define MIN_LEVL_SOUNDING_DURATION_MS 1000
 #define UNREFERENCED_PARAMETER(_p_)         (void)(_p_)
-static int schedule_mac_for_sounding(int ap_index, mac_address_t mac_address, int duration, int interval);
+static int schedule_mac_for_sounding_locked(int ap_index, mac_address_t mac_address, int duration, int interval);
 static int process_levl_sounding_timeout(timeout_data_t *t_data);
 static int process_levl_postpone_sounding(wifi_app_t *app);
+static int schedule_from_pending_map_locked(wifi_app_t *wifi_app);
+static int process_csi_start_levl_locked(wifi_app_t *app);
+static int process_csi_stop_levl_locked(wifi_app_t *app);
 
 static int levl_csi_status_publish(bus_handle_t *handle, mac_addr_t mac_addr, unsigned int status)
 {
@@ -86,10 +89,10 @@ static int levl_csi_status_publish(bus_handle_t *handle, mac_addr_t mac_addr, un
     return RETURN_OK;
 }
 
-
-static int schedule_from_pending_map(wifi_app_t *wifi_app)
+static int schedule_from_pending_map_locked(wifi_app_t *wifi_app)
 {
     int p_map_count = 0, ap_index = 0;
+    int duration = 0, interval = 0;
     hash_map_t *p_map = NULL;
     mac_addr_str_t mac_str = { 0 };
     mac_addr_t mac_addr;
@@ -108,6 +111,11 @@ static int schedule_from_pending_map(wifi_app_t *wifi_app)
     }
 
     p_map_count = hash_map_count(p_map);
+    wifi_util_dbg_print(WIFI_APPS,
+        "%s:%d pending:%d active:%d max:%d\n",
+        __func__, __LINE__, p_map_count,
+        wifi_app->data.u.levl.num_current_sounding,
+        wifi_app->data.u.levl.max_num_csi_clients);
     if ((p_map_count > 0) && (wifi_app->data.u.levl.num_current_sounding < wifi_app->data.u.levl.max_num_csi_clients)) {
         levl_sc_data = (levl_sched_data_t *)hash_map_get_first(p_map);
         while(levl_sc_data != NULL)
@@ -127,17 +135,34 @@ static int schedule_from_pending_map(wifi_app_t *wifi_app)
 
             memset(mac_addr, 0, sizeof(mac_address_t));
             memcpy(mac_addr, levl_sc_data->mac_addr, sizeof(mac_address_t));
-            levl_sc_data = hash_map_remove(p_map, mac_str);
-            if (levl_sc_data != NULL) {
-                //schedule for sounding
-                schedule_mac_for_sounding(ap_index, mac_addr, levl_sc_data->duration, levl_sc_data->interval);
-                free(levl_sc_data);
+            duration = levl_sc_data->duration;
+            interval = levl_sc_data->interval;
+            tmp_data = hash_map_remove(p_map, mac_str);
+            if (tmp_data != NULL) {
+                free(tmp_data);
+                wifi_util_dbg_print(WIFI_APPS,
+                    "pending map handoff mac:%02x..%02x\n",
+                    mac_addr[0], mac_addr[5]);
+                schedule_mac_for_sounding_locked(ap_index, mac_addr, duration, interval);
             }
-
             break;
         }
     }
     return 0;
+}
+
+static int schedule_from_pending_map(wifi_app_t *wifi_app)
+{
+    int ret;
+
+    if (wifi_app == NULL) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&wifi_app->data.u.levl.lock);
+    ret = schedule_from_pending_map_locked(wifi_app);
+    pthread_mutex_unlock(&wifi_app->data.u.levl.lock);
+    return ret;
 }
 
 static int push_levl_data_dml_to_ctrl_queue(levl_config_t **levl)
@@ -711,9 +736,11 @@ static int process_levl_postpone_sounding(wifi_app_t *app)
         return -1;
     }
 
+    pthread_mutex_lock(&app->data.u.levl.lock);
     app->data.u.levl.postpone_sched_handler_id = 0;
     //schedule from pending list
-    schedule_from_pending_map(app);
+    schedule_from_pending_map_locked(app);
+    pthread_mutex_unlock(&app->data.u.levl.lock);
     return 0;
 }
 
@@ -725,10 +752,18 @@ static int process_levl_sounding_timeout(timeout_data_t *t_data)
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     wifi_apps_mgr_t *apps_mgr;
     levl_sched_data_t *levl_sc_data = NULL;
+    levl_sched_data_t *removed_data = NULL;
+    mac_address_t stop_mac = { 0 };
+    int stop_ap_index = 0;
     wifi_app_t *wifi_app =  NULL;
 
     if (t_data == NULL) {
         wifi_util_dbg_print(WIFI_APPS,"%s:%d NULL Pointer \n", __func__, __LINE__);
+        return -1;
+    }
+
+    if (ctrl == NULL) {
+        free(t_data);
         return -1;
     }
 
@@ -752,33 +787,45 @@ static int process_levl_sounding_timeout(timeout_data_t *t_data)
         free(t_data);
         return -1;
     }
+    pthread_mutex_lock(&wifi_app->data.u.levl.lock);
     to_mac_str((unsigned char *)(t_data->mac_addr), mac_str);
     curr_map = wifi_app->data.u.levl.curr_sounding_mac_map;
     if (curr_map == NULL) {
         wifi_util_error_print(WIFI_APPS,"%s:%d NULL hash map\n", __func__, __LINE__);
+        pthread_mutex_unlock(&wifi_app->data.u.levl.lock);
         free(t_data);
         return -1;
     }
 
+    wifi_util_dbg_print(WIFI_APPS,
+        "%s:%d timeout ap:%d mac:%02x..%02x\n",
+        __func__, __LINE__, t_data->ap_index, t_data->mac_addr[0], t_data->mac_addr[5]);
+
     levl_sc_data = (levl_sched_data_t *)hash_map_get(curr_map, mac_str);
     if (levl_sc_data != NULL) {
-        //Disable CSI Sounding.
-        //No current sounding for this MAC
-        wifi_util_error_print(WIFI_APPS,"%s:%d Disable CSI Sounding for %02x:...%02x\n", __func__, __LINE__, t_data->mac_addr[0], t_data->mac_addr[5]);
-        csi_app->data.u.csi.csi_fns.csi_stop_fn(csi_app, t_data->ap_index, t_data->mac_addr, wifi_app_inst_levl);
-        levl_csi_status_publish(&wifi_app->handle, t_data->mac_addr, 0);
-        levl_sc_data = hash_map_remove(curr_map, mac_str);
-        if (levl_sc_data != NULL) {
-            free(levl_sc_data);
-        }
+        memcpy(stop_mac, levl_sc_data->mac_addr, sizeof(mac_address_t));
+        stop_ap_index = levl_sc_data->ap_index;
+        removed_data = (levl_sched_data_t *)hash_map_remove(curr_map, mac_str);
     }
+    if (removed_data != NULL) {
+        wifi_util_dbg_print(WIFI_APPS,
+            "timeout detached mac:%02x..%02x\n",
+            stop_mac[0], stop_mac[5]);
+        wifi_util_error_print(WIFI_APPS,"%s:%d Disable CSI Sounding for %02x:...%02x\n", __func__, __LINE__, stop_mac[0], stop_mac[5]);
+        csi_app->data.u.csi.csi_fns.csi_stop_fn(csi_app, stop_ap_index, stop_mac, wifi_app_inst_levl);
+    }
+    pthread_mutex_unlock(&wifi_app->data.u.levl.lock);
 
+    if (removed_data != NULL) {
+        levl_csi_status_publish(&wifi_app->handle, stop_mac, 0);
+        free(removed_data);
+    }
     schedule_from_pending_map(wifi_app);
     free(t_data);
     return 0;
 }
 
-static int schedule_mac_for_sounding(int ap_index, mac_address_t mac_address, int duration, int interval)
+static int schedule_mac_for_sounding_locked(int ap_index, mac_address_t mac_address, int duration, int interval)
 {
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
     hash_map_t *curr_map = NULL, *p_map = NULL;
@@ -793,6 +840,9 @@ static int schedule_mac_for_sounding(int ap_index, mac_address_t mac_address, in
     int curr_map_count = 0;
 
     to_mac_str((unsigned char *)mac_address, mac_str);
+    wifi_util_dbg_print(WIFI_APPS,
+        "%s:%d schedule ap:%d duration:%d interval:%d mac:%02x..%02x\n",
+        __func__, __LINE__, ap_index, duration, interval, mac_address[0], mac_address[5]);
     wifi_app = get_app_by_inst(apps_mgr, wifi_app_inst_levl);
     if (wifi_app == NULL) {
         wifi_util_error_print(WIFI_APPS,"%s:%d NULL wifi_app pointer\n", __func__, __LINE__);
@@ -827,6 +877,7 @@ static int schedule_mac_for_sounding(int ap_index, mac_address_t mac_address, in
         wifi_util_error_print(WIFI_APPS,"%s:%d NULL  Pointer\n", __func__, __LINE__);
         return -1;
     }
+    memset(levl_sc_data, 0, sizeof(levl_sched_data_t));
     memcpy(levl_sc_data->mac_addr, mac_address, sizeof(mac_address_t));
     levl_sc_data->ap_index = ap_index;
     levl_sc_data->duration = duration;
@@ -865,8 +916,14 @@ static int schedule_mac_for_sounding(int ap_index, mac_address_t mac_address, in
         }
         levl_csi_status_publish(&wifi_app->handle, mac_address, 1);
 
-        scheduler_add_timer_task(ctrl->sched, FALSE, &(levl_sc_data->sched_handler_id),
-                process_levl_sounding_timeout, t_data, levl_sc_data->duration, 1, FALSE);
+        if (scheduler_add_timer_task(ctrl->sched, FALSE, &(levl_sc_data->sched_handler_id),
+            process_levl_sounding_timeout, t_data, levl_sc_data->duration, 1, FALSE) != 0) {
+            csi_app->data.u.csi.csi_fns.csi_stop_fn(csi_app, ap_index, mac_address, wifi_app_inst_levl);
+            levl_csi_status_publish(&wifi_app->handle, mac_address, 0);
+            free(t_data);
+            free(levl_sc_data);
+            return RETURN_ERR;
+        }
         hash_map_put(curr_map, strdup(mac_str), levl_sc_data);
     } else {
         //Push MAC to pending queue
@@ -910,6 +967,9 @@ void levl_csi_publish(mac_address_t mac_address, wifi_csi_dev_t *csi_dev_data)
     csi_data_length = sizeof(wifi_csi_data_t);
     memcpy((header + curr_length), &csi_data_length, sizeof(unsigned int));
     int buffer_size = CSI_HEADER_SIZE + sizeof(wifi_csi_data_t);
+    wifi_util_dbg_print(WIFI_APPS,
+        "%s:%d publish mac:%02x..%02x fifo:%d\n",
+        __func__, __LINE__, mac_address[0], mac_address[5], wifi_app->data.u.levl.csi_over_fifo);
     if (wifi_app->data.u.levl.csi_over_fifo == false) {
         strncpy(eventName, "Device.WiFi.X_RDK_CSI_LEVL.data", sizeof(eventName) - 1);
         // Publish using new API
@@ -986,12 +1046,23 @@ int process_levl_csi(wifi_app_t *app, wifi_csi_dev_t *csi_data)
         pthread_mutex_unlock(&app->data.u.levl.lock);
         return RETURN_ERR;
     }
+    levl_sched_data_t sc_copy = *levl_sc_data;
+    wifi_util_dbg_print(WIFI_APPS,
+        "CSI snapshot mac:%02x..%02x interval:%d\n",
+        mac_addr[0], mac_addr[5], sc_copy.interval);
     //calculate timeout with current time and last time publish
     gettimeofday(&t_now, NULL);
     pthread_mutex_unlock(&app->data.u.levl.lock);
-    if ((levl_sc_data->interval == 0) || levl_check_timeout(levl_sc_data, &t_now)) {
+    if ((sc_copy.interval == 0) || levl_check_timeout(&sc_copy, &t_now)) {
         levl_csi_publish(mac_addr, csi_data);
-        levl_sc_data->last_time_publish = t_now;
+        pthread_mutex_lock(&app->data.u.levl.lock);
+        levl_sc_data = (levl_sched_data_t *)hash_map_get(app->data.u.levl.curr_sounding_mac_map, mac_str);
+        if (levl_sc_data != NULL) {
+            levl_sc_data->last_time_publish = t_now;
+        } else {
+            wifi_util_dbg_print(WIFI_APPS, "%s:%d entry gone before last_time_publish update\n", __func__, __LINE__);
+        }
+        pthread_mutex_unlock(&app->data.u.levl.lock);
     }
     return RETURN_OK;
 }
@@ -1091,6 +1162,7 @@ int levl_event_webconfig_set_data(wifi_app_t *apps, void *arg, wifi_event_subtyp
                 wifi_util_dbg_print(WIFI_APPS,"%s:%d NULL pointer \n", __func__, __LINE__);
                 return RETURN_ERR;
             }
+            pthread_mutex_lock(&apps->data.u.levl.lock);
             wifi_util_dbg_print(WIFI_APPS,"%s:%d Received config Client num %d, Client MAC %02x:... %02x publish interval %d sounding duration %d\n", __func__, __LINE__,
                     levl_config->max_num_csi_clients, levl_config->clientMac[0], levl_config->clientMac[5], levl_config->levl_publish_interval, levl_config->levl_sounding_duration);
             if (levl_config->max_num_csi_clients == 0) {
@@ -1111,9 +1183,10 @@ int levl_event_webconfig_set_data(wifi_app_t *apps, void *arg, wifi_event_subtyp
                 if (ap_index < 0) {
                     wifi_util_dbg_print(WIFI_APPS,"%s:%d Client is not connected not pushing to queue\n", __func__, __LINE__);
                 } else {
-                    schedule_mac_for_sounding(ap_index, levl_config->clientMac, levl_config->levl_sounding_duration, levl_config->levl_publish_interval);
+                    schedule_mac_for_sounding_locked(ap_index, levl_config->clientMac, levl_config->levl_sounding_duration, levl_config->levl_publish_interval);
                 }
             }
+            pthread_mutex_unlock(&apps->data.u.levl.lock);
             break;
         default:
             break;
@@ -1214,7 +1287,7 @@ int levl_event_csi(wifi_app_t *app, wifi_event_subtype_t sub_type, wifi_csi_dev_
     return RETURN_OK;
 }
 
-int process_csi_stop_levl(wifi_app_t *app)
+static int process_csi_stop_levl_locked(wifi_app_t *app)
 {
     mac_addr_str_t mac_str = { 0 };
     levl_sched_data_t *tmp_data = NULL;
@@ -1254,7 +1327,21 @@ int process_csi_stop_levl(wifi_app_t *app)
     return 0;
 }
 
-int process_csi_start_levl(wifi_app_t *app) 
+int process_csi_stop_levl(wifi_app_t *app)
+{
+    int ret;
+
+    if (app == NULL) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&app->data.u.levl.lock);
+    ret = process_csi_stop_levl_locked(app);
+    pthread_mutex_unlock(&app->data.u.levl.lock);
+    return ret;
+}
+
+static int process_csi_start_levl_locked(wifi_app_t *app)
 {
     if (app == NULL) {
         wifi_util_dbg_print(WIFI_APPS, "%s:%d NULL Pointer \n", __func__, __LINE__);
@@ -1263,8 +1350,22 @@ int process_csi_start_levl(wifi_app_t *app)
 
     wifi_util_dbg_print(WIFI_APPS, "Calling %s\n", __func__);
     app->data.u.levl.paused = false;
-    schedule_from_pending_map(app);
+    schedule_from_pending_map_locked(app);
     return 0;
+}
+
+int process_csi_start_levl(wifi_app_t *app)
+{
+    int ret;
+
+    if (app == NULL) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&app->data.u.levl.lock);
+    ret = process_csi_start_levl_locked(app);
+    pthread_mutex_unlock(&app->data.u.levl.lock);
+    return ret;
 }
 
 int process_speed_test_timeout_levl()
@@ -1305,8 +1406,10 @@ int levl_event_speed_test(wifi_app_t *app, wifi_event_subtype_t sub_type, void *
     }
     pthread_mutex_lock(&app->data.u.levl.lock);
     if (speed_test_data->speed_test_running == 1) {
+        wifi_util_dbg_print(WIFI_APPS,
+            "%s:%d speed-test pause\n", __func__, __LINE__);
         app->data.u.levl.paused = true;
-        process_csi_stop_levl(app);
+        process_csi_stop_levl_locked(app);
 
         if (app->data.u.levl.sched_handler_id == 0) {
             app->data.u.levl.speed_test_timeout  = speed_test_data->speed_test_timeout;
@@ -1317,8 +1420,10 @@ int levl_event_speed_test(wifi_app_t *app, wifi_event_subtype_t sub_type, void *
             scheduler_update_timer_task_interval(ctrl->sched, app->data.u.levl.sched_handler_id, (app->data.u.levl.speed_test_timeout)*1000);
         }
     } else if (speed_test_data->speed_test_running == 5) {
+        wifi_util_dbg_print(WIFI_APPS,
+            "%s:%d speed-test resume\n", __func__, __LINE__);
         if (app->data.u.levl.paused == true) {
-            process_csi_start_levl(app);
+            process_csi_start_levl_locked(app);
         }
     }
     pthread_mutex_unlock(&app->data.u.levl.lock);
@@ -1328,11 +1433,18 @@ int levl_event_speed_test(wifi_app_t *app, wifi_event_subtype_t sub_type, void *
 int apps_frame_event_exec_timeout(wifi_app_t *apps)
 {
     time_t l_curr_alive_time_sec, delta_time_sec;
-    hash_map_t *probe_map = apps->data.u.levl.probe_req_map;
+    hash_map_t *probe_map = NULL;
     probe_req_elem_t *l_elem = NULL, *l_temp_elem = NULL;
 
+    if (apps == NULL) {
+        return RETURN_ERR;
+    }
+
+    pthread_mutex_lock(&apps->data.u.levl.lock);
+    probe_map = apps->data.u.levl.probe_req_map;
     if (probe_map == NULL) {
         wifi_util_error_print(WIFI_APPS,"%s:%d probe map is NULL\r\n", __func__, __LINE__);
+        pthread_mutex_unlock(&apps->data.u.levl.lock);
         return RETURN_ERR;
     }
 
@@ -1362,6 +1474,7 @@ int apps_frame_event_exec_timeout(wifi_app_t *apps)
     }
 
     wifi_util_info_print(WIFI_APPS,"%s:%d total probe entry:%d\r\n", __func__, __LINE__, hash_map_count(probe_map));
+    pthread_mutex_unlock(&apps->data.u.levl.lock);
     return 0;
 }
 
@@ -1453,9 +1566,7 @@ int levl_event(wifi_app_t *app, wifi_event_t *event)
             hal_event_levl(app, event->sub_type, event->u.core_data.msg);
             break;
         case wifi_event_type_webconfig:
-            pthread_mutex_lock(&app->data.u.levl.lock);
             webconfig_event_levl(app, event->sub_type, event->u.webconfig_data);
-            pthread_mutex_unlock(&app->data.u.levl.lock);
             break;
         case wifi_event_type_monitor:
             monitor_radio_temperature(app, event);
@@ -1549,6 +1660,14 @@ int levl_deinit(wifi_app_t *app)
         scheduler_cancel_timer_task(ctrl->sched, app->data.u.levl.probe_collector_sched_handler_id);
         app->data.u.levl.probe_collector_sched_handler_id = 0;
     }
+    if (app->data.u.levl.postpone_sched_handler_id != 0) {
+        scheduler_cancel_timer_task(ctrl->sched, app->data.u.levl.postpone_sched_handler_id);
+        app->data.u.levl.postpone_sched_handler_id = 0;
+    }
+    if (app->data.u.levl.sched_handler_id != 0) {
+        scheduler_cancel_timer_task(ctrl->sched, app->data.u.levl.sched_handler_id);
+        app->data.u.levl.sched_handler_id = 0;
+    }
 
     for (unsigned int radio_idx = 0; radio_idx < MAX_NUM_RADIOS; radio_idx++) {
         if (app->data.u.levl.temperature_event_subscribed[radio_idx] == TRUE) {
@@ -1585,6 +1704,7 @@ int levl_deinit(wifi_app_t *app)
         }
     }
     hash_map_destroy(app->data.u.levl.curr_sounding_mac_map);
+    app->data.u.levl.curr_sounding_mac_map = NULL;
 
     levl_sched_data = (levl_sched_data_t *)hash_map_get_first(app->data.u.levl.pending_mac_map);
     while(levl_sched_data != NULL) {
@@ -1597,6 +1717,7 @@ int levl_deinit(wifi_app_t *app)
         }
     }
     hash_map_destroy(app->data.u.levl.pending_mac_map);
+    app->data.u.levl.pending_mac_map = NULL;
 
     probe_data = (probe_req_elem_t *)hash_map_get_first(app->data.u.levl.probe_req_map);
     while(probe_data != NULL) {
@@ -1616,6 +1737,7 @@ int levl_deinit(wifi_app_t *app)
         }
     }
     hash_map_destroy(app->data.u.levl.probe_req_map);
+    app->data.u.levl.probe_req_map = NULL;
 
     rc = get_bus_descriptor()->bus_close_fn(&app->handle);
     if (rc != bus_error_success) {
@@ -1629,7 +1751,6 @@ int levl_deinit(wifi_app_t *app)
     }
 
     pthread_mutex_unlock(&app->data.u.levl.lock);
-    pthread_mutex_destroy(&app->data.u.levl.lock);
     if (app->queue != NULL) {
         queue_destroy(app->queue);
     }
@@ -2135,7 +2256,7 @@ int levl_init(wifi_app_t *app, unsigned int create_flag)
     if (app_init(app, create_flag) != 0) {
         return RETURN_ERR;
     }
-    wifi_util_info_print(WIFI_APPS, "%s:%d: Init Levl\n", __func__, __LINE__);
+    wifi_util_dbg_print(WIFI_APPS, "%s:%d: Init Levl\n", __func__, __LINE__);
 
     wifi_app_t *csi_app = NULL;
     wifi_ctrl_t *ctrl = (wifi_ctrl_t *)get_wifictrl_obj();
@@ -2175,7 +2296,10 @@ int levl_init(wifi_app_t *app, unsigned int create_flag)
     for (unsigned int radio = 0; radio < MAX_NUM_RADIOS; radio++) {
         app->data.u.levl.temperature_event_subscribed[radio] = FALSE;
     }
-    pthread_mutex_init(&app->data.u.levl.lock, NULL);
+    if (!app->data.u.levl.lock_initialized) {
+        pthread_mutex_init(&app->data.u.levl.lock, NULL);
+        app->data.u.levl.lock_initialized = TRUE;
+    }
 
     scheduler_add_timer_task(ctrl->sched, FALSE, &(app->data.u.levl.probe_collector_sched_handler_id),
                                levl_event_exec_timeout, app, (APPS_FRAME_EXEC_TIMEOUT_PERIOD * 1000), 0, FALSE);

--- a/source/apps/levl/wifi_levl.h
+++ b/source/apps/levl/wifi_levl.h
@@ -89,6 +89,7 @@ typedef struct {
     bool                 temperature_event_subscribed[MAX_NUM_RADIOS];
     int                  radio_temperature_interval[MAX_NUM_RADIOS];
     pthread_mutex_t      lock;
+    bool                 lock_initialized;
     hash_map_t           *probe_req_map;
     hash_map_t           *curr_sounding_mac_map;
     hash_map_t           *pending_mac_map;

--- a/source/core/wifi_ctrl_queue_handlers.c
+++ b/source/core/wifi_ctrl_queue_handlers.c
@@ -3581,6 +3581,7 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
     wifi_radio_feature_param_t *radio_feat = NULL;
     wifi_radio_operationParam_t *temp_radio_params = NULL;
     wifi_mgr_t *g_wifidb;
+    unsigned int num_of_radios;
     g_wifidb = get_wifimgr_obj();
     wifi_ctrl_t *ctrl;
     vap_svc_t *ext_svc;
@@ -3588,15 +3589,52 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
     int ret = 0;
     wifi_monitor_data_t *data = NULL;
 
+    if (ch_chg == NULL) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d NULL channel-change event\n", __func__, __LINE__);
+        return;
+    }
+
+    if (g_wifidb == NULL) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d wifi_mgr_t is NULL radio:%d\n",
+            __func__, __LINE__, ch_chg->radioIndex);
+        return;
+    }
+
+    if (ch_chg->radioIndex >= MAX_NUM_RADIOS) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d invalid radio index:%d max:%d\n",
+            __func__, __LINE__, ch_chg->radioIndex, MAX_NUM_RADIOS);
+        return;
+    }
+
+    num_of_radios = getNumberRadios();
+    if (num_of_radios > MAX_NUM_RADIOS || ch_chg->radioIndex >= num_of_radios) {
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d radio index:%d outside configured radios:%u max:%d\n",
+            __func__, __LINE__, ch_chg->radioIndex, num_of_radios, MAX_NUM_RADIOS);
+        return;
+    }
+
+    wifi_util_dbg_print(WIFI_CTRL,
+        "%s:%d entry radio:%d event:%d sub_event:%d channel:%d bw:%d\n",
+        __func__, __LINE__, ch_chg->radioIndex, ch_chg->event, ch_chg->sub_event,
+        ch_chg->channel, ch_chg->channelWidth);
+
     radio_params = (wifi_radio_operationParam_t *)get_wifidb_radio_map(ch_chg->radioIndex);
     if (radio_params == NULL) {
-        wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, ch_chg->radioIndex);
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d radio map unavailable for index:%d\n",
+            __func__, __LINE__, ch_chg->radioIndex);
         return;
     }
 
     radio_feat = (wifi_radio_feature_param_t *)get_wifidb_radio_feat_map(ch_chg->radioIndex);
     if (radio_feat == NULL) {
-        wifi_util_error_print(WIFI_CTRL,"%s: wrong index for radio map: %d\n",__FUNCTION__, ch_chg->radioIndex);
+        wifi_util_error_print(WIFI_CTRL,
+            "%s:%d radio feature map unavailable for index:%d\n",
+            __func__, __LINE__, ch_chg->radioIndex);
         return;
     }
 
@@ -3613,10 +3651,12 @@ void process_channel_change_event(wifi_channel_change_event_t *ch_chg, bool is_n
         temp_radio_params->channelWidth = ch_chg->channelWidth;
         temp_radio_params->DfsEnabled = radio_params->DfsEnabled;
         // Channel change completed flag
+        pthread_mutex_lock(&g_wifidb->data_cache_lock);
         g_wifidb->channel_change_in_progress[ch_chg->radioIndex] = false;
+        pthread_mutex_unlock(&g_wifidb->data_cache_lock);
         wifi_util_dbg_print(WIFI_CTRL,
-            "%s:%d Channel change is completed, setting channel change progress to false\n",
-            __func__, __LINE__);
+            "%s:%d channel change complete; progress=false radio:%d\n",
+            __func__, __LINE__, ch_chg->radioIndex);
     }
 
     ctrl = &g_wifidb->ctrl;

--- a/source/core/wifi_ctrl_webconfig.c
+++ b/source/core/wifi_ctrl_webconfig.c
@@ -2114,11 +2114,18 @@ static int check_and_reset_channel_change(void *arg)
         return RETURN_ERR;
     }
 
-    if (mgr->channel_change_in_progress[radio_index] == true) {
+    bool channel_change_in_progress = false;
+    pthread_mutex_lock(&mgr->data_cache_lock);
+    channel_change_in_progress = mgr->channel_change_in_progress[radio_index];
+    if (channel_change_in_progress == true) {
+        mgr->channel_change_in_progress[radio_index] = false;
+    }
+    pthread_mutex_unlock(&mgr->data_cache_lock);
+
+    if (channel_change_in_progress == true) {
         wifi_util_dbg_print(WIFI_MON,
             "%s: Channel change still in progress after 5s. Resetting flag and restarting scan.\n",
             __func__);
-        mgr->channel_change_in_progress[radio_index] = false;
     }
 
     return RETURN_OK;
@@ -2287,7 +2294,9 @@ int webconfig_hal_radio_apply(wifi_ctrl_t *ctrl, webconfig_subdoc_decoded_data_t
 
         // channel_change_flag
         if (IS_CHANGED(radio_data->oper.channel, mgr_radio_data->oper.channel)) {
+            pthread_mutex_lock(&mgr->data_cache_lock);
             mgr->channel_change_in_progress[radio_data->vaps.radio_index] = true;
+            pthread_mutex_unlock(&mgr->data_cache_lock);
             wifi_util_dbg_print(WIFI_MGR, "%s:%d: channel_mismatch[%d] set to true\n", __func__,
                 __LINE__, radio_data->vaps.radio_index);
             scheduler_add_timer_task(ctrl->sched, false, NULL, check_and_reset_channel_change,

--- a/source/stats/wifi_monitor.c
+++ b/source/stats/wifi_monitor.c
@@ -4945,9 +4945,14 @@ int collector_postpone_execute_task(void *arg)
     wifi_monitor_t *mon_data = (wifi_monitor_t *)get_wifi_monitor();
     wifi_mgr_t *mgr = get_wifimgr_obj();
     int id = elem->collector_postpone_task_sched_id;
+    bool channel_change_in_progress = false;
+
+    pthread_mutex_lock(&mgr->data_cache_lock);
+    channel_change_in_progress = mgr->channel_change_in_progress[elem->args->radio_index];
+    pthread_mutex_unlock(&mgr->data_cache_lock);
 
     if ((mon_data->scan_status[elem->args->radio_index] == 1 ||
-            mgr->channel_change_in_progress[elem->args->radio_index] == true) &&
+            channel_change_in_progress == true) &&
         (elem->postpone_cnt < MAX_POSTPONE_EXECUTION)) {
         wifi_util_dbg_print(WIFI_MON, "%s : %d scan running postpone collector : %s\n", __func__,
             __LINE__, elem->key);
@@ -4974,10 +4979,16 @@ int collector_execute_task(void *arg)
     wifi_monitor_t *mon_data = (wifi_monitor_t *)get_wifi_monitor();
     wifi_mgr_t *mgr = get_wifimgr_obj();
     int id = elem->collector_postpone_task_sched_id;
+    bool channel_change_in_progress = false;
+
+    pthread_mutex_lock(&mgr->data_cache_lock);
+    channel_change_in_progress = mgr->channel_change_in_progress[elem->args->radio_index];
+    pthread_mutex_unlock(&mgr->data_cache_lock);
 
     if (elem->stat_desc->stats_type == mon_stats_type_radio_channel_stats || 
             elem->stat_desc->stats_type == mon_stats_type_neighbor_stats) {
-        if (mon_data->scan_status[elem->args->radio_index] == 1 || mgr->channel_change_in_progress[elem->args->radio_index] == true) {
+        if (mon_data->scan_status[elem->args->radio_index] == 1 ||
+            channel_change_in_progress == true) {
             if (elem->collector_postpone_task_sched_id == 0) {
                 wifi_util_dbg_print(WIFI_MON, "%s : %d scan running postpone collector : %s\n",__func__,__LINE__, elem->key);
                 scheduler_add_timer_task(mon_data->sched, FALSE, &id, collector_postpone_execute_task, arg, POSTPONE_TIME, 1, FALSE);


### PR DESCRIPTION
Reason for change: fix for onewificrash CSI/LEVL sync lock added
Test Procedure: check for onewifi restart
Risks:
Priority: P2
Signed-off-by: poornakumar_mezhiselvam@comcast.com