### PR TITLE
RDKBDEV-3500: Fix resource leak in CosaUtilGetStaticRouteTable()

### DIFF
--- a/source/dml/tr_181/ml/cosa_apis_util.c
+++ b/source/dml/tr_181/ml/cosa_apis_util.c
@@ -899,6 +899,7 @@ CosaUtilGetStaticRouteTable
 
     sroute = (StaticRoute *) malloc(sizeof(StaticRoute) * (*count));
     if (NULL == sroute) {
+        fclose(fp);
         return ANSC_STATUS_FAILURE;
     }
     bzero(sroute, sizeof(StaticRoute) * (*count));


### PR DESCRIPTION
**Issue:**
In CosaUtilGetStaticRouteTable(), the file /tmp/.route_table_tmp is opened using fopen(), but when memory allocation for sroute fails, the function returns without closing the opened file handle fp. This results in a file resource leak.

**Steps to Reproduce:**
    1.Execute CosaUtilGetStaticRouteTable().
    2.Allow the file to be opened successfully.
    3.Trigger a failure in the memory allocation for sroute.
    4.Observe that the function returns without closing the opened file handle.

**Expected Behavior:**
The opened file handle should be closed before returning from the memory allocation failure path.

**Fix:**
Add fclose(fp) before returning from the sroute memory allocation failure path.

**Acceptance Criteria:**
1.The opened file handle is properly closed when sroute memory allocation fails.
2.No file/resource leak occurs on the memory allocation failure path.
3.Existing successful execution and error handling behavior remains unchanged.
4.No unnecessary changes are introduced to other code paths.