### PR TITLE
RDKBWIFI-596: Keep the ctrl loop scheduler cadence across second boundaries

### DIFF
--- a/source/core/wifi_ctrl.c
+++ b/source/core/wifi_ctrl.c
@@ -326,24 +326,17 @@ bool is_sta_enabled(void)
 void ctrl_queue_loop(wifi_ctrl_t *ctrl)
 {
     struct timespec time_to_wait;
-    struct timespec tv_now;
-    time_t  time_diff;
     int rc = 0;
     wifi_event_t *event = NULL;
 
     pthread_mutex_lock(&ctrl->queue_lock);
     while (ctrl->exit_ctrl == false) {
 
-        clock_gettime(CLOCK_MONOTONIC, &tv_now);
+        /* Anchor the deadline on the previous scheduler run, not on the current
+         * time: if event handling ran past the second boundary the deadline is
+         * already due and the wait returns at once instead of skipping a run. */
+        time_to_wait.tv_sec = ctrl->last_polled_time.tv_sec + ctrl->poll_period;
         time_to_wait.tv_nsec = 0;
-        time_to_wait.tv_sec = tv_now.tv_sec + ctrl->poll_period;
-
-        if (ctrl->last_signalled_time.tv_sec > ctrl->last_polled_time.tv_sec) {
-            time_diff = ctrl->last_signalled_time.tv_sec - ctrl->last_polled_time.tv_sec;
-            if ((UINT)time_diff < ctrl->poll_period) {
-                time_to_wait.tv_sec = tv_now.tv_sec + (ctrl->poll_period - time_diff);
-            }
-        }
 
         rc = 0;
         if (queue_count(ctrl->queue) == 0) {
@@ -392,7 +385,6 @@ void ctrl_queue_loop(wifi_ctrl_t *ctrl)
 
                 destroy_wifi_event(event);
 
-                clock_gettime(CLOCK_MONOTONIC, &ctrl->last_signalled_time);
                 pthread_mutex_lock(&ctrl->queue_lock);
             }
         } else if (rc == ETIMEDOUT) {
@@ -1492,7 +1484,6 @@ int init_wifi_ctrl(wifi_ctrl_t *ctrl)
         return RETURN_ERR;
     }
     
-    clock_gettime(CLOCK_MONOTONIC, &ctrl->last_signalled_time);
     clock_gettime(CLOCK_MONOTONIC, &ctrl->last_polled_time);
     pthread_condattr_init(&cond_attr);
     pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);

--- a/source/core/wifi_ctrl.h
+++ b/source/core/wifi_ctrl.h
@@ -249,7 +249,6 @@ typedef struct wifi_ctrl {
     pthread_cond_t      cond;
     pthread_mutexattr_t attr;
     unsigned int        poll_period;
-    struct timespec     last_signalled_time;
     struct timespec     last_polled_time;
     struct scheduler    *sched;
     webconfig_t         webconfig;


### PR DESCRIPTION
ctrl_queue_loop() derives its wait deadline from the current time rounded up to the next whole second. When a queued event is being handled while the second boundary passes, the next deadline lands two seconds after the previous scheduler run and that run is skipped, so every timer task on ctrl->sched misses it. For the EasyMesh AP metrics report this shows as holes in the agent's AP Metrics Response stream. Details in RDKBWIFI-596.

Anchor the deadline on last_polled_time, the previous scheduler run, instead of on the current time. Nothing changes while handling stays inside the second; when it crosses the boundary the deadline is already in the past, pthread_cond_timedwait() returns ETIMEDOUT at once and the scheduler runs late instead of not at all. The last_signalled_time adjustment only applied to poll periods above one second and is subsumed, so it goes together with the field.

wifi_data_plane, wifi_apps_mgr and wifi_monitor build their deadline the same way. They are left as they are: no missed run has been observed there and each has its own timeout handling to verify.